### PR TITLE
fix(calendar): remove outline from today button

### DIFF
--- a/packages/default/scss/calendar/_layout.scss
+++ b/packages/default/scss/calendar/_layout.scss
@@ -117,6 +117,7 @@
             }
             .k-today {
                 cursor: pointer;
+                outline: none;
             }
 
             .k-calendar-nav {


### PR DESCRIPTION
related to: https://github.com/telerik/kendo-themes/issues/1602