### PR TITLE
fix(dialog): fix close button position in titleless dialog

### DIFF
--- a/packages/default/scss/dialog/_layout.scss
+++ b/packages/default/scss/dialog/_layout.scss
@@ -34,6 +34,10 @@
     .k-dialog-titlebar {}
     .k-dialog-title {}
 
+    .k-dialog-close {
+        align-self: flex-end;
+    }
+
 
     // Actions
     .k-dialog-actions {}


### PR DESCRIPTION
related https://github.com/telerik/kendo-ui-core/issues/3603