### PR TITLE
chore: add bootstrap script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "lerna run build",
     "lint": "lerna run lint",
     "test": "lerna run test && npm run karma-single",
+    "bootstrap": "lerna clean --yes && lerna bootstrap",
     "watch-test": "npm run karma-watch",
     "karma-watch": "karma start --auto-watch --no-single-run",
     "karma-single": "karma start --no-auto-watch --single-run --browsers ChromeHeadless"


### PR DESCRIPTION
In the [k2-site](https://github.com/telerik/k2-site) build process we can enable `LOCAL_MODE`, which bootstraps all monorepos. However the local mode script runs `npm run bootstrap`, which is present in the `kendo-react-private` monorepo, but missing in the `kendo-themes`. 
This results in inability to bootstrap other monorepos, or am i missing something?

To keep the unified build process of the monorepos, my suggestion is simply adding this script.