### PR TITLE
fix(grid): fix grid filter row double border

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -587,6 +587,10 @@
             padding: $cell-padding-y;
         }
 
+        td:first-child {
+            border-left: 0px;
+        }
+
         .k-multiselect {
             height: auto;
         }


### PR DESCRIPTION
This PR ~fixes~  tries fix to the filter row left double border ->
![image](https://user-images.githubusercontent.com/568765/36888227-376aa2a2-1dfd-11e8-9916-8027a4fb7623.png)
