### PR TITLE
fix(progressbar): set initial size to progress so it animates smoothly

### DIFF
--- a/packages/default/scss/progressbar/_layout.scss
+++ b/packages/default/scss/progressbar/_layout.scss
@@ -84,6 +84,7 @@
         }
 
         > .k-state-selected {
+            width: 0;
             flex-direction: row;
         }
 
@@ -128,6 +129,7 @@
         }
 
         > .k-state-selected {
+            height: 0;
             flex-direction: column-reverse;
             align-self: flex-end;
         }


### PR DESCRIPTION
Related to kendo-jquery: when no initial size (width, height) is set, the animations start from 100% instead of 0.