### PR TITLE
feat(grid): add focus shadow to the cells on native browser focus

### DIFF
--- a/packages/bootstrap/scss/grid/_theme.scss
+++ b/packages/bootstrap/scss/grid/_theme.scss
@@ -34,7 +34,12 @@
 
         // Focused state
         td.k-state-focused,
-        th.k-state-focused {
+        th.k-state-focused,
+        th:focus,
+        .k-master-row > td:focus,
+        .k-grouping-row > td:focus,
+        .k-detail-row > td:focus,
+        .k-group-footer > td:focus {
             box-shadow: $grid-focused-shadow;
         }
 

--- a/packages/default/scss/grid/_theme.scss
+++ b/packages/default/scss/grid/_theme.scss
@@ -86,7 +86,12 @@
 
         // Focused state
         td.k-state-focused,
-        th.k-state-focused {
+        th.k-state-focused,
+        th:focus,
+        .k-master-row > td:focus,
+        .k-grouping-row > td:focus,
+        .k-detail-row > td:focus,
+        .k-group-footer > td:focus {
             box-shadow: $grid-focused-shadow;
         }
 

--- a/packages/material/scss/grid/_theme.scss
+++ b/packages/material/scss/grid/_theme.scss
@@ -30,7 +30,12 @@
             tr:hover,
             tr.k-state-hover,
             td.k-state-focused,
-            th.k-state-focused {
+            th.k-state-focused,
+            th:focus,
+            .k-master-row > td:focus,
+            .k-grouping-row > td:focus,
+            .k-detail-row > td:focus,
+            .k-group-footer > td:focus  {
                 background-color: $grid-hovered-bg;
             }
 
@@ -43,7 +48,12 @@
             }
 
             td.k-state-focused,
-            th.k-state-focused {
+            th.k-state-focused,
+            th:focus,
+            .k-master-row > td:focus,
+            .k-grouping-row > td:focus,
+            .k-detail-row > td:focus,
+            .k-group-footer > td:focus  {
                 &.k-grid-header-sticky,
                 &.k-grid-content-sticky,
                 &.k-grid-footer-sticky {


### PR DESCRIPTION
Needs for the keyboard navigation implementation in React Grid/Treelist/Gantt components.