### PR TITLE
fix(splitter): set pane layout for IE10

### DIFF
--- a/packages/default/scss/splitter/_layout.scss
+++ b/packages/default/scss/splitter/_layout.scss
@@ -137,6 +137,7 @@
         .k-pane {
             position: relative;
             flex: 1 1 auto;
+            display: block; // ie10 + flex
             min-width: 0;
             max-width: 100%;
             min-height: 0;


### PR DESCRIPTION
In IE10, flex children should not be `display:inline`, which is the case for angular panes (which are custom elements).

see https://github.com/telerik/kendo-angular/issues/1408