### PR TITLE
Cannot select text if the Grid is inside Splitter pane

### DIFF
--- a/packages/default/scss/adaptive/_layout.scss
+++ b/packages/default/scss/adaptive/_layout.scss
@@ -1,19 +1,14 @@
 @include exports("adaptive/layout") {
 
-    .k-root,
-    .k-pane,
-    .k-pane-wrapper {
-        width: 100%;
-        height: 100%;
-        user-select: none;
-        box-sizing: border-box;
-    }
-
     .k-pane-wrapper {
         position: relative;
         font-size: 14px;
 
         .k-pane {
+            width: 100%;
+            height: 100%;
+            user-select: none;
+            box-sizing: border-box;
             font-family: sans-serif;
             overflow-x: hidden;
 


### PR DESCRIPTION
Targets: https://github.com/telerik/kendo-themes/issues/721