### PR TITLE
fix(calendar): layout glitch in Edge 18

### DIFF
--- a/packages/default/scss/calendar/_layout.scss
+++ b/packages/default/scss/calendar/_layout.scss
@@ -295,6 +295,7 @@
             .k-calendar-weekdays {
                 width: 100%;
                 flex: 0 0 auto;
+                table-layout: auto;
             }
 
             .k-calendar-yearview,


### PR DESCRIPTION
Edge 18 seems to have a glitch with calculating the column widths with `table-layout: fixed`.
See https://github.com/telerik/kendo-angular/issues/1840

![image](https://user-images.githubusercontent.com/6189002/46785567-b7455c80-cd64-11e8-886f-4b4abdf76963.png)
