### PR TITLE
Reduce color distance in chart component

### DIFF
--- a/packages/default/scss/dataviz/_layout.scss
+++ b/packages/default/scss/dataviz/_layout.scss
@@ -469,7 +469,7 @@
         series-30: $series-30,
 
         gauge-pointer: $primary,
-        gauge-track: darken($chart-bg, 10%)
+        gauge-track: try-shade( $chart-bg )
     );
 
     @each $name, $value in $exported {


### PR DESCRIPTION
Part of #2234

Use `try-shade` with default color step instead of `darken` with percentage.