### PR TITLE
Ensure widgets inside scheduler header or footer inherit font-size

### DIFF
--- a/packages/default/scss/scheduler/_layout.scss
+++ b/packages/default/scss/scheduler/_layout.scss
@@ -186,6 +186,16 @@
     }
 
     // Header and footer
+    .k-scheduler-header {
+        .k-widget {
+            font-size: inherit;
+        }
+    }
+    .k-scheduler-footer {
+        .k-widget {
+            font-size: inherit;
+        }
+    }
     .k-scheduler-toolbar,
     .k-scheduler-footer {
         padding: $toolbar-padding-y $toolbar-padding-x;


### PR DESCRIPTION
Hello Team,

I'd like to propose the following changes to the `.k-select` class inside the date-time pickers.

## The problem
While working on the KendoReact scheduler component, we wanted to replace the current `button.k-link` + `<Calendar />` with a `<DatePicker />` component + custom renders.

The custom renders consist of:
- Removing the `k-picker-wrap`
- Removing the `dateinput`
- Adding text (formatted `Date`) inside the `a.k-select` of the DatePicker.

After applying the custom renders to the `<DatePicker />` the markup is the following:
```html
<span role="group" aria-expanded="false" class="k-widget k-datepicker">
  <a role="button" class="k-select k-link" title="Toggle calendar" aria-label="Toggle calendar"> . 
  <span class="k-icon k-i-calendar"></span><span class="k-sm-date-format">June 2020</span> 
  <span class="k-i-lg-date-format">June 2020</span></a>
</span>
```

The custom renders work as expected, except for the `font-size` inside the `a.k-select`. Since we've removed the `.k-picker-wrap` container through custom rendering, the following rule does not apply: https://github.com/telerik/kendo-themes/blob/046ea6970bca396a671a226af485a3267c072c18/packages/material/scss/datetime/_layout.scss#L16-L19

Since the `k-datepicker` class applies `font-size: 16px`, there is not way to specify the font-size through the provided classnames.

I found a workaround by applying `k-grid-edit-row` to the wrapping element around the `<DatePicker />` but i believe this is not optimal.