### PR TITLE
fix(grid): empty grouping header collapses in IE

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -390,6 +390,7 @@
 
             &:last-child {
                 flex-grow: 1;
+                line-height: button-size();
             }
         }
     }


### PR DESCRIPTION
see https://github.com/telerik/kendo-themes/issues/210