### PR TITLE
fix(filemanager): view container should overflow

### DIFF
--- a/packages/default/scss/filemanager/_layout.scss
+++ b/packages/default/scss/filemanager/_layout.scss
@@ -60,6 +60,10 @@
         overflow: hidden;
     }
 
+    // Filemanager view
+    .k-filemanager-view {
+        overflow: auto;
+    }
 
     // Breadcrumb
     .k-filemanager-breadcrumb {


### PR DESCRIPTION
targets: telerik/kendo/issues/10923