### PR TITLE
feat: update default primary / secondary colors

### DIFF
--- a/packages/material/docs/customization.md
+++ b/packages/material/docs/customization.md
@@ -89,8 +89,8 @@ The following table lists the available variables for customizing the Material t
 <tr>
 <td>$primary</td>
 <td>
-    <span class="color-preview" style="background-color: #43a047"></span>
-    #43a047
+    <span class="color-preview" style="background-color: #3f51b5"></span>
+    #3f51b5
 </td>
 <td>The color that focuses the user attention.<br/>
 Used for primary buttons and for elements of primary importance across the theme.
@@ -109,8 +109,8 @@ Used to provide contrast between the background and foreground colors.
 <tr>
 <td>$secondary</td>
 <td>
-    <span class="color-preview" style="background-color: #3193ee"></span>
-    #3193ee
+    <span class="color-preview" style="background-color: #ff4081"></span>
+    #ff4081
 </td>
 <td>The secondary (accent) color of the theme.
 </td>

--- a/packages/material/scss/_variables.scss
+++ b/packages/material/scss/_variables.scss
@@ -119,7 +119,7 @@ $rgba-transparent: rgba( 0, 0, 0, 0 );
 // Theme colors
 /// The color that focuses the user attention.
 /// Used for primary buttons and for elements of primary importance across the theme.
-$primary: #43a047 !default;
+$primary: #3f51b5 !default;
 $accent: $primary;
 
 /// The color used along with the primary color denoted by $primary.
@@ -128,7 +128,7 @@ $primary-contrast: #ffffff !default;
 $accent-contrast: $primary-contrast;
 
 /// The secondary (accent) color of the theme.
-$secondary: #3193ee !default;
+$secondary: #ff4081 !default;
 
 /// The color used along with the secondary color denoted by $secondary.
 /// Used to provide contrast between the background and foreground colors.


### PR DESCRIPTION
The new values match the default colors from https://material.angular.io .
This simplifies uses of Kendo UI alongside the Google Material components

This also makes the migration from the LESS-based Material theme easier.

As discussed with @lkarakoleva, we should start shipping swatches along with the themes, see #36.

/cc @rkonstantinov @mvgmvg @theOrlin @joneff 