### PR TITLE
Datetime: remove k-select focus outline

### DIFF
--- a/packages/default/scss/datetime/_layout.scss
+++ b/packages/default/scss/datetime/_layout.scss
@@ -45,8 +45,9 @@
             padding: 0;
             width: if( $use-picker-select-width, $spinner-width, null );
             border-width: 0 0 0 $picker-select-border-width;
-            box-sizing: border-box;
             border-style: solid;
+            box-sizing: border-box;
+            outline: 0;
             display: flex;
             flex-direction: column;
             align-items: stretch;
@@ -171,6 +172,7 @@
             border-width: 0 0 0 $picker-select-border-width;
             border-style: solid;
             box-sizing: border-box;
+            outline: 0;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -260,6 +262,7 @@
             border-width: 0 0 0 $picker-select-border-width;
             border-style: solid;
             box-sizing: border-box;
+            outline: 0;
             display: flex;
             align-items: stretch;
             justify-content: center;


### PR DESCRIPTION
Due to the requirement of having the `tabindex="-1"` attribute on the `k-select` datetime elements, we need to remove the user agent default focus outline.