### PR TITLE
Improve build time and enable watch for themes

### DIFF
--- a/packages/theme-tasks/lib/tasks/sass.js
+++ b/packages/theme-tasks/lib/tasks/sass.js
@@ -41,6 +41,8 @@ const dartSassOptions = {
 
 // #region core
 function build(fileGlob = paths.sass.src, options = quickSassOptions) {
+    options.importer.resetImported();
+
     return gulp.src(fileGlob)
         .pipe(sass(options).on("error", sass.logError))
         .pipe(postcss(postcssPlugins))

--- a/packages/theme-tasks/lib/utils/nodesass-packageimporter.js
+++ b/packages/theme-tasks/lib/utils/nodesass-packageimporter.js
@@ -8,16 +8,21 @@ const EMPTY_IMPORT = {
 const imported = new Set();
 
 function packageImporterFactory(options = { cache: false }) {
-    return function packageImporter(url) {
-        if (!url.startsWith("~")) {
-            return null;
-        }
+    return function packageImporter(url, prev) {
+        let file;
 
-        let file = path.resolve( path.join(
-            process.cwd(),
-            "node_modules/",
-            url.slice(1)
-        ) );
+        if (url.startsWith("~")) {
+            file = path.resolve(path.join(
+                process.cwd(),
+                "node_modules/",
+                url.slice(1)
+            ));
+        } else {
+            file = path.resolve(path.join(
+                path.dirname(prev),
+                url
+            ));
+        }
 
         if (options.cache && imported.has(file)) {
             return EMPTY_IMPORT;

--- a/packages/theme-tasks/lib/utils/nodesass-packageimporter.js
+++ b/packages/theme-tasks/lib/utils/nodesass-packageimporter.js
@@ -8,7 +8,7 @@ const EMPTY_IMPORT = {
 const imported = new Set();
 
 function packageImporterFactory(options = { cache: false }) {
-    return function packageImporter(url, prev) {
+    function packageImporter(url, prev) {
         let file;
 
         if (url.startsWith("~")) {
@@ -31,7 +31,15 @@ function packageImporterFactory(options = { cache: false }) {
         imported.add(file);
 
         return { file };
-    };
+    }
+
+    packageImporter.resetImported = resetImported;
+
+    return packageImporter;
+}
+
+function resetImported() {
+    imported.clear();
 }
 
 


### PR DESCRIPTION
* rework sass importer logic so it handles local files imports, not only ~
* add utility method to sass import to conveniently reset imported paths, thus enabling watch again