### PR TITLE
fix(gantt): exported timeline does not expand to full width in ie

### DIFF
--- a/packages/default/scss/gantt/_layout.scss
+++ b/packages/default/scss/gantt/_layout.scss
@@ -508,10 +508,15 @@
         }
 
         .k-gantt,
-        .k-gantt-timeline {
+        .k-gantt-timeline,
+        .k-gantt-dependencies {
             width: auto !important; // sass-lint:disable-line no-important
             height: auto !important; // sass-lint:disable-line no-important
             overflow: visible !important; // sass-lint:disable-line no-important
+        }
+
+        .k-gantt-treelist .k-treelist {
+            display: block;
         }
 
         .k-gantt-layout.k-splitbar {


### PR DESCRIPTION
targets: #1158