### PR TITLE
Apply flex grow to tooltip content so the close icon is at the correct position

### DIFF
--- a/packages/default/scss/tooltip/_layout.scss
+++ b/packages/default/scss/tooltip/_layout.scss
@@ -34,6 +34,7 @@
     }
 
     .k-tooltip-content {
+        flex: 1 1 auto;
         overflow: hidden;
         text-overflow: ellipsis;
     }


### PR DESCRIPTION
Fixes: #2060
Less themes counterpart: telerik/kendo#11924