### PR TITLE
fix: switch from flex '1 1 0' to '1 1 auto' for ie 11 and edge

### DIFF
--- a/packages/default/scss/button/_layout.scss
+++ b/packages/default/scss/button/_layout.scss
@@ -160,7 +160,7 @@
 
         .k-button {
             display: inline-block;
-            flex: 1 1 0;
+            flex: 1 1 auto;
             overflow: hidden;
             text-overflow: ellipsis;
 

--- a/packages/default/scss/calendar/_layout.scss
+++ b/packages/default/scss/calendar/_layout.scss
@@ -131,13 +131,13 @@ $calendar-view-gap: 32px !default;
             // Fast navigation
             .k-nav-fast {
                 margin: 0 $calendar-cell-padding-y;
-                flex: 1 1 0%;
+                flex: 1 1 auto;
             }
 
 
             // Today
             .k-nav-today {
-                flex: 1 1 0%;
+                flex: 1 1 auto;
             }
 
         }

--- a/packages/default/scss/card/_layout.scss
+++ b/packages/default/scss/card/_layout.scss
@@ -53,7 +53,7 @@
         @extend %top-rounded-child !optional;
         @extend %bottom-rounded-child !optional;
         padding: $card-body-padding-y $card-body-padding-x;
-        flex: 1 1 0;
+        flex: 1 1 auto;
 
         p {
             margin: 0 0 $paragraph-margin-bottom;

--- a/packages/default/scss/common/_forms.scss
+++ b/packages/default/scss/common/_forms.scss
@@ -274,7 +274,7 @@ $forms-invalid-color: $error !default;
         }
 
         .k-link {
-            flex: 1 1 0;
+            flex: 1 1 auto;
             display: block;
             overflow: hidden;
             position: relative;

--- a/packages/default/scss/datetime/_layout.scss
+++ b/packages/default/scss/datetime/_layout.scss
@@ -23,7 +23,7 @@
 
         .k-dateinput {
             width: 100%;
-            flex: 1 1 0%;
+            flex: 1 1 auto;
             margin: 0;
         }
 

--- a/packages/default/scss/editor/_layout.scss
+++ b/packages/default/scss/editor/_layout.scss
@@ -70,7 +70,7 @@
         &.k-toolbar-resizable {
             flex-wrap: nowrap;
             overflow: hidden;
-            flex: 1 1 0%;
+            flex: 1 1 auto;
         }
 
         li {

--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -666,7 +666,7 @@
         > span,
         .k-filtercell-wrapper {
             display: flex;
-            flex: 1 1 0;
+            flex: 1 1 auto;
 
             > label {
                 vertical-align: middle;

--- a/packages/default/scss/numerictextbox/_layout.scss
+++ b/packages/default/scss/numerictextbox/_layout.scss
@@ -20,7 +20,7 @@
         }
 
         > .k-input {
-            flex: 1 1 0;
+            flex: 1 1 auto;
 
             &:invalid {
                 box-shadow: none;

--- a/packages/default/scss/tabstrip/_layout.scss
+++ b/packages/default/scss/tabstrip/_layout.scss
@@ -35,6 +35,7 @@
                 padding: 0;
                 border: $tabstrip-item-border-width solid transparent;
                 position: relative;
+                flex-shrink: 0;
                 display: flex;
                 flex-direction: row;
                 align-items: stretch;
@@ -61,6 +62,9 @@
                     flex: none;
                 }
             }
+        }
+        @at-root .k-ie11 .k-tabstrip-items {
+            white-space: nowrap;
         }
 
         > .k-content {

--- a/packages/default/scss/tabstrip/_layout.scss
+++ b/packages/default/scss/tabstrip/_layout.scss
@@ -51,7 +51,7 @@
                 cursor: pointer;
                 display: inline-flex;
                 vertical-align: middle;
-                flex: 1 1 0;
+                flex: 1 1 auto;
                 flex-direction: row;
                 align-content: center;
                 align-items: center;


### PR DESCRIPTION
fixes #362 and other flex related bugs, like tabstrip misalignment in edge and IE 11