### PR TITLE
fix(editor): hide toolbar buttons groups with all items

### DIFF
--- a/packages/default/scss/editor/_layout.scss
+++ b/packages/default/scss/editor/_layout.scss
@@ -88,7 +88,8 @@
         .k-tool-group + .k-tool-group {
             margin-left: $toolbar-padding-x;
         }
-        .k-tool-group .k-state-disabled {
+        .k-tool-group .k-state-disabled,
+        .k-tool-group.k-state-disabled {
             display: none;
         }
 


### PR DESCRIPTION
related https://github.com/telerik/kendo/issues/8212