### PR TITLE
fix(contextmenu): menu items cut off

### DIFF
--- a/packages/default/scss/common/_animations.scss
+++ b/packages/default/scss/common/_animations.scss
@@ -1,7 +1,6 @@
 @include exports("animation/container") {
 
     .k-animation-container {
-        max-width: 100%;
         position: absolute;
         overflow: hidden;
         z-index: 100;


### PR DESCRIPTION
fixes https://github.com/telerik/kendo-themes/issues/1597