### PR TITLE
fix(grid): focus outline is visible in Chrome

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -554,6 +554,7 @@
             display: block;
             overflow: hidden;
             text-overflow: ellipsis;
+            outline: 0;
         }
 
         .k-with-icon > .k-link,
@@ -718,6 +719,7 @@
     .k-grid-content,
     .k-grid-content-locked {
         border-color: inherit;
+        outline: 0;
 
         table {
             table-layout: fixed;


### PR DESCRIPTION
see https://github.com/telerik/kendo-angular/issues/1688