### PR TITLE
Grouping header text overflows with frozen columns

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -385,6 +385,7 @@
     .k-grouping-header {
         display: block;
         position: relative;
+        white-space: normal;
         padding: $grid-grouping-header-padding-y $grid-grouping-header-padding-x;
         border-width: 0 0 1px;
         border-style: solid;


### PR DESCRIPTION
targets: https://github.com/telerik/kendo-themes/issues/591