### PR TITLE
fix(splitter): force low z-index on splitter draghandle

### DIFF
--- a/packages/default/scss/splitter/_layout.scss
+++ b/packages/default/scss/splitter/_layout.scss
@@ -88,9 +88,10 @@
     .k-splitbar-static-vertical { height: 1px; }
 
     .k-splitbar-draggable-horizontal .k-resize-handle {
-        position: static;
         width: $splitter-drag-handle-thickness;
         height: $splitter-drag-handle-length;
+        position: static;
+        z-index: 1;
     }
 
     .k-splitbar .k-resize-handle {
@@ -123,9 +124,10 @@
     }
 
     .k-splitbar-draggable-vertical .k-resize-handle {
-        position: static;
         width: $splitter-drag-handle-length;
         height: $splitter-drag-handle-thickness;
+        position: static;
+        z-index: 1;
     }
 
     .k-pane > .k-splitter-overlay {


### PR DESCRIPTION
`.k-draghandle` is bleeding high z-index because it's too generic

fixes #845