### PR TITLE
chore: update handlebars dependency due to security issue

### DIFF
--- a/packages/default/package.json
+++ b/packages/default/package.json
@@ -33,6 +33,6 @@
     "@progress/kendo-theme-tasks": "^0.1.6",
     "bootstrap": "^4.3.1",
     "gulp": "^4.0.2",
-    "handlebars": "^4.0.10"
+    "handlebars": "^4.1.0"
   }
 }


### PR DESCRIPTION
Targeting WS-2019-0103 -- Handlebars.js before 4.1.0 has Remote Code Execution (RCE)