### PR TITLE
fix(grid): fix misaligned locked columns header in IE

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -437,6 +437,10 @@
 
     .k-grid-header-locked + .k-grid-header-wrap.k-auto-scrollable {
         margin-right: 0;
+
+        .k-ie & {
+            display: inline-block;
+        }
     }
 
     .k-grid-header,


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo-themes/issues/22