### PR TITLE
fix(charts): update series colors to match current primary

### DIFF
--- a/packages/material/docs/customization.md
+++ b/packages/material/docs/customization.md
@@ -412,8 +412,8 @@ Used to provide contrast between the background and foreground colors.
 <tr>
 <td>$series-a</td>
 <td>
-    <span class="color-preview" style="background-color: #499f50"></span>
-    #499f50
+    <span class="color-preview" style="background-color: #3f51b5"></span>
+    #3f51b5
 </td>
 <td>The color of the first series.
 </td>
@@ -421,8 +421,8 @@ Used to provide contrast between the background and foreground colors.
 <tr>
 <td>$series-b</td>
 <td>
-    <span class="color-preview" style="background-color: #3193ee"></span>
-    #3193ee
+    <span class="color-preview" style="background-color: #e91e63"></span>
+    #e91e63
 </td>
 <td>The clor of the second series.
 </td>
@@ -430,8 +430,8 @@ Used to provide contrast between the background and foreground colors.
 <tr>
 <td>$series-c</td>
 <td>
-    <span class="color-preview" style="background-color: #673ab1"></span>
-    #673ab1
+    <span class="color-preview" style="background-color: #2196f3"></span>
+    #2196f3
 </td>
 <td>The color of the third series.
 </td>
@@ -439,8 +439,8 @@ Used to provide contrast between the background and foreground colors.
 <tr>
 <td>$series-d</td>
 <td>
-    <span class="color-preview" style="background-color: #e52864"></span>
-    #e52864
+    <span class="color-preview" style="background-color: #43a047"></span>
+    #43a047
 </td>
 <td>The color of the fourth series.
 </td>

--- a/packages/material/scss/_variables.scss
+++ b/packages/material/scss/_variables.scss
@@ -379,19 +379,19 @@ $link-hover-text: desaturate(darken($accent, 5), 25) !default;
 // Chart
 /// The color of the first series.
 /// @group charts
-$series-a: #499f50 !default;
+$series-a: #3f51b5 !default;
 
 /// The clor of the second series.
 /// @group charts
-$series-b: #3193ee !default;
+$series-b: #e91e63 !default;
 
 /// The color of the third series.
 /// @group charts
-$series-c: #673ab1 !default;
+$series-c: #2196f3 !default;
 
 /// The color of the fourth series.
 /// @group charts
-$series-d: #e52864 !default;
+$series-d: #43a047 !default;
 
 /// The color of the fifth series.
 /// @group charts


### PR DESCRIPTION
The Series-A color did not match the current primary color leading to inconsistencies. Consulted with @lkarakoleva and switched the series' colors around. Soon to be reflected in the designs.