### PR TITLE
Tooltip content should take all available vertical space

### DIFF
--- a/packages/default/scss/tooltip/_layout.scss
+++ b/packages/default/scss/tooltip/_layout.scss
@@ -34,6 +34,7 @@
     }
 
     .k-tooltip-content {
+        align-self: stretch;
         flex: 1 1 auto;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
fixed #1744

Needed so iframes can take as much as space as needed.