### PR TITLE
fix(grid): fix filter menu double border

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -983,4 +983,13 @@
         }
     }
 
+    .k-grid-filter-popup {
+        border: 0;
+        padding: 0;
+
+        .k-filter-menu {
+            padding: 0;
+        }
+    }
+
 }


### PR DESCRIPTION
This PR fixes the double border of the filter menu in `default` theme:
![image](https://user-images.githubusercontent.com/568765/36902677-fbdbb604-1e33-11e8-8eea-be9a12ae1c5a.png)

as well as in `bootstrap` theme:
![image](https://user-images.githubusercontent.com/568765/36902712-1ff79ef4-1e34-11e8-819a-59a455b729d8.png)

The `bootstrap` requires a bit more overrides, which seems not used in the `default` theme.
