### PR TITLE
Apply chart colors in tests

### DIFF
--- a/packages/default/scss/dataviz/_layout.scss
+++ b/packages/default/scss/dataviz/_layout.scss
@@ -449,10 +449,6 @@
             @if $type == "color" {
                 // background-color can store any color
                 background-color: $value;
-
-                svg & {
-                    fill: $value;
-                }
             } @else if $type == "number" {
                 // margin-top can store positive & negative values
                 margin-top: $value;

--- a/tests/visual/assets/scripts.js
+++ b/tests/visual/assets/scripts.js
@@ -18,3 +18,10 @@ if (animations === true) {
 } else {
     document.documentElement.classList.add("k-no-animations");
 }
+
+// Apply chart colors to SVG elements
+window.addEventListener('load', () => [ ...kendoThemeLink.sheet.cssRules ]
+    .filter(rule => rule.selectorText && rule.selectorText.startsWith('.k-var'))
+    .filter(rule => Boolean(rule.style.backgroundColor))
+    .forEach(rule => { rule.style.fill = rule.style.backgroundColor; })
+);


### PR DESCRIPTION
Extracted from #2184.

The change allows to simplify the styles we use to expose css values to charts. It also reduces the amount of actual css output by a good margin.