### PR TITLE
fix(grid): explicitly declare box sizing to non-locked Grid content

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -286,6 +286,9 @@
             right: auto;
         }
 
+        .k-grid-content-locked + .k-grid-content {
+            box-sizing: content-box;
+        }
     }
 
     // Toolbar


### PR DESCRIPTION
Needed for the sake of Bootstrap 4 compatibility. See ticket 1154845.