### PR TITLE
fix(window): window actions are not properly aligned in IE

### DIFF
--- a/packages/bootstrap/scss/window/_theme.scss
+++ b/packages/bootstrap/scss/window/_theme.scss
@@ -14,6 +14,11 @@
         height: 1em;
         border-width: 0;
         opacity: .5;
+
+        // fix: IE 11 tends to displace the buttons, so we remove the padding
+        .k-ie & {
+            padding: 0;
+        }
     }
     .k-window-action:hover {
         opacity: .75;


### PR DESCRIPTION
Only in IE, only for Bootstrap theme, the window actions are displaced. Culprit is the padding, so I've scoped and removed it just for IE
![image](https://user-images.githubusercontent.com/8048/50760845-8a281d80-1271-11e9-8fa3-58601e754092.png)
