### PR TITLE
fix: long content in item body overflows

### DIFF
--- a/packages/default/scss/tilelayout/_layout.scss
+++ b/packages/default/scss/tilelayout/_layout.scss
@@ -27,4 +27,8 @@
         }
     }
 
+    .k-tilelayout-item-body {
+        min-height: 0;
+    }
+
 }


### PR DESCRIPTION
By default, flex items have min-height: auto as initial value (https://drafts.csswg.org/css-flexbox/#min-size-auto). Therefore in scenarios when the content placed in the TileLayout item body component is higher than the wrapper, it overflows. Setting min-height to 0 will give users the opportunity to use vertical scroll for the long content.

