### PR TITLE
Splitbutton in overflow should display its items vertically

### DIFF
--- a/packages/bootstrap/scss/toolbar/_layout.scss
+++ b/packages/bootstrap/scss/toolbar/_layout.scss
@@ -1,2 +1,1 @@
 @import "~@progress/kendo-theme-default/scss/toolbar/_layout.scss";
-

--- a/packages/default/scss/toolbar/_layout.scss
+++ b/packages/default/scss/toolbar/_layout.scss
@@ -153,6 +153,12 @@
             }
         }
 
+        // Split button
+        .k-split-button {
+            display: flex;
+            flex-direction: column;
+        }
+
         // Hidden items
         .k-overflow-hidden {
             display: none;


### PR DESCRIPTION
Fixes #1665

Note: we do have a test, but the rendering is not correct. We should and will revise it.