### PR TITLE
fix(inputs): angular checkbox and radio labels on the same line

### DIFF
--- a/packages/default/scss/checkbox/_layout.scss
+++ b/packages/default/scss/checkbox/_layout.scss
@@ -144,6 +144,9 @@
     kendo-label.k-checkbox-label > .k-label:first-child {
         margin-right: $checkbox-label-margin-x;
     }
+    kendo-label.k-checkbox-label > .k-label {
+        display: inline;
+    }
 
 
     // Checkbox list

--- a/packages/default/scss/radio/_layout.scss
+++ b/packages/default/scss/radio/_layout.scss
@@ -109,6 +109,9 @@
     kendo-label.k-radio-label > .k-label:first-child {
         margin-right: $radio-label-margin-x;
     }
+    kendo-label.k-radio-label > .k-label {
+        display: inline;
+    }
 
 
     // Radio list


### PR DESCRIPTION
The issue can be seen on Angular Forms Guideline page: 
 - https://www.telerik.com/kendo-angular-ui/components/forms/forms-guideline/#toc-form-controls
 - https://www.telerik.com/kendo-angular-ui/components/forms/forms-guideline/#toc-checkboxes--radiobuttons

The reason that Angular checkboxes and radios have their labels on a new line is the difference in the rendering compared to the other suites. Here, we have a host element that is inline and there is a `<label>`, that is a block element.