### PR TITLE
fix(input): remove additional box shadow in Firefox browser

### DIFF
--- a/packages/default/scss/input/_layout.scss
+++ b/packages/default/scss/input/_layout.scss
@@ -12,6 +12,8 @@
         font-size: $input-font-size;
         line-height: $input-line-height;
         box-sizing: border-box;
+        // Targets https://github.com/telerik/kendo-react/issues/638.
+        box-shadow: none;
         background: none;
         display: inline-flex;
         flex-flow: row nowrap;


### PR DESCRIPTION
The issue is logged in the React repo: https://github.com/telerik/kendo-react/issues/638