### PR TITLE
fix(multicolumncombobox): item k-state-hover styles not applied on hover

### DIFF
--- a/packages/default/scss/dropdowngrid/_layout.scss
+++ b/packages/default/scss/dropdowngrid/_layout.scss
@@ -73,6 +73,7 @@
         box-sizing: border-box;
         display: table-row;
         position: relative;
+        cursor: pointer;
     }
     .k-grid-list > .k-item > .k-cell,
     .k-grid-list > .k-item > .k-group,

--- a/packages/default/scss/dropdowngrid/_theme.scss
+++ b/packages/default/scss/dropdowngrid/_theme.scss
@@ -54,7 +54,8 @@
 
 
     // Interactive states
-    .k-dropdowngrid-popup .k-item.k-state-hover {
+    .k-dropdowngrid-popup .k-item.k-state-hover,
+    .k-dropdowngrid-popup .k-item:hover {
         border-color: $grid-hovered-border;
         color: $grid-hovered-text;
         background-color: $grid-hovered-bg;


### PR DESCRIPTION
https://github.com/telerik/kendo-angular-dropdowns/issues/758

Repro demo:
https://stackblitz.com/edit/angular-mwkaiw?file=app/app.component.ts

Reproducible with React's MCCB as well. https://www.telerik.com/kendo-react-ui-develop/components/dropdowns/multicolumncombobox/keyboard-navigation/