### PR TITLE
feat: add $chart-pane-title-font-weight variable

### DIFF
--- a/packages/bootstrap/scss/dataviz/_variables.scss
+++ b/packages/bootstrap/scss/dataviz/_variables.scss
@@ -91,6 +91,7 @@ $chart-font-size-lg: 16px !default;
 $chart-tooltip-font-size: ($font-size * .929) !default;
 $chart-label-font-size: .857em !default;
 $chart-title-font-size: 1.143em !default;
+$chart-pane-title-font-weight: $font-weight-bold !default;
 
 $chart-inactive: rgba( $body-text, .5 ) !default;
 

--- a/packages/bootstrap/scss/dataviz/_variables.scss
+++ b/packages/bootstrap/scss/dataviz/_variables.scss
@@ -91,7 +91,8 @@ $chart-font-size-lg: 16px !default;
 $chart-tooltip-font-size: ($font-size * .929) !default;
 $chart-label-font-size: .857em !default;
 $chart-title-font-size: 1.143em !default;
-$chart-pane-title-font-weight: $font-weight-bold !default;
+$chart-pane-title-font-size: $chart-label-font-size !default;
+$chart-pane-title-font-weight: $font-weight-normal !default;
 
 $chart-inactive: rgba( $body-text, .5 ) !default;
 

--- a/packages/classic/scss/dataviz/_variables.scss
+++ b/packages/classic/scss/dataviz/_variables.scss
@@ -91,7 +91,8 @@ $chart-font-size-lg: 16px !default;
 $chart-tooltip-font-size: ($font-size * .929) !default;
 $chart-label-font-size: .857em !default;
 $chart-title-font-size: 1.143em !default;
-$chart-pane-title-font-weight: $font-weight-bold !default;
+$chart-pane-title-font-size: $chart-label-font-size !default;
+$chart-pane-title-font-weight: $font-weight-normal !default;
 
 $chart-inactive: rgba( $body-text, .5 ) !default;
 /// The color of the Chart grid lines (major).

--- a/packages/classic/scss/dataviz/_variables.scss
+++ b/packages/classic/scss/dataviz/_variables.scss
@@ -91,6 +91,7 @@ $chart-font-size-lg: 16px !default;
 $chart-tooltip-font-size: ($font-size * .929) !default;
 $chart-label-font-size: .857em !default;
 $chart-title-font-size: 1.143em !default;
+$chart-pane-title-font-weight: $font-weight-bold !default;
 
 $chart-inactive: rgba( $body-text, .5 ) !default;
 /// The color of the Chart grid lines (major).

--- a/packages/default/scss/dataviz/_layout.scss
+++ b/packages/default/scss/dataviz/_layout.scss
@@ -18,6 +18,10 @@
         font-size: $chart-title-font-size;
     }
 
+    .k-var--chart-pane-title-font {
+        font-weight: $chart-pane-title-font-weight;
+    }
+
     .k-var--chart-label-font {
         font-size: $chart-label-font-size;
     }

--- a/packages/default/scss/dataviz/_layout.scss
+++ b/packages/default/scss/dataviz/_layout.scss
@@ -19,6 +19,7 @@
     }
 
     .k-var--chart-pane-title-font {
+        font-size: $chart-pane-title-font-size;
         font-weight: $chart-pane-title-font-weight;
     }
 

--- a/packages/default/scss/dataviz/_variables.scss
+++ b/packages/default/scss/dataviz/_variables.scss
@@ -91,7 +91,8 @@ $chart-font-size-lg: 16px !default;
 $chart-tooltip-font-size: ($font-size * .929) !default;
 $chart-label-font-size: .857em !default;
 $chart-title-font-size: 1.143em !default;
-$chart-pane-title-font-weight: $font-weight-bold !default;
+$chart-pane-title-font-size: $chart-label-font-size !default;
+$chart-pane-title-font-weight: $font-weight-normal !default;
 
 $chart-inactive: rgba( $body-text, .5 ) !default;
 /// The color of the Chart grid lines (major).

--- a/packages/default/scss/dataviz/_variables.scss
+++ b/packages/default/scss/dataviz/_variables.scss
@@ -91,6 +91,7 @@ $chart-font-size-lg: 16px !default;
 $chart-tooltip-font-size: ($font-size * .929) !default;
 $chart-label-font-size: .857em !default;
 $chart-title-font-size: 1.143em !default;
+$chart-pane-title-font-weight: $font-weight-bold !default;
 
 $chart-inactive: rgba( $body-text, .5 ) !default;
 /// The color of the Chart grid lines (major).

--- a/packages/material/scss/dataviz/_variables.scss
+++ b/packages/material/scss/dataviz/_variables.scss
@@ -91,7 +91,8 @@ $chart-font-size-lg: 16px !default;
 $chart-tooltip-font-size: ($font-size * .929) !default;
 $chart-label-font-size: .857em !default;
 $chart-title-font-size: 1.143em !default;
-$chart-pane-title-font-weight: $font-weight-bold !default;
+$chart-pane-title-font-size: $chart-label-font-size !default;
+$chart-pane-title-font-weight: $font-weight-normal !default;
 
 $chart-inactive: rgba( $component-text, .5 ) !default;
 /// The color of the Chart grid lines (major).

--- a/packages/material/scss/dataviz/_variables.scss
+++ b/packages/material/scss/dataviz/_variables.scss
@@ -91,6 +91,7 @@ $chart-font-size-lg: 16px !default;
 $chart-tooltip-font-size: ($font-size * .929) !default;
 $chart-label-font-size: .857em !default;
 $chart-title-font-size: 1.143em !default;
+$chart-pane-title-font-weight: $font-weight-bold !default;
 
 $chart-inactive: rgba( $component-text, .5 ) !default;
 /// The color of the Chart grid lines (major).


### PR DESCRIPTION
Not sure if this is the right way to do it. All existing variables either set the font family or size.