### PR TITLE
Pivot: row headers width in IE

### DIFF
--- a/packages/default/scss/pivotgrid/_layout.scss
+++ b/packages/default/scss/pivotgrid/_layout.scss
@@ -222,13 +222,10 @@
 
     // Pivotgrid is stretched beyond container in IE 11
     // see https://github.com/telerik/kendo-theme-default/issues/647
+    // see https://github.com/telerik/kendo-themes/issues/1880
     .k-ie11 {
-        .k-pivot-layout {
-            width: 100%;
-            table-layout: fixed;
-        }
-        .k-pivot-layout > tbody > tr > td:first-child {
-            width: 280px;
+        .k-pivot .k-grid {
+            display: block;
         }
     }
 


### PR DESCRIPTION
targets: #1880