### PR TITLE
Improve Gantt Timeline Header Accessibility

### DIFF
--- a/packages/default/scss/gantt/_layout.scss
+++ b/packages/default/scss/gantt/_layout.scss
@@ -162,6 +162,11 @@
         .k-grid-content {
             overflow-x: scroll;
         }
+        .k-header {
+            padding: $grid-header-padding-y $grid-header-padding-x;
+            border-width: 0 0 1px $grid-cell-vertical-border-width;
+            white-space: nowrap;
+        }
     }
 
 
@@ -469,8 +474,18 @@
         .k-task-wrap:not(.k-milestone-wrap) {
             margin: 0 -26px;
         }
-        .k-timeline .k-gantt-tasks tbody {
-            text-align: left;
+
+        .k-gantt-timeline {
+
+            .k-gantt-tasks tbody {
+                text-align: left;
+            }
+            .k-header {
+                border-width: 0 $grid-cell-vertical-border-width 1px 0;
+            }
+            .k-header:first-child {
+                border-right-width: 0;
+            }
         }
 
         .k-task-content {

--- a/packages/default/scss/gantt/_theme.scss
+++ b/packages/default/scss/gantt/_theme.scss
@@ -53,6 +53,15 @@
     }
 
 
+    // Timeline
+    .k-gantt-timeline {
+
+        .k-header {
+            border-color: inherit;
+        }
+    }
+
+
     // Treelist
     .k-gantt-treelist {
         background-color: darken( $panel-bg, 2 );

--- a/packages/material/scss/gantt/_layout.scss
+++ b/packages/material/scss/gantt/_layout.scss
@@ -60,6 +60,20 @@
     }
 
 
+    //Timeline
+    .k-gantt-timeline {
+
+        .k-header {
+            font-weight: 700;
+        }
+        .k-rtl & {
+
+            .k-header {
+                border-width: 0 $grid-cell-vertical-border-width 1px 0;
+            }
+        }
+    }
+
     // Treelist
     .k-gantt-treelist {}
 

--- a/packages/material/scss/gantt/_theme.scss
+++ b/packages/material/scss/gantt/_theme.scss
@@ -31,6 +31,24 @@
     }
 
 
+    //Timeline
+    .k-gantt-timeline {
+
+        tbody > tr:not(:only-child) > .k-header {
+            border-left-color: $grid-border;
+        }
+        .k-rtl & {
+
+            .k-grid-header {
+
+                tbody > tr:not(:only-child) > .k-header {
+                    border-right-color: $grid-border;
+                }
+            }
+        }
+    }
+
+
     // Rows and colls
     .k-gantt-rows {}
     .k-gantt-columns {}


### PR DESCRIPTION
Because of an issue reported by Compliance Sherrif (https://www.w3.org/TR/WCAG20-TECHS/H43), I had to change the `<thead>` and `<th>` elements in the header of the Gantt Timeline to `<tbody>` and `<td>`. In order to keep the styling as it is now, I have to introduce some new rules for the Gantt widget.