### PR TITLE
fix(tooltip): tooltip in Material theme showing extra padding

### DIFF
--- a/packages/material/scss/popup/_theme.scss
+++ b/packages/material/scss/popup/_theme.scss
@@ -47,7 +47,10 @@ $grouping-border: $grouping-header-bg !default;
         }
     }
 
-
+    // Tooltip popup container padding
+    .k-animation-container-shown.k-tooltip-wrapper {
+        padding: 0
+    }
 
     .k-list-filter {
 


### PR DESCRIPTION
see telerik/kendo-themes#231
