### PR TITLE
Update @joneff/baka to mitigate caching issue when flattening files for dist

### DIFF
--- a/packages/theme-tasks/package-lock.json
+++ b/packages/theme-tasks/package-lock.json
@@ -25,10 +25,9 @@
       }
     },
     "@joneff/baka": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@joneff/baka/-/baka-0.1.1.tgz",
-      "integrity": "sha512-on1PSwqWfURNrb7r82mFsMPRMeq+QRje1kwRmieApgx+aRJevs2gtU7U5h5AXa/VXvBDe6ZofdPXLHqiQHRFQg==",
-      "dev": true
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@joneff/baka/-/baka-0.1.2.tgz",
+      "integrity": "sha512-KwElRhL2MDXk6XNVGg47fdJy1ZXvLqfZFkmUephJgtO1USf2kxbVl4hnRSKAqqk4a72a6Ku0PMLn9QKCtdPMxA=="
     },
     "a-sync-waterfall": {
       "version": "1.0.1",
@@ -4877,7 +4876,8 @@
         "normalize-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "optional": true
         },
         "readdirp": {
           "version": "3.3.0",
@@ -5270,7 +5270,8 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "optional": true
     },
     "pify": {
       "version": "2.3.0",

--- a/packages/theme-tasks/package.json
+++ b/packages/theme-tasks/package.json
@@ -29,6 +29,7 @@
     "lint": "gulp lint"
   },
   "dependencies": {
+    "@joneff/baka": "^0.1.2",
     "ansi-colors": "^4.1.1",
     "autoprefixer": "^9.7.5",
     "fibers": "^4.0.2",
@@ -40,16 +41,15 @@
     "gulplog": "^1.0.0",
     "mime": "^2.4.4",
     "minimist": "^1.2.5",
+    "nunjucks": "^3.2.1",
     "plugin-error": "^1.0.1",
     "postcss-calc": "^7.0.2",
     "sass": "^1.26.3",
     "sass-lint": "^1.13.1",
     "sassdoc": "^2.7.1",
-    "sassdoc-extras": "^3.0.0",
-    "nunjucks": "^3.2.1"
+    "sassdoc-extras": "^3.0.0"
   },
   "devDependencies": {
-    "@joneff/baka": "^0.1.1",
     "gulp-eslint": "^6.0.0"
   }
 }


### PR DESCRIPTION
Fixes a bug where calling `sass:flat` and `sass:swatches` sequentially will result in "empty" /dist/all.scss file. That happens in prepublish...

/cc @vstaykov @svetq FYI the bug is being fixed