### PR TITLE
Move color variables

### DIFF
--- a/packages/bootstrap/docs/customization.md
+++ b/packages/bootstrap/docs/customization.md
@@ -396,15 +396,6 @@ The following table lists the available variables for customizing the Bootstrap 
 <th>Description</th>
 </tr>
 <tr>
-<td>$color-level-step</td>
-<td>
-    
-    $theme-color-interval
-</td>
-<td>Set a specific jump point for requesting color jumps
-</td>
-</tr>
-<tr>
 <td>$primary</td>
 <td>
     
@@ -477,33 +468,6 @@ Used to provide contrast between the background and foreground colors.
     $danger
 </td>
 <td>The color for error messages and states.
-</td>
-</tr>
-<tr>
-<td>$yiq-threshold</td>
-<td>
-    
-    $yiq-contrasted-threshold
-</td>
-<td>The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
-</td>
-</tr>
-<tr>
-<td>$yiq-dark</td>
-<td>
-    
-    $yiq-text-dark
-</td>
-<td>Dark color for use in YIQ color contrast function.
-</td>
-</tr>
-<tr>
-<td>$yiq-light</td>
-<td>
-    
-    $yiq-text-light
-</td>
-<td>Light color for use in YIQ color contrast function.
 </td>
 </tr>
 </table>

--- a/packages/bootstrap/scss/_variables.scss
+++ b/packages/bootstrap/scss/_variables.scss
@@ -71,10 +71,6 @@ $zindex-window: 2 !default;
 $accent: $primary !default;
 $accent-contrast: contrast-wcag( $accent ) !default;
 
-/// Set a specific jump point for requesting color jumps
-/// @group color-system
-$color-level-step: $theme-color-interval !default;
-
 
 // Theme colors
 /// The color that focuses the user attention.
@@ -123,21 +119,6 @@ $warning-darker: shade($warning, 2) !default;
 $error: $danger !default;
 $error-lighter: tint($error, 2) !default;
 $error-darker: shade($error, 2) !default;
-
-
-// Contrast
-
-/// The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
-/// @group color-system
-$yiq-threshold: $yiq-contrasted-threshold !default;
-
-/// Dark color for use in YIQ color contrast function.
-/// @group color-system
-$yiq-dark: $yiq-text-dark !default;
-
-/// Light color for use in YIQ color contrast function.
-/// @group color-system
-$yiq-light: $yiq-text-light !default;
 
 
 // Color constants

--- a/packages/default/docs/customization.md
+++ b/packages/default/docs/customization.md
@@ -396,15 +396,6 @@ The following table lists the available variables for customizing the Default th
 <th>Description</th>
 </tr>
 <tr>
-<td>$color-level-step</td>
-<td>
-    
-    8%
-</td>
-<td>Set a specific jump point for requesting color jumps
-</td>
-</tr>
-<tr>
 <td>$primary</td>
 <td>
     
@@ -477,33 +468,6 @@ Used to provide contrast between the background and foreground colors.
     #f31700
 </td>
 <td>The color for error messages and states.
-</td>
-</tr>
-<tr>
-<td>$yiq-threshold</td>
-<td>
-    
-    150
-</td>
-<td>The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
-</td>
-</tr>
-<tr>
-<td>$yiq-dark</td>
-<td>
-    
-    black
-</td>
-<td>Dark color for use in YIQ color contrast function.
-</td>
-</tr>
-<tr>
-<td>$yiq-light</td>
-<td>
-    
-    white
-</td>
-<td>Light color for use in YIQ color contrast function.
 </td>
 </tr>
 </table>

--- a/packages/default/scss/_variables.scss
+++ b/packages/default/scss/_variables.scss
@@ -63,10 +63,6 @@ $zindex-window: 2 !default;
 // Color settings
 // $is-dark-theme: ;
 
-/// Set a specific jump point for requesting color jumps
-/// @group color-system
-$color-level-step: 8% !default;
-
 // Deprecated
 // TODO: remove for v5
 $accent: #ff6358 !default;
@@ -120,21 +116,6 @@ $warning-darker: shade($warning, 2) !default;
 $error: #f31700 !default;
 $error-lighter: tint($error, 2) !default;
 $error-darker: shade($error, 2) !default;
-
-
-// Contrast
-
-/// The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
-/// @group color-system
-$yiq-threshold: 150 !default;
-
-/// Dark color for use in YIQ color contrast function.
-/// @group color-system
-$yiq-dark: black !default;
-
-/// Light color for use in YIQ color contrast function.
-/// @group color-system
-$yiq-light: white !default;
 
 
 // Color constants

--- a/packages/default/scss/functions/_colors.scss
+++ b/packages/default/scss/functions/_colors.scss
@@ -269,6 +269,50 @@ $linear-channel-values: (
     1
 );
 
+/// Set a specific jump point for requesting color jumps
+/// @group color-system
+/// @access private
+$color-level-step: if(
+    /* check for existance of bootstrap variable */
+    variable-exists("theme-color-interval"),
+    $theme-color-interval,
+    /* fallback */
+    8%
+) !default;
+
+/// The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
+/// @group color-system
+/// @access private
+$yiq-threshold: if(
+    /* check for existance of bootstrap variable */
+    variable-exists("yiq-contrasted-threshold"),
+    $yiq-contrasted-threshold,
+    /* fallback */
+    150
+) !default;
+
+/// Dark color for use in YIQ color contrast function.
+/// @group color-system
+/// @access private
+$yiq-dark: if(
+    /* check for existance of bootstrap variable */
+    variable-exists("yiq-text-dark"),
+    $yiq-text-dark,
+    /* fallback */
+    black
+) !default;
+
+/// Light color for use in YIQ color contrast function.
+/// @group color-system
+/// @access private
+$yiq-light: if(
+    /* check for existance of bootstrap variable */
+    variable-exists("yiq-text-light"),
+    $yiq-text-light,
+    /* fallback */
+    white
+) !default;
+
 // Calculate the luminance for a color.
 // See https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests
 @function luminance($color) {

--- a/packages/material/docs/customization.md
+++ b/packages/material/docs/customization.md
@@ -396,15 +396,6 @@ The following table lists the available variables for customizing the Material t
 <th>Description</th>
 </tr>
 <tr>
-<td>$color-level-step</td>
-<td>
-    
-    8%
-</td>
-<td>Set a specific jump point for requesting color jumps
-</td>
-</tr>
-<tr>
 <td>$primary</td>
 <td>
     
@@ -477,33 +468,6 @@ Used to provide contrast between the background and foreground colors.
     #f31700
 </td>
 <td>The color for error messages and states.
-</td>
-</tr>
-<tr>
-<td>$yiq-threshold</td>
-<td>
-    
-    150
-</td>
-<td>The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
-</td>
-</tr>
-<tr>
-<td>$yiq-dark</td>
-<td>
-    
-    black
-</td>
-<td>Dark color for use in YIQ color contrast function.
-</td>
-</tr>
-<tr>
-<td>$yiq-light</td>
-<td>
-    
-    white
-</td>
-<td>Light color for use in YIQ color contrast function.
 </td>
 </tr>
 </table>

--- a/packages/material/scss/_variables.scss
+++ b/packages/material/scss/_variables.scss
@@ -106,10 +106,6 @@ $zindex-window: 2;
 // Color settings
 $is-dark-theme: map-get($theme, is-dark);
 
-/// Set a specific jump point for requesting color jumps
-/// @group color-system
-$color-level-step: 8% !default;
-
 
 // Theme colors
 /// The color that focuses the user attention.
@@ -158,21 +154,6 @@ $warning-darker: shade($warning, 2) !default;
 $error: #f31700 !default;
 $error-lighter: tint($error, 2) !default;
 $error-darker: shade($error, 2) !default;
-
-
-// Contrast
-
-/// The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
-/// @group color-system
-$yiq-threshold: 150 !default;
-
-/// Dark color for use in YIQ color contrast function.
-/// @group color-system
-$yiq-dark: black !default;
-
-/// Light color for use in YIQ color contrast function.
-/// @group color-system
-$yiq-light: white !default;
 
 
 // Color constants


### PR DESCRIPTION
When creating swatches, we must specify `$color-level-step` and `$yiq-` vars, which seems counter intuitive.

To avoid this, I am moving the variables to `functions/_colors.scss` file. The downside is the intricate fallback mechanism, but we could simplify that at a later point, should we see the need to.