### PR TITLE
fix: speedup dart-sass compilation

### DIFF
--- a/packages/theme-tasks/lib/tasks/sass.js
+++ b/packages/theme-tasks/lib/tasks/sass.js
@@ -25,17 +25,12 @@ const postcssPlugins = [
 const quickSassOptions = {
     precision: 10,
     outputStyle: "compressed",
-    importer: packageImporterFactory({ cache: true })
+    importer: packageImporterFactory({ cache: true }),
+    fiber: Fiber
 };
 const fullSassOptions = {
     ...quickSassOptions,
     importer: packageImporterFactory({ cache: false })
-};
-const dartSassOptions = {
-    ...quickSassOptions,
-    importer: packageImporterFactory({ cache: false }),
-    outputStyle: "expanded",
-    fiber: Fiber
 };
 
 
@@ -44,7 +39,7 @@ function build(fileGlob = paths.sass.src, options = quickSassOptions) {
     options.importer.resetImported();
 
     return gulp.src(fileGlob)
-        .pipe(sass(options).on("error", sass.logError))
+        .pipe(sass.sync(options).on("error", sass.logError))
         .pipe(postcss(postcssPlugins))
         .pipe(gulp.dest(paths.sass.dist));
 }
@@ -67,7 +62,7 @@ function swatches() {
 // #region dart
 function dart() {
     sass.compiler = require("sass");
-    return build(paths.sass.theme, dartSassOptions);
+    return build(paths.sass.theme, quickSassOptions);
 }
 // #endregion
 

--- a/packages/theme-tasks/lib/utils/nodesass-packageimporter.js
+++ b/packages/theme-tasks/lib/utils/nodesass-packageimporter.js
@@ -1,9 +1,6 @@
 const path = require("path");
 
-const EMPTY_IMPORT = {
-    file: "",
-    contents: ""
-};
+const EMPTY_IMPORT = {};
 
 const imported = new Set();
 


### PR DESCRIPTION
dart-sass compilation couldn't be fast, because we couldn't use caching properly. Reason for that being how dart-sass and node-sass treat our `EMPTY_FILE` descriptor. Previously, node-sass treated it OK, but dart-sass was complaining. It turns out `EMPTY_FILE` needs to be blank object with no fields!

Some data:
```bash
# with old EMPTY_FILE
$ gulp sass
[16:19:37] Using gulpfile ~/work/kendo-themes/packages/bootstrap/gulpfile.js
[16:19:37] Starting 'sass'...
[16:19:38] Finished 'sass' after 973 ms

$ gulp dart
[16:19:51] Using gulpfile ~/work/kendo-themes/packages/bootstrap/gulpfile.js
[16:19:51] Starting 'dart'...
[16:20:15] Finished 'dart' after 23 s

# with new EMPTY_FILE and sass.sync
$ gulp sass
[16:21:35] Using gulpfile ~/work/kendo-themes/packages/bootstrap/gulpfile.js
[16:21:35] Starting 'sass'...
[16:21:36] Finished 'sass' after 957 ms

$ gulp dart
[16:21:50] Using gulpfile ~/work/kendo-themes/packages/bootstrap/gulpfile.js
[16:21:50] Starting 'dart'...
[16:21:56] Finished 'dart' after 6.71 s
```

I should mention that the neither using `sass.sync`, nor `fibers` nor any combination of them yields any significant improvement (as per documentation) and the results are mostly consistent within a small margin.

Still, being able to resolve files on our own and suggest the compiler where to look; and being able to skip the file next time it's requested did improve build time -- in the last month, time dropdded from about 30-40 seconds to sub 1 for node-sass and from about a minute to 6 seconds for dart-sass. And we are not done yet :)