### PR TITLE
fix(dropdowngrid): column width is not respected when virtualization is enabled

### DIFF
--- a/packages/default/scss/dropdowngrid/_layout.scss
+++ b/packages/default/scss/dropdowngrid/_layout.scss
@@ -69,6 +69,11 @@
         display: table-cell;
         vertical-align: middle;
     }
+    .k-grid-list.k-virtual-list > .k-item > .k-cell,
+    .k-grid-list.k-virtual-list > .k-item > .k-group,
+    .k-grid-list.k-virtual-list > .k-item > .k-spacer-group {
+        display: inline-block;
+    }
     .k-grid-list > .k-item:last-child > .k-cell,
     .k-grid-list > .k-item:last-child > .k-group-cell,
     .k-grid-list > .k-item:last-child > .k-spacer-cell {


### PR DESCRIPTION
The sass counter part of  telerik/kendo@3788274dd1393a4bce8fa04602edbac1bbb03114

Fixes telerik/kendo-ui-core#4663