### PR TITLE
Flatten theme files for dist

### DIFF
--- a/packages/theme-tasks/gulpfile.js
+++ b/packages/theme-tasks/gulpfile.js
@@ -16,6 +16,7 @@ const Fiber = require("fibers");
 const sassdoc = require("sassdoc");
 const eslint = require("gulp-eslint");
 const sasslint = require("gulp-sass-lint");
+const baka = require("@joneff/baka");
 const sassImporterFactory = require("./lib/sassimporter");
 
 
@@ -30,6 +31,7 @@ const paths = {
         theme: "./scss/all.scss",
         swatches: "./scss/swatches/*.scss",
         src: "./scss/**/*.scss",
+        inline: "./dist/all.scss",
         dist: "./dist",
         assets: "./scss/**/*.{png,gif,ttf,woff}"
     },
@@ -115,7 +117,6 @@ gulp.task('sass:swatches', function() {
     sass.compiler = require("node-sass");
     return build(paths.sass.swatches, paths.sass.dist);
 });
-gulp.task('sass:prepublish', gulp.series("sass", "sass:swatches"));
 // #endregion
 
 
@@ -135,7 +136,6 @@ gulp.task('dart:swatches', function() {
     sass.compiler = require("sass");
     return build(paths.sass.swatches, paths.sass.dist);
 });
-gulp.task('dart:prepublish', gulp.series("dart", "dart:swatches"));
 // #endregion
 
 
@@ -223,7 +223,22 @@ gulp.task("ci:full", gulp.series("lint", "sass", "dart", "api:check"));
 // #endregion
 
 
+// #region Flatten files
+gulp.task("flatten-sass-files", function(done) {
+    let file = getArg("--file") || paths.sass.theme;
+    let outFile = getArg("--out-file") || paths.sass.inline;
+
+    baka.compile(file, outFile);
+
+    Promise.resolve();
+    done();
+});
+// #region
+
+
 // #region prepublish
+gulp.task('sass:prepublish', gulp.series("sass", "sass:swatches", "flatten-sass-files"));
+gulp.task('dart:prepublish', gulp.series("dart", "dart:swatches", "flatten-sass-files"));
 gulp.task("prepublish", gulp.series("sass:prepublish"));
 // #endregion
 

--- a/packages/theme-tasks/package.json
+++ b/packages/theme-tasks/package.json
@@ -41,6 +41,7 @@
     "sassdoc": "^2.5.0"
   },
   "devDependencies": {
+    "@joneff/baka": "^0.1.0",
     "gulp-eslint": "^5.0.0"
   }
 }


### PR DESCRIPTION
Note: Obviously, this needs to be rebased after #904 is merged. Pay attention to the last two commits.

It's been an issue for a while now, compiling the themes outside of the scope of our development takes too much time. That's why I've added functionality to inline / flatten / squash / whatever the themes in a single mostly self-contained file that can be included.

The results are sub 1s compile time.

Since we are not using `_index.scss` convention anywhere, we could actually have the current `_all.scss` files renamed to `_index.scss` and the have `_all.scss` generated. We could even do it for components.

~~I am open to suggestions how to name the tasks. `inline-sass-files` doesn't sound right. Perhaps "flatten"?~~ Renamed task to `flatten-sass-files`.

* fixes #423 and probably others

/cc @gyoshev thoughts?