### PR TITLE
fix: ExpansionPanel with sibling has wrong top margin

### DIFF
--- a/packages/default/scss/expansion-panel/_layout.scss
+++ b/packages/default/scss/expansion-panel/_layout.scss
@@ -58,8 +58,9 @@
         box-sizing: border-box;
     }
 
-    .k-expander.k-expanded + .k-expander,
-    .k-expander.k-expanded:not(:first-child) {
+    // Multiple expanders
+    .k-expander + .k-expander.k-expanded,
+    .k-expander.k-expanded + .k-expander {
         margin-top: $expander-spacing-y;
     }
 


### PR DESCRIPTION
Fixes https://github.com/telerik/kendo-themes/issues/2304