### PR TITLE
fix(slider): background-image empty url in material theme

### DIFF
--- a/packages/bootstrap/scss/slider/_theme.scss
+++ b/packages/bootstrap/scss/slider/_theme.scss
@@ -11,11 +11,4 @@
             }
         }
     }
-
-    .k-slider-horizontal .k-tick {
-        background-image: url(map-get($data-uris, "slider-h.gif"));
-    }
-    .k-slider-vertical .k-tick {
-        background-image: url(map-get($data-uris, "slider-v.gif"));
-    }
 }

--- a/packages/default/scss/mixins/_decoration.scss
+++ b/packages/default/scss/mixins/_decoration.scss
@@ -19,3 +19,9 @@
     background-color: transparent;
     background-image: none;
 }
+
+@mixin background-image( $background-image: null ) {
+    @if $background-image {
+        background-image: url(#{$background-image});
+    }
+}

--- a/packages/default/scss/slider/_theme.scss
+++ b/packages/default/scss/slider/_theme.scss
@@ -1,4 +1,6 @@
 @include exports("slider/theme") {
+    $slider-tick-horizontal-image: map-get($data-uris, "slider-h.gif") !default;
+    $slider-tick-vertical-image: map-get($data-uris, "slider-v.gif") !default;
 
     .k-slider {
         .k-slider-track,
@@ -71,10 +73,10 @@
     }
 
     .k-slider-horizontal .k-tick {
-        background-image: url(map-get($data-uris, "slider-h.gif"));
+        @include background-image( $slider-tick-horizontal-image );
     }
 
     .k-slider-vertical .k-tick {
-        background-image: url(map-get($data-uris, "slider-v.gif"));
+        @include background-image( $slider-tick-vertical-image );
     }
 }


### PR DESCRIPTION
fixes: https://github.com/telerik/kendo-themes/issues/1177

Note: as the material theme file inherits most of the styles from the default theme, the empty URL cannot be completely removed.