### PR TITLE
fix(grid): grid filter button cut off in IE11

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -795,6 +795,10 @@
             .k-button,
             .k-dropdown-operator {
                 margin-left: $grid-cell-padding-y / 2;
+
+                .k-ie & {
+                    min-width: $button-inner-calc-size;
+                }
             }
 
             .k-widget {


### PR DESCRIPTION
targets: #2069 

Before:
![image](https://user-images.githubusercontent.com/72436523/104393771-e7849280-554d-11eb-8c1d-8d7592605103.png)

After:
![image](https://user-images.githubusercontent.com/72436523/104393665-ad1af580-554d-11eb-893b-e9822075f4c4.png)


