### PR TITLE
ColorPicker: wrapper hover styles not applied

### DIFF
--- a/packages/bootstrap/scss/colorpicker/_theme.scss
+++ b/packages/bootstrap/scss/colorpicker/_theme.scss
@@ -14,6 +14,7 @@
         }
 
         // Hovered state
+        .k-picker-wrap:hover,
         .k-state-hover {
             @include appearance( hovered-button );
         }

--- a/packages/default/scss/colorpicker/_layout.scss
+++ b/packages/default/scss/colorpicker/_layout.scss
@@ -216,6 +216,7 @@
             height: 14px;
             overflow: hidden;
             -ms-high-contrast-adjust: none;
+            cursor: pointer;
         }
         // TODO: consider extrangting variables
         // sass-lint:disable no-color-literals no-color-keywords

--- a/packages/default/scss/colorpicker/_theme.scss
+++ b/packages/default/scss/colorpicker/_theme.scss
@@ -20,6 +20,7 @@
         }
 
         // Hovered state
+        .k-picker-wrap:hover,
         .k-state-hover {
             @include appearance( hovered-button );
         }


### PR DESCRIPTION
* Applied the `.k-state-hover` also to `.k-picker-wrap:hover` - no point in using js to achieve the hover effect.
* While on the ColorPicker topic: the styles of the `.k-item` elements inside the ColorPalette are inconsistent when the palette is used as a standalone component and when it's used in the ColorPicker component (inside a popup), as you can see below. The `cursor: pointer` is applied from the popup styles (`.k-popup .k-item`). Perhaps we should apply that style for the standalone palette as well. Raising the question here, as there's no point in opening a separate PR for this in my opinion.

![image](https://user-images.githubusercontent.com/18740853/54043007-3d5eb580-41d4-11e9-84fe-11d62ea8d1b3.png)

![image](https://user-images.githubusercontent.com/18740853/54043119-7eef6080-41d4-11e9-8572-59c99041a20a.png)
