### PR TITLE
fix(scrollview): allow interaction in templates

### DIFF
--- a/packages/default/scss/scrollview/_layout.scss
+++ b/packages/default/scss/scrollview/_layout.scss
@@ -21,8 +21,7 @@
         height: 100%;
         cursor: default;
 
-        img,
-        li {
+        img {
             user-select: none;
         }
 
@@ -32,11 +31,6 @@
             position: absolute;
             top: 0;
             left: 0;
-        }
-
-        li > * {
-            user-select: none;
-            pointer-events: none;
         }
     }
 


### PR DESCRIPTION
currently content in templates is blocked from interaction, which limits the usefulness of the component

see #32, telerik/kendo-angular#493, telerik/kendo-angular#1311