### PR TITLE
Add k-no-click class styles

### DIFF
--- a/packages/default/scss/common/_base.scss
+++ b/packages/default/scss/common/_base.scss
@@ -84,6 +84,12 @@ $widget-border-width: 1px !default;
     }
 
 
+    // Disable mouse events
+    .k-no-click {
+        pointer-events: none;
+    }
+
+
     // Off-screen container used during PDF export
     .k-pdf-export-shadow {
         position: absolute;


### PR DESCRIPTION
As discussed with @joneff I am adding the `k-no-click` class. We are going to use this class when we cannot assign the `k-state-disabled`, however, the user should not interact with the element.

cc: @elena-gancheva @TeyaVes @Juveniel 