### PR TITLE
fix(tabstrip): remove default browser outline

### DIFF
--- a/packages/default/scss/tabstrip/_layout.scss
+++ b/packages/default/scss/tabstrip/_layout.scss
@@ -40,6 +40,7 @@
                 flex-direction: row;
                 align-items: stretch;
                 justify-items: stretch;
+                outline: 0;
             }
 
             .k-tab-on-top {


### PR DESCRIPTION
fixes https://github.com/telerik/kendo-themes/issues/1039