### PR TITLE
Grid: footer misalignment when scroll is enabled

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -511,7 +511,8 @@
         overflow: hidden;
     }
 
-    .k-grid-header-wrap.k-auto-scrollable {
+    .k-grid-header-wrap.k-auto-scrollable,
+    .k-grid-footer-wrap {
         margin-right: -1px;
     }
 


### PR DESCRIPTION
related to: https://github.com/telerik/kendo-themes/issues/511