### PR TITLE
chore(menu): remove resetting padding for the second sub-menu level

### DIFF
--- a/packages/default/scss/menu/_layout.scss
+++ b/packages/default/scss/menu/_layout.scss
@@ -94,9 +94,6 @@ $image-spacing: 8px !default;
             display: block;
         }
     }
-    .k-menu-group .k-menu-group {
-        padding: 0;
-    }
 
 
     // Orientation


### PR DESCRIPTION
related https://github.com/telerik/kendo-themes/issues/78