### PR TITLE
fix(editor): whitespaces are trimmed at the end of a text in FF

### DIFF
--- a/packages/default/scss/editor/_layout.scss
+++ b/packages/default/scss/editor/_layout.scss
@@ -32,6 +32,7 @@
 
             > .ProseMirror { // sass-lint:disable-line class-name-format
                 padding: $padding-x;
+                white-space: pre-wrap;
             }
         }
 


### PR DESCRIPTION
see telerik/kendo-angular#2227