### PR TITLE
chore: remove redundant width from adaptive timezone editor

### DIFF
--- a/packages/default/scss/adaptive/_layout.scss
+++ b/packages/default/scss/adaptive/_layout.scss
@@ -457,7 +457,6 @@
             }
 
             .k-mobiletimezoneeditor {
-                width: 100;
                 display: flex;
                 align-items: center;
                 justify-content: flex-end;


### PR DESCRIPTION
Reported from Sitefinity client (tool validation) that units are not specified for the width property.

Design ref: https://github.com/telerik/kendo-ux-private/issues/13

Note: width is not required due to [flex](https://github.com/telerik/kendo-themes/blob/86d6b6dcee890dafa0c3dc0b8cf515d0b69a1cff/packages/default/scss/adaptive/_layout.scss#L464).