### PR TITLE
docs: fix bootstrap mismatching variable descriptions

### DIFF
--- a/packages/bootstrap/docs/customization.md
+++ b/packages/bootstrap/docs/customization.md
@@ -421,7 +421,7 @@ Used to provide contrast between the background and foreground colors.
     
     $success
 </td>
-<td>The color for error messages and states.
+<td>The color for success messages and states.
 </td>
 </tr>
 <tr>
@@ -430,7 +430,7 @@ Used to provide contrast between the background and foreground colors.
     
     $info
 </td>
-<td>The color for warning messages and states.
+<td>The color for informational messages and states.
 </td>
 </tr>
 <tr>
@@ -439,7 +439,7 @@ Used to provide contrast between the background and foreground colors.
     
     $warning
 </td>
-<td>The color for success messages and states.
+<td>The color for warning messages and states.
 </td>
 </tr>
 <tr>
@@ -448,7 +448,7 @@ Used to provide contrast between the background and foreground colors.
     
     $danger
 </td>
-<td>The color for informational messages and states.
+<td>The color for error messages and states.
 </td>
 </tr>
 <tr>

--- a/packages/bootstrap/scss/_variables.scss
+++ b/packages/bootstrap/scss/_variables.scss
@@ -24,19 +24,19 @@ $accent: $primary !default;
 /// @group color-system
 $accent-contrast: contrast-wcag( $accent ) !default;
 
-/// The color for error messages and states.
+/// The color for success messages and states.
 /// @group color-system
 $success: $success !default;
 
-/// The color for warning messages and states.
+/// The color for informational messages and states.
 /// @group color-system
 $info: $info !default;
 
-/// The color for success messages and states.
+/// The color for warning messages and states.
 /// @group color-system
 $warning: $warning !default;
 
-/// The color for informational messages and states.
+/// The color for error messages and states.
 /// @group color-system
 $error: $danger !default;
 


### PR DESCRIPTION
See https://github.com/telerik/kendo-themes/issues/733 