### PR TITLE
fix(multicolumncombobox): remove the horizontal scroll from popup

### DIFF
--- a/packages/default/scss/dropdowngrid/_layout.scss
+++ b/packages/default/scss/dropdowngrid/_layout.scss
@@ -1,12 +1,14 @@
 @include exports("dropdowngrid/layout") {
-
     .k-dropdowngrid-popup {
         overflow: hidden;
     }
     .k-dropdowngrid-popup .k-virtual-wrap {
         margin: 0;
-    }
+    }​​​​​​​​
 
+    .k-dropdowngrid-popup .k-list-scroller {
+        overflow-x: hidden;
+    }
 
     // Grid list
     .k-grid-list {


### PR DESCRIPTION
Needs for the React MultiColumnComboBox implementation. Tested and doesn't break the jQuery widget.