### PR TITLE
Add tooltip dependency to chart

### DIFF
--- a/packages/default/scss/dataviz/_index.scss
+++ b/packages/default/scss/dataviz/_index.scss
@@ -5,6 +5,7 @@
 // Dependencies
 @import "../common/_index.scss";
 @import "../popup/_index.scss";
+@import "../tooltip/_index.scss";
 
 
 // Component


### PR DESCRIPTION
tooltip dependency is added to the chart in order for this to work as expected: https://github.com/telerik/kendo-themes/issues/1623