### PR TITLE
fix(dialog): there should be no spacing between streched buttons in rtl

### DIFF
--- a/packages/default/scss/dialog/_layout.scss
+++ b/packages/default/scss/dialog/_layout.scss
@@ -104,6 +104,7 @@
 
             .k-rtl &,
             [dir='rtl'] & {
+                margin: 0;
                 border-left-width: 0;
                 border-right-width: $dialog-stretched-button-border-width;
             }


### PR DESCRIPTION
There should be no spacing between stretched buttons, regardless of orientation, but there is:
![image](https://user-images.githubusercontent.com/8048/50765013-4509e880-127d-11e9-86d8-041a969fc537.png)
