### PR TITLE
Grid: Material filter menu wrong font-weight

### DIFF
--- a/packages/material/scss/grid/_layout.scss
+++ b/packages/material/scss/grid/_layout.scss
@@ -52,6 +52,10 @@ $grid-group-drag-clue-opacity: .9 !default;
 
         th {
             font-weight: 700;
+
+            .k-grid-filter {
+                font-weight: normal;
+            }
         }
 
         .k-grid-filter {


### PR DESCRIPTION
targets: https://github.com/telerik/kendo-themes/issues/761