### PR TITLE
fix(splitter): collapsed panes take visible space

### DIFF
--- a/packages/default/scss/splitter/_layout.scss
+++ b/packages/default/scss/splitter/_layout.scss
@@ -165,7 +165,7 @@
             &[hidden] {
                 // sass-lint:disable-block no-important
                 // hidden panes need to be zero-width to allow pane animation
-                flex-basis: 0 !important;
+                flex: 0 1 0 !important;
                 overflow: hidden !important;
                 display: block !important;
             }


### PR DESCRIPTION
flex-basis is insufficient to make the pane fully collapse, so the flex property should be forced to shrink

see https://github.com/telerik/kendo-angular/issues/1978