### PR TITLE
Fix swatches and add them to npm package

### DIFF
--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -26,7 +26,7 @@
     "watch": "kendotheme build --watch",
     "swatches": "kendotheme build --swatches",
     "test": "npm run lint && npm run build && npm run api-check",
-    "prepublishOnly": "bash ./build/embed-dependencies 'bootstrap' '@progress/kendo-theme-default' && npm run build",
+    "prepublishOnly": "bash ./build/embed-dependencies 'bootstrap' '@progress/kendo-theme-default' && npm run build && npm run swatches",
     "postpublish": "rm -rf modules && git checkout scss"
   },
   "peerDependencies": {

--- a/packages/default/package.json
+++ b/packages/default/package.json
@@ -26,7 +26,8 @@
     "swatches": "kendotheme build --swatches",
     "embed-assets": "kendotheme assets",
     "test": "npm run lint && npm run build && npm run api-check",
-    "twbs-compat": "kendotheme build --file ./build/twbs-compat.scss"
+    "twbs-compat": "kendotheme build --file ./build/twbs-compat.scss",
+    "prepublishOnly": "npm run build && npm run swatches"
   },
   "devDependencies": {
     "@progress/kendo-theme-tasks": "^0.1.1",

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -27,7 +27,7 @@
     "watch": "kendotheme build --watch",
     "swatches": "kendotheme build --swatches",
     "test": "npm run lint && npm run build && npm run api-check",
-    "prepublishOnly": "bash ./build/embed-dependencies '@progress/kendo-theme-default' && npm run build",
+    "prepublishOnly": "bash ./build/embed-dependencies '@progress/kendo-theme-default' && npm run build && npm run swatches",
     "postpublish": "rm -rf modules && git checkout scss"
   },
   "dependencies": {

--- a/packages/material/scss/swatches/pink-bluegrey-dark.scss
+++ b/packages/material/scss/swatches/pink-bluegrey-dark.scss
@@ -1,5 +1,5 @@
 $primary-palette-name: pink;
-$secondary-palette-name: blueGray;
+$secondary-palette-name: blueGrey;
 $theme-type: dark;
 
 @import "../all.scss";

--- a/packages/theme-tasks/.eslintrc
+++ b/packages/theme-tasks/.eslintrc
@@ -1,6 +1,9 @@
 {
     "root": true,
     "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
     "env": {
         "browser": true,
         "node": true,

--- a/packages/theme-tasks/lib/tasks/sass.js
+++ b/packages/theme-tasks/lib/tasks/sass.js
@@ -11,7 +11,6 @@ const nodeSassPackageImporter = require("../utils/nodesass-packageimporter");
 const postcss = require("gulp-postcss");
 const autoprefixer = require("autoprefixer");
 const calc = require("postcss-calc");
-const browserSync = require("browser-sync").create();
 const sassdoc = require('sassdoc');
 
 const postcssPlugins = [
@@ -27,12 +26,6 @@ const sassOptions = {
     outputStyle: "compressed",
     importer: nodeSassPackageImporter
 };
-const browserSyncOptions = {
-    server: {
-        baseDir: "./"
-    },
-    open: false
-};
 
 
 // #region core
@@ -42,8 +35,7 @@ function build(glob) {
     return gulp.src(_glob)
         .pipe(sass(sassOptions).on("error", sass.logError))
         .pipe(postcss(postcssPlugins))
-        .pipe(gulp.dest(paths.sass.dist))
-        .pipe(browserSync.stream({ match: "**/*.css" }));
+        .pipe(gulp.dest(paths.sass.dist));
 }
 function buildFile(file) {
     return build(file);
@@ -56,8 +48,6 @@ function theme() {
     return build(paths.sass.theme);
 }
 function watchtheme() {
-    browserSync.init(browserSyncOptions);
-
     gulp.watch(paths.sass.src, theme);
 }
 function swatches() {

--- a/packages/theme-tasks/lib/tasks/sass.js
+++ b/packages/theme-tasks/lib/tasks/sass.js
@@ -7,7 +7,7 @@ const path = require("path");
 const fs = require("fs");
 const mime = require("mime");
 const sass = require("gulp-sass");
-const nodeSassPackageImporter = require("../utils/nodesass-packageimporter");
+const { slowPackageImporter, fastPackageImporter } = require("../utils/nodesass-packageimporter");
 const postcss = require("gulp-postcss");
 const autoprefixer = require("autoprefixer");
 const calc = require("postcss-calc");
@@ -21,10 +21,15 @@ const postcssPlugins = [
         browsers: browsers
     })
 ];
-const sassOptions = {
+const fastSassOptions = {
     precision: 10,
     outputStyle: "compressed",
-    importer: nodeSassPackageImporter
+    importer: fastPackageImporter
+};
+const slowSassOptions = {
+    precision: 10,
+    outputStyle: "compressed",
+    importer: slowPackageImporter
 };
 
 
@@ -33,7 +38,15 @@ function build(glob) {
     let _glob = glob || paths.sass.src;
 
     return gulp.src(_glob)
-        .pipe(sass(sassOptions).on("error", sass.logError))
+        .pipe(sass(fastSassOptions).on("error", sass.logError))
+        .pipe(postcss(postcssPlugins))
+        .pipe(gulp.dest(paths.sass.dist));
+}
+function buildSlow(glob) {
+    let _glob = glob || paths.sass.src;
+
+    return gulp.src(_glob)
+        .pipe(sass(slowSassOptions).on("error", sass.logError))
         .pipe(postcss(postcssPlugins))
         .pipe(gulp.dest(paths.sass.dist));
 }
@@ -48,10 +61,10 @@ function theme() {
     return build(paths.sass.theme);
 }
 function watchtheme() {
-    gulp.watch(paths.sass.src, theme);
+    gulp.watch(paths.sass.src, () => buildSlow(paths.sass.theme) );
 }
 function swatches() {
-    return build(paths.sass.swatches);
+    return buildSlow(paths.sass.swatches);
 }
 // #endregion
 

--- a/packages/theme-tasks/lib/utils/nodesass-packageimporter.js
+++ b/packages/theme-tasks/lib/utils/nodesass-packageimporter.js
@@ -2,30 +2,24 @@ const path = require("path");
 
 const EMPTY_IMPORT = {
     file: "",
-    contents: "",
+    contents: ""
 };
 
 const imported = new Set();
 
-module.exports = function(url, prev/*, done*/) {
+function fastPackageImporter(url) {
+
+    if (!url.startsWith("~")) {
+        return null;
+    }
+
     let file;
 
-    if (url.startsWith("~")) {
-        file = path.resolve(
-            path.join(
-                process.cwd(),
-                "node_modules/",
-                url.slice(1)
-            )
-        );
-    } else {
-        file = path.resolve(
-            path.join(
-                path.dirname(prev),
-                url
-            )
-        );
-    }
+    file = path.resolve( path.join(
+        process.cwd(),
+        "node_modules/",
+        url.slice(1)
+    ) );
 
     if (imported.has(file)) {
         return EMPTY_IMPORT;
@@ -37,4 +31,30 @@ module.exports = function(url, prev/*, done*/) {
         file: file
     };
 
+}
+
+function slowPackageImporter(url) {
+
+    if (!url.startsWith("~")) {
+        return null;
+    }
+
+    let file;
+
+    file = path.resolve( path.join(
+        process.cwd(),
+        "node_modules/",
+        url.slice(1)
+    ) );
+
+    return {
+        file: file
+    };
+
+}
+
+
+module.exports = {
+    slowPackageImporter,
+    fastPackageImporter
 };

--- a/packages/theme-tasks/lib/utils/nodesass-packageimporter.js
+++ b/packages/theme-tasks/lib/utils/nodesass-packageimporter.js
@@ -7,54 +7,27 @@ const EMPTY_IMPORT = {
 
 const imported = new Set();
 
-function fastPackageImporter(url) {
+function packageImporterFactory(options = { cache: false }) {
+    return function packageImporter(url) {
+        if (!url.startsWith("~")) {
+            return null;
+        }
 
-    if (!url.startsWith("~")) {
-        return null;
-    }
+        let file = path.resolve( path.join(
+            process.cwd(),
+            "node_modules/",
+            url.slice(1)
+        ) );
 
-    let file;
+        if (options.cache && imported.has(file)) {
+            return EMPTY_IMPORT;
+        }
 
-    file = path.resolve( path.join(
-        process.cwd(),
-        "node_modules/",
-        url.slice(1)
-    ) );
+        imported.add(file);
 
-    if (imported.has(file)) {
-        return EMPTY_IMPORT;
-    }
-
-    imported.add(file);
-
-    return {
-        file: file
+        return { file };
     };
-
-}
-
-function slowPackageImporter(url) {
-
-    if (!url.startsWith("~")) {
-        return null;
-    }
-
-    let file;
-
-    file = path.resolve( path.join(
-        process.cwd(),
-        "node_modules/",
-        url.slice(1)
-    ) );
-
-    return {
-        file: file
-    };
-
 }
 
 
-module.exports = {
-    slowPackageImporter,
-    fastPackageImporter
-};
+module.exports = packageImporterFactory;

--- a/packages/theme-tasks/package.json
+++ b/packages/theme-tasks/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "autoprefixer": "^9.1.5",
-    "browser-sync": "^2.26.3",
     "glob": "^7.1.3",
     "gulp": "^4.0.0",
     "gulp-postcss": "^8.0.0",


### PR DESCRIPTION
Previously, swatches only built the first swatch, due to heavy optimizations on our side and the way gulp works.

I've extended the code to allow building without optimizations, which does take some more time.