### PR TITLE
fix(colorpicker): remove additional padding for material theme

### DIFF
--- a/packages/material/scss/popup/_layout.scss
+++ b/packages/material/scss/popup/_layout.scss
@@ -13,6 +13,9 @@ $popup-filter-padding-x: $padding-x;
         .k-group-header {
             text-transform: uppercase;
         }
+        &.k-colorpicker-popup {
+            padding: 0;
+        }
     }
 
     .k-list-container {

--- a/tests/visual/colorpicker.html
+++ b/tests/visual/colorpicker.html
@@ -360,7 +360,6 @@
                             <span class="k-select"><span class="k-icon k-i-arrow-s"></span></span>
                         </span>
                     </kendo-colorpicker>
-                    <div>dummy div for testing prevent direct sibling rendering</div>
                     <kendo-popup class="k-animation-container k-animation-container-shown" style="left: 0; top: 40px;">
                         <div class="k-popup k-colorpicker-popup">
                             <kendo-colorgradient class="k-widget k-flatcolorpicker">

--- a/tests/visual/colorpicker.html
+++ b/tests/visual/colorpicker.html
@@ -360,8 +360,9 @@
                             <span class="k-select"><span class="k-icon k-i-arrow-s"></span></span>
                         </span>
                     </kendo-colorpicker>
+                    <div>dummy div for testing prevent direct sibling rendering</div>
                     <kendo-popup class="k-animation-container k-animation-container-shown" style="left: 0; top: 40px;">
-                        <div class="k-popup">
+                        <div class="k-popup k-colorpicker-popup">
                             <kendo-colorgradient class="k-widget k-flatcolorpicker">
                                 <div class="k-hsv-wrap k-horizontal">
                                     <div class="k-hsv-rectangle" style="background-color: rgb(255, 0, 0);">
@@ -483,7 +484,7 @@
                         </span>
                     </kendo-colorpicker>
                     <kendo-popup class="k-animation-container k-animation-container-shown" style="left: 0; top: 40px;">
-                        <div class="k-popup">
+                        <div class="k-popup k-colorpicker-popup">
                             <kendo-colorpalette class="k-widget k-colorpalette">
                                 <div role="grid">
                                     <table class="k-palette k-reset" role="presentation">


### PR DESCRIPTION
See: https://github.com/telerik/kendo-themes/issues/740

The popup element cannot be targeted by the existing selector because it is rendered dynamically and can exist in a different HTML structure. 
An additional class of the ColorPicker component has to be added. Class name: `k-colorpicker-popup`. 
This class sets the padding of the targeted element to zero and thus removes the additional padding of the popup in the Material theme. 
