### PR TITLE
fix(grid): add styles for standalone column menu

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -274,14 +274,6 @@
                     right: auto;
                     left: $grid-header-menu-icon-spacing;
                 }
-
-                // Column Menu in header template is positioned inline.
-                .k-link .k-grid-filter {
-                    position: initial;
-                    display: inline-block;
-                    margin: -4px 0;
-                    padding: 4px 8px;
-                }
             }
 
             .k-filtercell-operator {
@@ -699,6 +691,14 @@
 
     .k-grid-filter-popup {
         min-width: 200px;
+    }
+
+    // Standalone column menu
+    .k-grid-column-menu-standalone a.k-grid-filter {
+        position: initial;
+        display: inline-block;
+        margin: -4px 0;
+        padding: 4px 8px;
     }
 
     .k-grid-columnmenu-popup {


### PR DESCRIPTION
Adds a dedicated class for the standalone column menu that overrides the default position.

The attempt from #1051 relied on the header content being wrapped in `<a class="k-link">` which is not the case if the column is not sortable.

This approach also allows placing the column menu outside the Grid.