### PR TITLE
infra: add stable release action

### DIFF
--- a/.github/workflows/tag_stable.yml
+++ b/.github/workflows/tag_stable.yml
@@ -1,0 +1,16 @@
+name: Tag stable version
+
+on: [workflow_dispatch]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Tag stable version
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        printf "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+        ./build/tag-stable.sh

--- a/build/constants.sh
+++ b/build/constants.sh
@@ -1,0 +1,8 @@
+# root dir
+dir=$(pwd)
+
+# all themes
+themes=$(ls $dir/packages/ --ignore=theme-tasks)
+
+#all packages
+packages=$(ls $dir/packages/)

--- a/build/foreach.sh
+++ b/build/foreach.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-# exit early on error
 set -e
 
-dir=$(pwd);
+source $(pwd)/build/constants.sh
 
-for pkg in default bootstrap material nouvelle theme-tasks
+for pkg in $packages
 do
     cd $dir/packages/$pkg
     npm run $1 --if-present

--- a/build/install.sh
+++ b/build/install.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-# exit early on error
 set -e
 
-dir=$(pwd);
+source $(pwd)/build/constants.sh
 
 if [[ $TRAVIS == true ]]
 then
@@ -23,9 +22,13 @@ else
     npm link --force
 
     # Install dependant themes
-    for pkg in bootstrap classic material nouvelle
+    for theme in $themes
     do
-        cd $dir/packages/$pkg
+        if [[ $theme == "default" ]]
+        then
+            continue
+        fi
+        cd $dir/packages/$theme
         npm link @progress/kendo-theme-default
         npm install
         npm link --force

--- a/build/tag-stable.sh
+++ b/build/tag-stable.sh
@@ -2,9 +2,12 @@
 
 set -e
 
-for theme in default bootstrap classic material nouvelle
+source $(pwd)/build/constants.sh
+
+for theme in $themes
 do
-    pkg=@progress/kendo-theme-$theme;
-    version=$(npm view $pkg version);
+    pkg=@progress/kendo-theme-$theme
+    version=$(npm view $pkg version)
+
     npm dist-tag $pkg@$version stable
 done

--- a/build/tag-stable.sh
+++ b/build/tag-stable.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+for theme in default bootstrap classic material nouvelle
+do
+    pkg=@progress/kendo-theme-$theme;
+    version=$(npm view $pkg version);
+    npm dist-tag $pkg@$version stable
+done


### PR DESCRIPTION
Action that adds **stable** dist-tag to themes themes. Used to denote version compatible with kendo-jquery.

Fixes #1770