### PR TITLE
fix(grid): improve layout calculation in hidden containers

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -818,7 +818,7 @@
     .k-grid-content-locked,
     .k-grid-footer-locked,
     .k-grid-header-locked {
-        flex: 1 0 auto;
+        flex: 0 0 auto;
         display: inline-block;
         vertical-align: top;
         overflow: hidden;


### PR DESCRIPTION
The locked content always has a size, and should not be allowed to grow.
This change fixes problems when the ng grid is initialized in a hidden container.

See https://github.com/telerik/kendo-angular-grid/pull/516
Reported in ticket 1156102