### PR TITLE
fix(utils): reverse middle pos in rtl

### DIFF
--- a/packages/default/scss/utils/_position.scss
+++ b/packages/default/scss/utils/_position.scss
@@ -45,12 +45,26 @@
         top: 50%;
         transform: translateY(-50%);
         left: 0;
+
+        .k-rtl &,
+        &[dir="rtl"],
+        [dir="rtl"] & {
+            left: auto;
+            right: 0;
+        }
     }
     .k-middle-end ,
     .k-pos-middle-end {
         top: 50%;
         transform: translateY(-50%);
         right: 0;
+
+        .k-rtl &,
+        &[dir="rtl"],
+        [dir="rtl"] & {
+            right: auto;
+            left: 0;
+        }
     }
     .k-bottom-start,
     .k-pos-bottom-start {


### PR DESCRIPTION
Reverses middle pos in RTL. Currently utilized in the FloatingActionButton.

related to: https://github.com/telerik/kendo-themes/issues/1948