### PR TITLE
Detect jenkins for clean and install jobs

### DIFF
--- a/build/clean.sh
+++ b/build/clean.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-if [[ $TRAVIS == true ]]
+if [[ $TRAVIS == 'true' ]]
 then
     echo "Travis CI detected. Skipping clean."
+elif [[ $JENKINS == 'true' ]] || [[ -n $JENKINS_URL ]]
+then
+    echo "Jenkins detected. Skipping clean."
 else
     echo "Local environment detected."
 

--- a/build/install.sh
+++ b/build/install.sh
@@ -4,9 +4,13 @@ set -e
 
 source $(pwd)/build/constants.sh
 
-if [[ $TRAVIS == true ]]
+if [[ $TRAVIS == 'true' ]]
 then
     echo "Travis CI detected. Bootstraping trough lerna."
+    npx lerna bootstrap
+elif [[ $JENKINS == 'true' ]] || [[ -n $JENKINS_URL ]]
+then
+    echo "Jenkins detected. Bootstraping trough lerna."
     npx lerna bootstrap
 else
     echo "Local environment detected. Bootstraping manually ..."


### PR DESCRIPTION
Ugly hack. Requires environmental `$JENKINS` variable to be set to `true`, even though there is no true `true` in bash :D

Alternatively, I could use `$CI` variable for all such cases, in case we need the same handling for all cases.

/cc @ipeshev @tsvetomir ideas?