### PR TITLE
fix: add whitespace around operators in calc expressions

### DIFF
--- a/packages/bootstrap/scss/_variables.scss
+++ b/packages/bootstrap/scss/_variables.scss
@@ -1812,7 +1812,7 @@ $timeline-collapse-arrow-padding-x: $padding-x-sm !default;
 
 $timeline-event-width: 400px !default;
 $timeline-event-height: 600px !default;
-$timeline-event-min-height-calc: calc(2 * (#{$timeline-track-event-offset}- #{$card-border-width})) !default;
+$timeline-event-min-height-calc: calc(2 * (#{$timeline-track-event-offset} - #{$card-border-width})) !default;
 
 
 // Upload

--- a/packages/default/scss/_variables.scss
+++ b/packages/default/scss/_variables.scss
@@ -1806,7 +1806,7 @@ $timeline-collapse-arrow-padding-x: $padding-x !default;
 
 $timeline-event-width: 400px !default;
 $timeline-event-height: 600px !default;
-$timeline-event-min-height-calc: calc(2 * (#{$timeline-track-event-offset}- #{$card-border-width})) !default;
+$timeline-event-min-height-calc: calc(2 * (#{$timeline-track-event-offset} - #{$card-border-width})) !default;
 
 
 // Upload

--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -512,7 +512,7 @@
             width: $grid-group-dropclue-line-size;
             height: calc(100% - #{$grid-group-dropclue-size});
             top: $grid-group-dropclue-size;
-            left: calc( #{$grid-group-dropclue-size} - (#{$grid-group-dropclue-line-size} / 2) );
+            left: calc( #{$grid-group-dropclue-size} - #{$grid-group-dropclue-line-size / 2} );
         }
     }
 

--- a/packages/default/scss/upload/_layout.scss
+++ b/packages/default/scss/upload/_layout.scss
@@ -200,7 +200,7 @@
 
             .k-file-name-size-wrapper {
                 margin-left: calc( #{$upload-item-image-width} + #{$spacer-x} );
-                margin-right: calc( #{$icon-size}*2 + 3.5em );
+                margin-right: calc( #{$icon-size * 2} + 3.5em );
                 min-height: $upload-item-image-height + ($upload-item-image-border * 2);
                 display: block;
                 overflow: hidden;

--- a/packages/material/scss/_variables.scss
+++ b/packages/material/scss/_variables.scss
@@ -1899,7 +1899,7 @@ $timeline-collapse-arrow-padding-x: $padding-x-sm !default;
 
 $timeline-event-width: 400px !default;
 $timeline-event-height: 600px !default;
-$timeline-event-min-height-calc: calc(2 * (#{$timeline-track-event-offset}- #{$card-border-width})) !default;
+$timeline-event-min-height-calc: calc(2 * (#{$timeline-track-event-offset} - #{$card-border-width})) !default;
 
 
 // Upload


### PR DESCRIPTION
To ensure correct calc expression there must be space around operators (`-`, `+`, `*`, `/`)