### PR TITLE
Added list of keyboad navigation articles

### DIFF
--- a/docs/accessibility/AnimationContainer.md
+++ b/docs/accessibility/AnimationContainer.md
@@ -1,0 +1,9 @@
+---
+title: Animation Container
+category: components
+slug: animation-container
+position: 0
+---
+# AnimationContainer Keyboard Support
+
+Not applicable.

--- a/docs/accessibility/AutoComplete.md
+++ b/docs/accessibility/AutoComplete.md
@@ -1,0 +1,26 @@
+---
+title: Auto Complete
+category: components
+slug: auto-complete
+position: 1
+---
+# AutoComplete Keyboard Support
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Esc` | Closes the popup, if opened. Otherwise, resets the value in the combo |
+| `Up` | Moves focus to the next item in the collection. |
+| `Down` |  Moves focus to the prev item in the collection |
+| `Enter` |  Selects the item from the collection, if the popup is open. Otherwise, triggers change event.|
+| `Home` | Moves focus to the first item.  |
+| `End` | Moves focus to the last item. |
+
+Typing in the input should focus matched item.
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
+https://www.w3.org/TR/wai-aria-practices-1.2/examples/combobox/combobox-autocomplete-list.html
+https://www.w3.org/TR/wai-aria-practices/#listbox_kbd_interaction

--- a/docs/accessibility/Button.md
+++ b/docs/accessibility/Button.md
@@ -1,0 +1,19 @@
+---
+title: Button
+category: components
+slug: button
+position: 2
+---
+# Button Keyboard Support
+
+## Managing Focus
+
+The button is focusable by default, and follows the regular tab order of the page.
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter/Space`| Triggers a click action on the button |
+
+## Resources

--- a/docs/accessibility/ButtonGroup.md
+++ b/docs/accessibility/ButtonGroup.md
@@ -1,0 +1,21 @@
+---
+title: Button Group
+category: components
+slug: button-group
+position: 3
+---
+# ButtonGroup Keyboard Support
+
+## Managing Focus
+
+All of the buttons in the group are focusable by default, and follow the regular tab order of the page.
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Tab`| Focuses the next button in the group. If Focus is on the last button, focuses the next focusable element on the page. |
+| `Shfit + Tab`| Focuses to the previous button in the group. If focus is on the first button, focus the previous focusable element before the ButtonGorup. |
+| `Enter/Space`| Triggers a click action on the button |
+
+## Resources

--- a/docs/accessibility/Calendar.md
+++ b/docs/accessibility/Calendar.md
@@ -1,0 +1,32 @@
+---
+title: Calendar
+category: components
+slug: calendar
+position: 4
+---
+# Calendar Keyboard Support
+
+## Managing Focus
+
+- Tab Sequence follows the dom elements order.
+- Header Button that navigates to a view => focuses the table, so that the user can proceed with the navigation
+- Today Button that navigates to current date => focuses the table
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Down Arrow`| Moves focus to down cell, or navigates the view if currently focused date is in the last row of the current view period. |
+| `Up Arrow`| Moves focus to upper cell, or navigates the view if currently focused date is at the top row of the current view period. |
+| `Left Arrow`| Moves focus to previous cell |
+| `Right Arrow`| Moves focus to next cell |
+| `Enter` | Selects single date, range of dates (`Shift` pressed), or toggle selection (`Ctrl` pressed), respecting the selection mode. |
+| `Ctrl + Up Arrow` | Navigates to the upper view (e.g., from current month days, to the year). |
+| `Ctrl + Down Arrow` | Navigates to the lower view (e.g., from the months in the year to the days of the month). |
+| `Ctrl + Right Arrow` | Navigates to the next period. |
+| `Ctrl + Left Arrow` | Navigates to the previous period. |
+| `Tab` | Moves focus between the different navigation elements - view selection, previous/next buttons, today button, and the grid with dates/months/years. |
+| `Shift + Tab` | Moves backwards through these focusable elements. |
+
+## Resources
+https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html#kbd_label_5

--- a/docs/accessibility/Chart.md
+++ b/docs/accessibility/Chart.md
@@ -1,0 +1,9 @@
+---
+title: Chart
+category: components
+slug: chart
+position: 5
+---
+# Chart Keyboard Support
+
+Not applicable.

--- a/docs/accessibility/CheckBox.md
+++ b/docs/accessibility/CheckBox.md
@@ -1,0 +1,18 @@
+---
+title: Check Box
+category: components
+slug: check-box
+position: 6
+---
+# CheckBox Keyboard Support
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Space` | Toggles checked state. It always looks at the `Value` of the CheckBox, regardless of the Indeterminate state. |
+
+## Resources
+
+https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/checkbox/checkbox-1/checkbox-1.html
+https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/checkbox/checkbox-2/checkbox-2.html

--- a/docs/accessibility/ChunkProgressBar.md
+++ b/docs/accessibility/ChunkProgressBar.md
@@ -1,0 +1,9 @@
+---
+title: Chunk Progress Bar
+category: components
+slug: chunk-progress-bar
+position: 7
+---
+# ChunkProgressBar Keyboard Support
+
+Not applicable.

--- a/docs/accessibility/ComboBox.md
+++ b/docs/accessibility/ComboBox.md
@@ -1,0 +1,28 @@
+---
+title: Combo Box
+category: components
+slug: combo-box
+position: 8
+---
+# ComboBox Keyboard Support
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Down Arrow`| Moves focus to next item|
+| `Up Arrow`| Moves focus to previous|
+| `Alt Down` | Opens pop up|
+| `Alt Up` or `Esc` | Closes popup|
+|  `Esc` | Clears the value if popup is not visible|
+| `Home` | Moves focus to the first item.  |
+| `End` | Moves focus to the last item. |
+| `Enter` | Selects the item |
+
+Typing in the input should focus matched item.
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/#combobox
+https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
+https://www.w3.org/TR/wai-aria-practices/#listbox_kbd_interaction

--- a/docs/accessibility/ContextMenu.md
+++ b/docs/accessibility/ContextMenu.md
@@ -1,0 +1,33 @@
+---
+title: Context Menu
+category: components
+slug: context-menu
+position: 9
+---
+# ContextMenu Keyboard Support
+
+## Managing Focus
+
+When the context menu is opened, the focus will go to the first item of the context menu.
+Only one node will have tabindex in the menu.Interaction on a `menuitem` should focus it.
+
+## Keyboard Shortcuts
+| Shortcut | Behavior |
+|----------|----------|
+| `Shift + F10` | Activates the context menu from the context of the current focused element |
+| `Esc` | Close the popup of the context menu when the focus is in the main context menu |
+| `Enter` | Activates the item and closes the context menu. If the current menu item has a submenu (child items), opens the submenu and places the focus on its first item. |
+| `Space` | Same as Enter |
+| `Home` | Moves focus to the first item in the current menu or sub-menu. |
+| `End` | Moves focus to the last item in the current menu or sub-menu. |
+| `Arrow Down` |- When the focus is on a menuitem in a menubar or menu, moves focus to the next item, wrapping from the last to the first only on the root menuitems. <br> - When the focus is on the last menuitem in the menu performs the following: <br> 1.Closes the menu. <br> 2.Focus next root item. <br> 3.Open the submenu of the menuitem without focus it if it has any.|
+| `Arrow Up` | - When the focus is on a menuitem in a menubar or menu, moves focus to the previous item, optionally wrapping from the first to the last. |
+| `Arrow Left` | - When focus is on a menuitem in a menubar or in a submenu of an item in a menubar, opens its submenu and places focus on the last item in the submenu <br> - When focus is in a submenu of an item in a menu, closes the submenu and returns focus to the parent menuitem. |
+| `Arrow Right` | - When the focus is on a menuitem in a menubar on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br> - When the focus is in a menu and on an item that does not have a submenu, doesn't perform anything.|
+
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/#menu
+https://www.w3.org/TR/wai-aria-practices/#keyboard-interaction-12
+https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-1/menubar-1.html#kbd_label

--- a/docs/accessibility/ContextMenu.md
+++ b/docs/accessibility/ContextMenu.md
@@ -20,10 +20,10 @@ Only one node will have tabindex in the menu.Interaction on a `menuitem` should 
 | `Space` | Same as Enter |
 | `Home` | Moves focus to the first item in the current menu or sub-menu. |
 | `End` | Moves focus to the last item in the current menu or sub-menu. |
-| `Arrow Down` |- When the focus is on a menuitem in a menubar or menu, moves focus to the next item, wrapping from the last to the first only on the root menuitems. <br> - When the focus is on the last menuitem in the menu performs the following: <br> 1.Closes the menu. <br> 2.Focus next root item. <br> 3.Open the submenu of the menuitem without focus it if it has any.|
+| `Arrow Down` |- When the focus is on a menuitem in a menubar or menu, moves focus to the next item, wrapping from the last to the first only on the root menuitems. <br/> - When the focus is on the last menuitem in the menu performs the following: <br/> 1.Closes the menu. <br/> 2.Focus next root item. <br/> 3.Open the submenu of the menuitem without focus it if it has any.|
 | `Arrow Up` | - When the focus is on a menuitem in a menubar or menu, moves focus to the previous item, optionally wrapping from the first to the last. |
-| `Arrow Left` | - When focus is on a menuitem in a menubar or in a submenu of an item in a menubar, opens its submenu and places focus on the last item in the submenu <br> - When focus is in a submenu of an item in a menu, closes the submenu and returns focus to the parent menuitem. |
-| `Arrow Right` | - When the focus is on a menuitem in a menubar on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br> - When the focus is in a menu and on an item that does not have a submenu, doesn't perform anything.|
+| `Arrow Left` | - When focus is on a menuitem in a menubar or in a submenu of an item in a menubar, opens its submenu and places focus on the last item in the submenu <br/> - When focus is in a submenu of an item in a menu, closes the submenu and returns focus to the parent menuitem. |
+| `Arrow Right` | - When the focus is on a menuitem in a menubar on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br/> - When the focus is in a menu and on an item that does not have a submenu, doesn't perform anything.|
 
 
 ## Resources

--- a/docs/accessibility/DateInput.md
+++ b/docs/accessibility/DateInput.md
@@ -1,0 +1,21 @@
+---
+title: Date Input
+category: components
+slug: date-input
+position: 10
+---
+# DateInput Keyboard Support
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Up` | Increases the value of the date segment that is highlighted. |
+| `Down` | Decreases the value of the date segment that is highlighted. |
+| `Left` | Moves to previous date segment in the input. |
+| `Right` | Moves to next date segment in the input. |
+| `Backspace` | Deletes value of the date segment. |
+
+## Resouces
+
+N/A - following standard `input date` behaviour.

--- a/docs/accessibility/DatePicker.md
+++ b/docs/accessibility/DatePicker.md
@@ -1,0 +1,35 @@
+---
+title: Date Picker
+category: components
+slug: date-picker
+position: 11
+---
+# DatePicker Keyboard Support
+
+## Managing Focus
+
+Initial focus is on the selected date.
+
+Focus is trapped in the picker's popup. Meaning that once the popup is opened, Tab key will go only through its content.
+
+## Keyboard Shortcuts
+
+**Actions applied to the DateInput:**
+
+| Shortcut| Behavior |
+|---------------------|---------------------|
+|`Esc`| Closes the popup|
+|`Alt + Down`| Opens the popup|
+|`Alt + Up`| Closes the popup|
+| `Up` | Increases the value of the date segment that is highlighted. |
+| `Down` | Decreases the value of the date segment that is highlighted. |
+| `Left` | Moves to previous date segment in the input. |
+| `Right` | Moves to next date segment in the input. |
+| `Backspace` | Deletes value of the date segment. |
+
+**Actions applied to the Calendar:**
+Ones the popup is open, navigation is handled through the calendar
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html

--- a/docs/accessibility/DateRangePicker.md
+++ b/docs/accessibility/DateRangePicker.md
@@ -1,0 +1,33 @@
+---
+title: Date Range Picker
+category: components
+slug: date-range-picker
+position: 12
+---
+# DateRangePicker Keyboard Support
+
+## Managing Focus
+
+Focus goes through the two date inputs and the popup.
+
+## Keyboard Shortcuts
+
+**Actions applied to the DateInput:**
+
+| Shortcut| Behavior |
+|---------------------|---------------------|
+|`Esc`| Closes the popup|
+|`Alt + Down`| Opens the popup|
+|`Alt + Up`| Closes the popup|
+| `Up` | Increases the value of the date segment that is highlighted. |
+| `Down` | Decreases the value of the date segment that is highlighted. |
+| `Left` | Moves to previous date segment in the input. |
+| `Right` | Moves to next date segment in the input. |
+| `Backspace` | Deletes value of the date segment. |
+
+**Actions applied to the Calendar:**
+Ones the popup is open, navigation is handled through the calendar
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html

--- a/docs/accessibility/DateTimePicker.md
+++ b/docs/accessibility/DateTimePicker.md
@@ -1,0 +1,44 @@
+---
+title: Date Time Picker
+category: components
+slug: date-time-picker
+position: 13
+---
+# DateTimePicker Keyboard Support
+
+## Managing Focus
+
+The initial focus is on the selected date.
+
+Focus is trapped in the picker's popup. Meaning that once the popup is opened, Tab key will go only through its content.
+
+## Keyboard Shortcuts
+
+**Actions applied to the DateInput:**
+
+| Shortcut| Behavior |
+|---------------------|---------------------|
+|`Esc`| Discards the selection and closes the popup. |
+|`Enter`| Enters in time edit if calendar is the target. Otherwise, accepts the selected time and closes the popup. |
+|`Alt + Down`| Opens the dropdown and moves the focus to the displayed calendar.|
+|`Alt + Up`| Closes the dropdown and moves the focus to the input element.|
+|`Left`| Executes Calendar Navigation or focuses previous carousel in time view.|
+|`Right`| Executes Calendar Navigation or focuses next carousel in time view.|
+
+**Actions applied to the calendar part:**
+
+Ones the popup is open, navigation is handled through the calendar
+
+
+**Actions applied to the time part:**
+| Shortcut| Behavior |
+|---------------------|---------------------|
+|`Esc`| Closes the popup|
+|`Shift + Tab` or `Left`| Focuses previous carousel.|
+|`Tab` or `Right`| Focuses next carousel.|
+|`Down`| Selects next in the timepart.|
+|`Up`| Selects previous in the timepart.|
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html

--- a/docs/accessibility/Drawer.md
+++ b/docs/accessibility/Drawer.md
@@ -1,0 +1,22 @@
+---
+title: Drawer
+category: components
+slug: drawer
+position: 14
+---
+# Drawer Keyboard Support
+
+## Managing Focus In the Grid
+
+- Initial focus - First item in the drawer
+- Removing TabIndex components Practice for managing the focus
+- Persist only the last focused element with TabIndex = 0
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter` | Execute the item action |
+| `Arrow Up` | Goes to the previous item. Focus is moved to the prev item and its tabindex is set to 0. |
+| `Arrow Down` | Goes to the next item. Focus is moved to the next item and its tabindex is set to 0. |
+

--- a/docs/accessibility/DropDownList.md
+++ b/docs/accessibility/DropDownList.md
@@ -1,0 +1,26 @@
+---
+title: Drop Down List
+category: components
+slug: drop-down-list
+position: 15
+---
+# DropDownList Keyboard Support
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Down Arrow`| Moves focus to next item|
+| `Up Arrow`| Moves focus to previous|
+| `Alt Down` | Opens pop up|
+| `Alt Up` or `Esc` | `Closes popup|
+| `Home` | Moves focus to the first item. Could be the default item or the first in the collection |
+| `End` | Moves focus to the last item. |
+| `Enter` | Selects the item |
+|`printable characters`|Typing "M" or any other printable character should select the next or first item in the list|
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/#combobox
+https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
+https://www.w3.org/TR/wai-aria-practices/#listbox_kbd_interaction

--- a/docs/accessibility/Editor.md
+++ b/docs/accessibility/Editor.md
@@ -1,0 +1,38 @@
+---
+title: Editor
+category: components
+slug: editor
+position: 16
+---
+# Editor Keyboard Support
+
+## Managing focus
+
+The editor integrates the toolbar and inherits all shortcuts from it. So, the component has two tab stops - one the toolbar and one the content area.
+
+**Actions applied to the toolbar:**
+
+| Key         | Behavior                                                    |
+|-------------|-------------------------------------------------------------|
+| `Right Arrow`  | Move focus to the next focusable element in the toolbar. Focuses first element if the end of the toolbar is reached. |
+| `Left Arrow`  | Move focus to the previous focusable element in the toolbar. Focuses last element if the begining of the toolbar is reached. |
+| `Home`  | Move focus to the first focusable element. |
+| `End`  | Move focus to the last focusable element. |
+
+**Actions applied to the content:**
+
+
+| Key         | Behavior                                                    |
+|-------------|-------------------------------------------------------------|
+| `Ctrl+B`  | Executes bold command. |
+| `Ctrl+I`  | Executes italic command. |
+| `Ctrl+U`  | Executes underline command. |
+| `Ctrl+Z`  | Executes undo command. |
+| `Ctrl+Y`  | Executes redo command. |
+| `Shift+Enter`  | Adds `<br/>` to content. |
+| `Enter`  | Adds `<p>` to content. |
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices-1.1/examples/toolbar/toolbar.html
+

--- a/docs/accessibility/Grid.md
+++ b/docs/accessibility/Grid.md
@@ -156,6 +156,7 @@ As the toolbar inside the grid is currently just an HTML container and users dec
 **Checkbox column**
 
 `CheckBoxOnlySelection` is set to `true`
+
 | Shortcut | Behavior |
 |----------|----------|
 | `Enter`| Focus checkbox|
@@ -164,6 +165,7 @@ As the toolbar inside the grid is currently just an HTML container and users dec
 
 
 `CheckBoxOnlySelection` is explicitly set to `false` or not set at all
+
 | Shortcut | Behavior |
 |----------|----------|
 | `Enter`| Focus checkbox |

--- a/docs/accessibility/Grid.md
+++ b/docs/accessibility/Grid.md
@@ -1,0 +1,191 @@
+---
+title: Grid
+category: components
+slug: grid
+position: 17
+---
+# Grid Keyboard Support
+
+## Managing Focus
+
+- Initial focus - First cell in `Grid`
+- Managing focus in the table:
+   - Roving TabIndex components Practice for managing the focus: https://www.w3.org/TR/wai-aria-practices/#gridNav - Meaning that going through the cells will update the tabindex of the cell.
+   - If the cell contains focusable element - focus it instead of the td.
+
+## Keyboard Shortcuts
+
+**Table**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Right Arrow`| Moves focus one cell to the right|
+| `Left Arrow`| Moves focus one cell to the left|
+| `Down Arrow`| Moves focus one cell down|
+| `Up Arrow`| Moves focus one cell up|
+| `Page Down` | `GridScrollMode` is configured - scrolls with one page down. `Pageable` - loads next page|
+| `Page Up` | `GridScrollMode` is configured - scrolls with one page up. `Pageable` - loads previous page|
+| `Home` | Moves focus to the first cell in the row that contains focus. |
+| `End` | Moves focus to the last cell in the row that contains focus. |
+| `Ctrl/Cmd + Home` | Moves focus to the first cell in the grid. **Note:** pending on https://github.com/w3c/aria-practices/issues/1287 |
+| `Ctrl/Cmd + End` | Moves focus to the last cell in the last **loaded** row of the Grid. |
+| `Space` | Selects a row ; Second hit on Space should unselect the whole selection*|
+| `Ctrl/Cmd + Space` | Selects/Unselects a row (equivalent to Ctrl + Click) |
+| `Shift + Space` | Having a row selected and hitting `Shift + Space` on another row should make a range selection between the two rows starting from the upper and ending with the lower |
+| `Shift + Up Arrow` | Selects the upper row. `GridSelectionMode.Single` - only upper row is selected. `GridSelectionMode.Multiple` - selection is extended. |
+| `Shift + Down Arrow` | Selects the upper row. `GridSelectionMode.Single` - only upper row is selected. `GridSelectionMode.Multiple` - selection is extended. |
+| `Enter` | In header cell - Sort is applied. In data cell - EditMode is activated. In hierarchy cell - expands the detail row. If the cell contains a template - focus is handled inside |
+| `F2` | In data cell enters edit mode. |
+
+Ctrl Selection Shortcuts will be further implemeneted until introducing Cell Selection, including `Ctrl + A`.
+
+*When using a `CheckboxColumn` this is valid only when `CheckBoxOnlySelection = false`.
+
+**Command Column**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter`| Moves focus inside the command column. First button is focused. If a button is focused, triggers the button action. |
+| `Tab`| Moves focus to the next button in the column. If focus is already on the last button, focus is moved to the next element after the grid.|
+| `Shift + Tab`| Moves focus to the previous button in the column. If focus is already on the first button, focus is moved to the element before the grid.|
+| `Esc`| If a button is focused, returns focus to the command cell.|
+
+**Inline Edit Row**
+Triggering an edit in Inline mode focuses the first editor.
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Tab`| Moves to the next editor in the row. |
+| `Escape`| Cancels the row edit. The focus goes to the command cell from where the popup was opened.|
+
+**Incell Edit Cell**
+When editing mode is incell, we have an excel-like navigation. When an editor is opened and focus is inside it, the following key combinations are in use.
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Tab`| Moves to the next editor in the row (closing current editor). It skips cells with `Editable='false'` and command columns. If focus is already on the last editable cell on the row, focus is moved to the first editable cell on the next row, and it's editor is opened. If we're already on the last row of the grid, focus remains on the cell, with the editor closed. |
+| `Shift + Tab`| Moves to the previous editor in the row (closing current editor). It skips cells with `Editable='false'` and command columns. If focus is already on the first editable cell on the row, focus is moved to the last editable cell on the previous row, and it's editor is opened. If we're already on the first row of the grid, focus remains on the cell, with the editor closed. |
+| `Enter`| Commits changes for the edited item, and moves focus to the same cell on the row below, opening it for edit.|
+| `Escape`| Cancels the edit. The focus goes to the current cell.|
+
+**Popup editor**
+Opening the popup editor focuses the first editor.
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Tab`| Moves to the next editor in the form. |
+| `Escape`| Closes the editor. The focus goes to the command cell from where the popup was opened.|
+| `Enter`| Triggers a submit action for the editor, including validation.|
+
+**Pager**
+To access the pager press `Arrow Down` when focus is on the last row in the grid.
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Left/Right Arrow` | Moves focus to page buttons|
+| `Up Arrow` | Moves focus to first cell of last row in grid|
+| `Enter`| Selects the page|
+
+**Note:** After a discussion it was decided that selecting the go to first/last page of the pager will move the focus to the first/last number button in the pager (instead of focusing the first actionable button).
+
+**Header**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Left/Right Arrow` | Moves focus to adjacent headers|
+| `Down Arrow` | Moves focus to the cell below (either FilterRow cell or content cell)|
+| `Enter`| If sorting is enabled toggles next sort mode|
+
+**Filter Row**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Arrow Keys`| `td` elements receive focus as standard navigation in grid|
+| `Enter`, `Typing` | Enters in the `td`. Meaning that all filter components gain `tabindex=0` |
+| `Tab`| Goes through the filter row components. If this is the last filter cell and the last filter component, the focus will go to the next focusable element on the page outside of the grid. |
+| `Esc`| Focus goes to the `td` element |
+
+**Filter Menu**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Tab` | When a header cell is focused, pressing `Tab` will move to the filter header icon (`Enter` key is reserved for sorting. After that navigation will be focused as a standard DropDownList navigation, e.g. `Alt + Down arrow` will open the DropDownList. |
+| `Shift + Tab` | When the FilterMenu is focused, moves focus back to the header cell. |
+| `Esc`| Closes the filter menu. Note that if a DropDownList inside the menu is currently opened, `Escape` will close the DropDownList instead of the filter menu (pressing `Escape` a second time will close the menu). |
+
+**Multi-checkbox Filter**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Tab` | Moves focus between the search input, checkboxes and action buttons. |
+| `Space` | Toggles a checkbox (the default behavior). |
+| `Enter`| If the focus is on an action button, triggers its action. |
+| `Esc`| Closes the menu. |
+
+**Column Menu**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Alt + Arrow Down` | When the header cell is focused, opens the column menu. |
+| `Arrow Down/Up` | Focuses the next/previous item in the column menu. |
+| `Enter`| Activates the focused action in the column menu. |
+| `Esc`| Closes the column menu. If the focus is inside a dropdown list or a filter, closes the dropdown. |
+| `Tab`| Moves the focus from the parent item to the inner items, and between the elements in the inner items. |
+
+**Group row**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter`| Toggles the row |
+| `ArrowDown/ArrowUp`| Focuses the previous/next group row (if any) or a cell in a content row.|
+
+**Detail Template**
+Detail template is accessed through the detail cell.
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter`| Toggles the detail template |
+| `Tab`| Focus the first focusable element inside the detail template|
+| `Shift + Tab`| Once inside the template, returns focus to the grid (first focusable cell) |
+
+**Toolbar**
+As the toolbar inside the grid is currently just an HTML container and users decide which component will be added to it, we decided to provide developers with full control of what will be focused by using the TabIndex parameter of either `TelerikButton` or the grid command button components, so no explicit navigation will be added.
+
+**Note:** Due to the above, navigation to and out of the pager will be possible using the `Tab` key only.
+
+**Checkbox column**
+
+`CheckBoxOnlySelection` is set to `true`
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter`| Focus checkbox|
+| `Space`| Toggle checkbox only if it's focused. Toggling the checkbox selects/deselects a row.|
+| `Esc`| Returns focus to the cell. |
+
+
+`CheckBoxOnlySelection` is explicitly set to `false` or not set at all
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter`| Focus checkbox |
+| `Space`| Toggle checkbox regardless if it's focused or not. Toggling the checkbox selects/deselects a row.|
+| `Esc`| Returns focus to the cell. |
+
+
+Note: after toggling the checkbox, focus must be returned to the cell in order to navigate to adjacent cells or rows.
+
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/#grid
+https://www.w3.org/TR/wai-aria-practices/examples/grid/dataGrids.html
+
+https://www.telerik.com/kendo-angular-ui/components/grid
+
+The above specification covers most of the angular grid. The improvements beyond the angular's component:
+
+1. FilterMenu Behavior
+   - having the haspopup accessible attribute that will give a hint that there is an interaction with the th element
+   - handling the tab order after the last filter menu
+2. Pager Behavior
+   - focusable pager and allowing the users to operate with it
+3. Aria-rowindex sequence is consistent and clear: https://github.com/w3c/aria-practices/issues/1275

--- a/docs/accessibility/ListView.md
+++ b/docs/accessibility/ListView.md
@@ -1,0 +1,15 @@
+---
+title: List View
+category: components
+slug: list-view
+position: 18
+---
+# ListView Keyboard Support
+
+## Managing Focus
+
+The ListView is a templated component, and as such doesn't have any rendering of itself. Thus, no internal keyboard navigation is provided.
+Focus moves through the focusable elements of the item template.
+The `Pager` component is focusable, and it's actions are described in the `Pager.md` keyboard navigation specification.
+
+## Resources

--- a/docs/accessibility/Loader.md
+++ b/docs/accessibility/Loader.md
@@ -1,0 +1,9 @@
+---
+title: Loader
+category: components
+slug: loader
+position: 19
+---
+# Loader Keyboard Support
+
+Not applicable.

--- a/docs/accessibility/LoaderContainer.md
+++ b/docs/accessibility/LoaderContainer.md
@@ -1,0 +1,9 @@
+---
+title: Loader Container
+category: components
+slug: loader-container
+position: 20
+---
+# LoaderContainer Keyboard Support
+
+Not applicable.

--- a/docs/accessibility/MaskedTextBox.md
+++ b/docs/accessibility/MaskedTextBox.md
@@ -1,0 +1,15 @@
+---
+title: Masked Text Box
+category: components
+slug: masked-text-box
+position: 21
+---
+# MaskedTextBox Keyboard Support
+
+## Managing focus
+
+Standard focusable input
+
+## Keyboard navigation
+
+Supports the default input cursor navigation with arrow keys.

--- a/docs/accessibility/Menu.md
+++ b/docs/accessibility/Menu.md
@@ -1,0 +1,47 @@
+---
+title: Menu
+category: components
+slug: menu
+position: 22
+---
+# Menu Keyboard Support
+
+## Managing Focus
+
+Roving tab index components strategy implemented. Meaning that only one node has tabindex in the menu.
+Interaction on a `menuitem` should focus it.
+
+## Keyboard Shortcuts
+
+**Actions applied to the Horizontal Menu:**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter` | - When the focus is on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br>	- Otherwise, activates the item and closes the menu. |
+| `Space` | - When the focus is on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br> - Otherwise, activates the item and closes the menu. |
+| `Home` | Moves focus to the first item in the `menuitem` in the current menu/submenu. |
+| `End` |Moves focus to the last item in the `menuitem` in the current menu/submenu.  |
+| `Arrow Down` | - When the focus is on a menuitem in a menubar, opens its submenu and places focus on the first item in the submenu. <br> - When the focus is in a menu, moves focus to the next item, optionally wrapping from the last to the first. |
+| `Arrow Up` | - When the focus is in a menu, moves focus to the previous item, optionally wrapping from the first to the last. <br> - When the focus is on a menuitem in a menubar, opens its submenu and places focus on the last item in the submenu. |
+| `Arrow Left` | - When the focus is in a menubar, moves focus to the previous item, optionally wrapping from the first to the last. <br> - When the focus is in a submenu of an item in a menu, closes the submenu and returns focus to the parent menuitem. <br> - When focus is in a submenu of an item in a menubar, performs the following 3 actions: <br> 1. Closes the submenu. <br> 2. Moves focus to the previous menuitem in the menubar. <br> 3. Opens the submenu of that menuitem without moving focus into the submenu.|
+| `Arrow Right` | - When the focus is in a menubar, moves focus to the next item, optionally wrapping from the last to the first. <br> - When the focus is in a menu and on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br> - When the focus is in a menu and on an item that does not have a submenu, performs the following 3 actions: <br> 1. Closes the submenu and any parent menus. <br> 2. Moves focus to the next menuitem in the menubar. <br> 3. Opens the submenu of that menuitem without moving focus into the submenu <br> - Note that if the menubar was not present, e.g., the menus were opened from a menubutton, Right Arrow would not do anything when the focus is on an item that does not have a submenu. |
+
+**Actions applied to the Verical Menu:**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter` | Same as horizontal |
+| `Space` | Same as horizontal |
+| `Home` | Same as horizontal |
+| `End` | Same as horizontal|
+| `Arrow Down` |- When the focus is on a menuitem in a menubar or menu, moves focus to the next item, wrapping from the last to the first only on the root menuitems. <br> - When the focus is on the last menuitem in the menu performs the following: <br> 1.Closes the menu. <br> 2.Focus next root item. <br> 3.Open the submenu of the menuitem without focus it if it has any.|
+| `Arrow Up` | - When the focus is on a menuitem in a menubar or menu, moves focus to the previous item, optionally wrapping from the first to the last. |
+| `Arrow Left` | - When focus is on a menuitem in a menubar or in a submenu of an item in a menubar, opens its submenu and places focus on the last item in the submenu <br> - When focus is in a submenu of an item in a menu, closes the submenu and returns focus to the parent menuitem. |
+| `Arrow Right` | - When the focus is on a menuitem in a menubar on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br> - When the focus is in a menu and on an item that does not have a submenu, doesn't perform anything.|
+
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/#menu
+https://www.w3.org/TR/wai-aria-practices/#keyboard-interaction-12
+https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-1/menubar-1.html#kbd_label

--- a/docs/accessibility/Menu.md
+++ b/docs/accessibility/Menu.md
@@ -17,14 +17,14 @@ Interaction on a `menuitem` should focus it.
 
 | Shortcut | Behavior |
 |----------|----------|
-| `Enter` | - When the focus is on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br>	- Otherwise, activates the item and closes the menu. |
-| `Space` | - When the focus is on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br> - Otherwise, activates the item and closes the menu. |
+| `Enter` | - When the focus is on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br/>	- Otherwise, activates the item and closes the menu. |
+| `Space` | - When the focus is on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br/> - Otherwise, activates the item and closes the menu. |
 | `Home` | Moves focus to the first item in the `menuitem` in the current menu/submenu. |
 | `End` |Moves focus to the last item in the `menuitem` in the current menu/submenu.  |
-| `Arrow Down` | - When the focus is on a menuitem in a menubar, opens its submenu and places focus on the first item in the submenu. <br> - When the focus is in a menu, moves focus to the next item, optionally wrapping from the last to the first. |
-| `Arrow Up` | - When the focus is in a menu, moves focus to the previous item, optionally wrapping from the first to the last. <br> - When the focus is on a menuitem in a menubar, opens its submenu and places focus on the last item in the submenu. |
-| `Arrow Left` | - When the focus is in a menubar, moves focus to the previous item, optionally wrapping from the first to the last. <br> - When the focus is in a submenu of an item in a menu, closes the submenu and returns focus to the parent menuitem. <br> - When focus is in a submenu of an item in a menubar, performs the following 3 actions: <br> 1. Closes the submenu. <br> 2. Moves focus to the previous menuitem in the menubar. <br> 3. Opens the submenu of that menuitem without moving focus into the submenu.|
-| `Arrow Right` | - When the focus is in a menubar, moves focus to the next item, optionally wrapping from the last to the first. <br> - When the focus is in a menu and on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br> - When the focus is in a menu and on an item that does not have a submenu, performs the following 3 actions: <br> 1. Closes the submenu and any parent menus. <br> 2. Moves focus to the next menuitem in the menubar. <br> 3. Opens the submenu of that menuitem without moving focus into the submenu <br> - Note that if the menubar was not present, e.g., the menus were opened from a menubutton, Right Arrow would not do anything when the focus is on an item that does not have a submenu. |
+| `Arrow Down` | - When the focus is on a menuitem in a menubar, opens its submenu and places focus on the first item in the submenu. <br/> - When the focus is in a menu, moves focus to the next item, optionally wrapping from the last to the first. |
+| `Arrow Up` | - When the focus is in a menu, moves focus to the previous item, optionally wrapping from the first to the last. <br/> - When the focus is on a menuitem in a menubar, opens its submenu and places focus on the last item in the submenu. |
+| `Arrow Left` | - When the focus is in a menubar, moves focus to the previous item, optionally wrapping from the first to the last. <br/> - When the focus is in a submenu of an item in a menu, closes the submenu and returns focus to the parent menuitem. <br/> - When focus is in a submenu of an item in a menubar, performs the following 3 actions: <br/> 1. Closes the submenu. <br/> 2. Moves focus to the previous menuitem in the menubar. <br/> 3. Opens the submenu of that menuitem without moving focus into the submenu.|
+| `Arrow Right` | - When the focus is in a menubar, moves focus to the next item, optionally wrapping from the last to the first. <br/> - When the focus is in a menu and on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br/> - When the focus is in a menu and on an item that does not have a submenu, performs the following 3 actions: <br/> 1. Closes the submenu and any parent menus. <br/> 2. Moves focus to the next menuitem in the menubar. <br/> 3. Opens the submenu of that menuitem without moving focus into the submenu <br/> - Note that if the menubar was not present, e.g., the menus were opened from a menubutton, Right Arrow would not do anything when the focus is on an item that does not have a submenu. |
 
 **Actions applied to the Verical Menu:**
 
@@ -34,10 +34,10 @@ Interaction on a `menuitem` should focus it.
 | `Space` | Same as horizontal |
 | `Home` | Same as horizontal |
 | `End` | Same as horizontal|
-| `Arrow Down` |- When the focus is on a menuitem in a menubar or menu, moves focus to the next item, wrapping from the last to the first only on the root menuitems. <br> - When the focus is on the last menuitem in the menu performs the following: <br> 1.Closes the menu. <br> 2.Focus next root item. <br> 3.Open the submenu of the menuitem without focus it if it has any.|
+| `Arrow Down` |- When the focus is on a menuitem in a menubar or menu, moves focus to the next item, wrapping from the last to the first only on the root menuitems. <br/> - When the focus is on the last menuitem in the menu performs the following: <br/> 1.Closes the menu. <br/> 2.Focus next root item. <br/> 3.Open the submenu of the menuitem without focus it if it has any.|
 | `Arrow Up` | - When the focus is on a menuitem in a menubar or menu, moves focus to the previous item, optionally wrapping from the first to the last. |
-| `Arrow Left` | - When focus is on a menuitem in a menubar or in a submenu of an item in a menubar, opens its submenu and places focus on the last item in the submenu <br> - When focus is in a submenu of an item in a menu, closes the submenu and returns focus to the parent menuitem. |
-| `Arrow Right` | - When the focus is on a menuitem in a menubar on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br> - When the focus is in a menu and on an item that does not have a submenu, doesn't perform anything.|
+| `Arrow Left` | - When focus is on a menuitem in a menubar or in a submenu of an item in a menubar, opens its submenu and places focus on the last item in the submenu <br/> - When focus is in a submenu of an item in a menu, closes the submenu and returns focus to the parent menuitem. |
+| `Arrow Right` | - When the focus is on a menuitem in a menubar on a menuitem that has a submenu, opens the submenu and places focus on its first item. <br/> - When the focus is in a menu and on an item that does not have a submenu, doesn't perform anything.|
 
 
 ## Resources

--- a/docs/accessibility/MultiSelect.md
+++ b/docs/accessibility/MultiSelect.md
@@ -1,0 +1,30 @@
+---
+title: Multi Select
+category: components
+slug: multi-select
+position: 23
+---
+# MultiSelect Keyboard Support
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Alt Down` | Opens pop up|
+| `Alt Up` or `Esc` | Closes popup|
+|`Left`| Focuses the previous tag item in the selected list. |
+|`Right`| Focuses the next tag item in the selected list. |
+|`Down`| Focuses the next item in the list, if the popup is opened. |
+|`Up`| Focuses the previous item in the list, if the popup is opened.  |
+|`Home`| Focuses the first item in the list, if the popup is opened.  |
+|`End`| Focuses the last item in the list, if the popup is opened.  |
+|`Enter`| Selects the current focused item and closes the popup.  |
+| `Delete` or `Backspace`| When the focused item is a tag list, removes the item from the selection.  |
+
+Typing in the input should focus matched item.
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/#combobox
+https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
+https://www.w3.org/TR/wai-aria-practices/#listbox_kbd_interaction

--- a/docs/accessibility/Notification.md
+++ b/docs/accessibility/Notification.md
@@ -1,0 +1,9 @@
+---
+title: Notification
+category: components
+slug: notification
+position: 24
+---
+# Notification Keyboard Support
+
+Not applicable.

--- a/docs/accessibility/NumericTextBox.md
+++ b/docs/accessibility/NumericTextBox.md
@@ -1,0 +1,22 @@
+---
+title: Numeric Text Box
+category: components
+slug: numeric-text-box
+position: 25
+---
+# NumericTextBox Keyboard Support
+
+## Managing focus
+
+Standard focusable input
+
+## Keyboard Shortcuts
+
+Supports the default input cursor navigation with left/right arrow keys.
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Up Arrow`| Increases the value of the focused numeric textbox with the Step. |
+| `Down  Arrow`| Decreases the value of the focused numeric textbox with the Step. |
+
+## Resources

--- a/docs/accessibility/Pager.md
+++ b/docs/accessibility/Pager.md
@@ -11,6 +11,7 @@ position: 26
 - Moving tab index components strategy implemented.
 
 ## Keyboard Shortcuts
+
 | Shortcut | Behavior |
 |----------|----------|
 | `Arrow Keys` | Moves focus to page buttons|

--- a/docs/accessibility/Pager.md
+++ b/docs/accessibility/Pager.md
@@ -1,0 +1,17 @@
+---
+title: Pager
+category: components
+slug: pager
+position: 26
+---
+# Pager Keyboard Support
+
+## Managing focus
+- Initial focus - First actionable item in the pager
+- Moving tab index components strategy implemented.
+
+## Keyboard Shortcuts
+| Shortcut | Behavior |
+|----------|----------|
+| `Arrow Keys` | Moves focus to page buttons|
+| `Enter`| Selects the page|

--- a/docs/accessibility/ProgressBar.md
+++ b/docs/accessibility/ProgressBar.md
@@ -1,0 +1,9 @@
+---
+title: Progress Bar
+category: components
+slug: progress-bar
+position: 27
+---
+# ChunkProgressBar Keyboard Support
+
+Not applicable.

--- a/docs/accessibility/RadioGroup.md
+++ b/docs/accessibility/RadioGroup.md
@@ -1,0 +1,22 @@
+---
+title: Radio Group
+category: components
+slug: radio-group
+position: 28
+---
+# RadioGroup Keyboard Support
+
+## Keyboard Shortcuts
+
+The radio group does not implement any keyboard navigation. Everything is handled through the default browser behavior for radio buttons.
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Space` | Toggles checked state |
+| `Up/Left` | Moves focus to previous button and selects it. If first button is focused, moves focus to the last. |
+| `Down/Right` | Moves focus to next button and selects it. If last button is focused, moves focus to the first. |
+
+## Resources
+
+https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/radio/radio-1/radio-1.html
+https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/radio/radio-2/radio-2.html

--- a/docs/accessibility/RangeSlider.md
+++ b/docs/accessibility/RangeSlider.md
@@ -1,0 +1,27 @@
+---
+title: Range Slider
+category: components
+slug: range-slider
+position: 29
+---
+# RangeSlider Keyboard Support
+
+## Managing Focus
+
+Both slider handles are focusable through Tab Key, and the below shortcuts are applicable to them.
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|--------|-----------------|
+|`Arrow Up or Arrow Left`| Decreases value by small step.|
+|`Arrow Down or Arrow Right`|Increases value by small step.|
+|`Home`| Sets value to the Min value.|
+|`End`| Sets value to the Max value.|
+|`Page up`| Increases value by large step.|
+|`Page down`| Decreases value by large step.|
+
+### Resources
+
+https://www.w3.org/TR/wai-aria-practices/#slider
+https://www.w3.org/TR/wai-aria-practices-1.1/examples/slider/multithumb-slider.html

--- a/docs/accessibility/Scheduler.md
+++ b/docs/accessibility/Scheduler.md
@@ -1,0 +1,43 @@
+---
+title: Scheduler
+category: components
+slug: scheduler
+position: 30
+---
+# Scheduler Keyboard Support
+
+## Managing Focus
+
+The navigation will be always on, and won't need a `Navigable` parameter like the Grid. Focusing the Component will have the following effect, depending on whether appointments are loaded, or the component is empty:
+- empty scheduler - the focus is on the scheduler component itself.
+- non-empty - the first appointment is focused.
+
+Roving tab index is used to track the currently focused appointment.
+
+Any navigation or CRUD operation will reset focus to the first appointment, as this is the only consistent way of tracking focus (we can't always return focus on the same appointment for edit for instance, since editing it can move it outside of the current view).
+
+## Keyboard Shortcuts
+
+**Actions applied to the content (empty scheduler):**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `t`| navigates to today's time period |
+|`c` | opens the popup for creation of new appointment |
+|`Shift+ Left Arrow` | navigates to the previous time period |
+|`Shift+ Right Arrow` | navigates to the next time period |
+|`Alt + 1,2,3` | navigates to the view with the respective number |
+
+**Actions applied to the appointments**
+All of the content keyboard shortcuts work when focus is on the appointment. In addition to that we also have:
+
+| Shortcut | Behavior |
+|----------|----------|
+|`Arrow Keys` | move focus through appointments |
+|`Enter` | opens the Edit Popup to modify the appointment |
+|`Delete/Backspace` | opens the Delete confirmation popup to modify the appointment |
+
+**Actions applied to the Scheduler Popups**
+Using the default Window component shortcuts
+
+## Resources

--- a/docs/accessibility/Scheduler.md
+++ b/docs/accessibility/Scheduler.md
@@ -29,6 +29,7 @@ Any navigation or CRUD operation will reset focus to the first appointment, as t
 |`Alt + 1,2,3` | navigates to the view with the respective number |
 
 **Actions applied to the appointments**
+
 All of the content keyboard shortcuts work when focus is on the appointment. In addition to that we also have:
 
 | Shortcut | Behavior |
@@ -38,6 +39,7 @@ All of the content keyboard shortcuts work when focus is on the appointment. In 
 |`Delete/Backspace` | opens the Delete confirmation popup to modify the appointment |
 
 **Actions applied to the Scheduler Popups**
+
 Using the default Window component shortcuts
 
 ## Resources

--- a/docs/accessibility/Slider.md
+++ b/docs/accessibility/Slider.md
@@ -1,0 +1,21 @@
+---
+title: Slider
+category: components
+slug: slider
+position: 31
+---
+# Slider Keyboard Support
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|--------|-----------------|
+|`Arrow Up or Arrow Left`| Decreases value by small step.|
+|`Arrow Down or Arrow Right`|Increases value by small step.|
+|`Home`| Sets value to the Min value.|
+|`End`| Sets value to the Max value.|
+|`Page up`| Increases value by large step.|
+|`Page down`| Decreases value by large step.|
+
+## Resources
+https://www.w3.org/TR/wai-aria-practices/#slider

--- a/docs/accessibility/Splitter.md
+++ b/docs/accessibility/Splitter.md
@@ -1,0 +1,24 @@
+---
+title: Splitter
+category: components
+slug: splitter
+position: 32
+---
+# Splitter Keyboard Support
+
+## Keyboard Shortcuts
+
+| Shortcut         | Behavior |
+|:-                |:-        |
+| `Up Arrow`         | Moves up the split-bar in a vertical Splitter.    |
+| `Down Arrow`       | Moves down a split-bar in a vertical Splitter.    |
+| `Left Arrow`       | Moves left a split-bar in a horizontal Splitter.  |
+| `Right Arrow`      | Moves right a split-bar in a horizontal Splitter. |
+| `Enter`            | Toggles the collapsed state of the nearest collapsible pane. |
+| `Tab`              | The key that allows focusing a splitter bar |
+
+**Note 1:** The "splitter bar/split-bar" is the section between two panes that allows collapsing/resizing.
+
+**Note 2:** Splitter bars can be expanded/collapsed when double clicked apart from clicking on the expand/collapse icon element. Double-clicking (or `Enter` key) toggles the closest collapsible pane (left pane has priority over right pane if both are collapsible).
+
+## Resources

--- a/docs/accessibility/StockChart.md
+++ b/docs/accessibility/StockChart.md
@@ -1,0 +1,9 @@
+---
+title: Stock Chart
+category: components
+slug: stock-chart
+position: 33
+---
+# StockChart Keyboard Support
+
+Not applicable.

--- a/docs/accessibility/Switch.md
+++ b/docs/accessibility/Switch.md
@@ -1,0 +1,18 @@
+---
+title: Switch
+category: components
+slug: switch
+position: 34
+---
+# Switch Keyboard Support
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Space` | Toggles checked state of the switch. Works analogically to the checkbox. |
+
+## Resources
+
+https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/checkbox/checkbox-1/checkbox-1.html
+https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/checkbox/checkbox-2/checkbox-2.html

--- a/docs/accessibility/TabStrip.md
+++ b/docs/accessibility/TabStrip.md
@@ -1,0 +1,23 @@
+---
+title: Tab Strip
+category: components
+slug: tab-strip
+position: 35
+---
+# TabStrip Keyboard Support
+
+## Managing Focus
+
+- The currently selected Tab and and the tab panel are the only focusable elments
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Up Arrow` & `Down Arrow`| Vertical Orientation shortcuts. Activates the previous/next tab, or current tab if there is no active tab. |
+| `Left Arrow` & `RightArrow`| Horizontal Orientation shortcuts. Activates the previous/next tab, or current tab if there is no active tab.  |
+
+## Resources
+- https://www.w3.org/TR/wai-aria-practices/#keyboard-interaction-19
+- https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html
+

--- a/docs/accessibility/TextArea.md
+++ b/docs/accessibility/TextArea.md
@@ -1,0 +1,15 @@
+---
+title: Text Area
+category: components
+slug: text-area
+position: 36
+---
+# Splitter Keyboard Support
+
+## Keyboard Shortcuts
+
+| Shortcut         | Behavior |
+|:-                |:-        |
+| Tab              | Focuses/blurs the component |
+
+## Resources

--- a/docs/accessibility/TextBox.md
+++ b/docs/accessibility/TextBox.md
@@ -1,0 +1,15 @@
+---
+title: Text Box
+category: components
+slug: text-box
+position: 37
+---
+# TextBox Keyboard Support
+
+## Managing focus
+
+Standard focusable input
+
+## Keyboard navigation
+
+Supports the default input cursor navigation with arrow keys.

--- a/docs/accessibility/TileLayout.md
+++ b/docs/accessibility/TileLayout.md
@@ -1,0 +1,27 @@
+---
+title: Tile Layout
+category: components
+slug: tile-layout
+position: 38
+---
+# TileLayout Keyboard Support
+
+## Managing Focus
+
+The navigation will be enabled by a `Navigable` parameter, like the Grid.
+When `Navigable` is true, all tiles will have a tabindex of `0`, and can be accessed through the reglar `Tab` key navigation.
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+|`Tab` | Move focus to the next tile. If focus is on the last tile, focus the next focusable element on the page. |
+|`Shift + Tab` | Move focus to the previous tile. If focus is on the first tile, focus the previous focusable element before the TileLayout. |
+|`Shift + Right` | Reorder with next tile. |
+|`Shift + Left` | Reorder with previous tile. |
+|`Ctrl + Right` | Increment width with one column. |
+|`Ctrl + Left` | Decrement width with one column. |
+|`Ctrl + Down` | Increment height with one row. |
+|`Ctrl + Up` | Decrement height with one row. |
+
+## Resources

--- a/docs/accessibility/TimePicker.md
+++ b/docs/accessibility/TimePicker.md
@@ -1,0 +1,42 @@
+---
+title: Time Picker
+category: components
+slug: time-picker
+position: 39
+---
+# TimePicker Keyboard Support
+
+## Managing Focus
+
+Initial focus is on the selected time.
+
+The time dropdown tab sequence is:  **hours** part, **minutes** part, **seconds** part, **Cancel** button, **Set** button, **Now** button (activated on Enter). The tab key is trapped in the popup.
+
+Enhanced Mouse UX - when mouse is over a timelist - it gets the focus.
+
+## Keyboard Shortcuts
+
+**Actions applied to the DateInput:**
+
+| Shortcut| Behavior |
+|---------------------|---------------------|
+|`Esc`| Closes the popup|
+|`Alt + Down`| Opens the popup|
+|`Alt + Up`| Closes the popup|
+| `Up` | Increases the value of the date segment that is highlighted. |
+| `Down` | Decreases the value of the date segment that is highlighted. |
+| `Left` | Moves to previous date segment in the input. |
+| `Right` | Moves to next date segment in the input. |
+| `Backspace` | Deletes value of the date segment. |
+
+**Actions applied to the popup**
+
+| Shortcut| Behavior |
+|---------------------|---------------------|
+|`Esc`| Closes the popup|
+|`Shift + Tab` or `Left`| Focuses previous carousel.|
+|`Tab` or `Right`| Focuses next carousel.|
+|`Down`| Selects next in the timepart.|
+|`Up`| Selects previous in the timepart.|
+
+## Resources

--- a/docs/accessibility/ToggleButton.md
+++ b/docs/accessibility/ToggleButton.md
@@ -1,0 +1,21 @@
+---
+title: Toggle Button
+category: components
+slug: toggle-button
+position: 40
+---
+# ToggleButton Keyboard Support
+
+## Managing Focus
+
+The button is focusable by default, and follows the regular tab order of the page.
+
+## Keyboard navigation
+
+| Shortcut| |
+|---------------------|---------------------|
+|`Enter \ Space`| Selects/Deselects the button|
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/#button

--- a/docs/accessibility/ToolBar.md
+++ b/docs/accessibility/ToolBar.md
@@ -1,0 +1,25 @@
+---
+title: Tool Bar
+category: components
+slug: tool-bar
+position: 41
+---
+# ToolBar Keyboard Support
+
+## Managing focus
+
+Single tab stop in the toolbar component, and implemented roving tabindex mechanism for the inner components.
+
+## Keyboard Shortcuts
+
+| Key         | Behavior                                                    |
+|-------------|-------------------------------------------------------------|
+| `Right Arrow`  | Move focus to the next focusable element in the toolbar. Focuses first element if the end of the toolbar is reached. |
+| `Left Arrow`  | Move focus to the previous focusable element in the toolbar. Focuses last element if the begining of the toolbar is reached. |
+| `Home`  | Move focus to the first focusable element. |
+| `End`  | Move focus to the last focusable element. |
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices-1.1/examples/toolbar/toolbar.html
+

--- a/docs/accessibility/Tooltip.md
+++ b/docs/accessibility/Tooltip.md
@@ -1,0 +1,9 @@
+---
+title: Tooltip
+category: components
+slug: tooltip
+position: 42
+---
+# Tooltip Keyboard Support
+
+Not applicable.

--- a/docs/accessibility/TreeList.md
+++ b/docs/accessibility/TreeList.md
@@ -1,0 +1,155 @@
+---
+title: Tree List
+category: components
+slug: tree-list
+position: 43
+---
+# TreeList Keyboard Support
+
+## Managing Focus
+
+Just like in the Grid, keyboard navigation will be enabled by the `Navigable(default: false)` parameter.
+
+- Initial focus - First cell in `TreeList`
+- Managing focus in the table:
+   - Roving TabIndex components Practice for managing the focus: https://www.w3.org/TR/wai-aria-practices/#gridNav - Meaning that going through the cells will update the tabindex of the cell.
+
+- `Pager` accessed with `ArrowDown ` from the last cell in Grid
+
+## Keyboard Shortcuts
+
+**Table**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Right Arrow`| Moves focus one cell to the right|
+| `Left Arrow`| Moves focus one cell to the left|
+| `Down Arrow`| Moves focus one cell down|
+| `Up Arrow`| Moves focus one cell up|
+| `Page Down` | `GridScrollMode` is configured - scrolls with one page down. `Pageable` - loads next page|
+| `Page Up` | `GridScrollMode` is configured - scrolls with one page up. `Pageable` - loads previous page|
+| `Home` | Moves focus to the first cell in the row that contains focus. |
+| `End` | Moves focus to the last cell in the row that contains focus. |
+| `Ctrl/Cmd + Home` | Moves focus to the first cell in the grid. **Note:** pending on https://github.com/w3c/aria-practices/issues/1287 |
+| `Ctrl/Cmd + End` | Moves focus to the last cell in the last **loaded** row of the Grid. |
+| `Space` | Selects a row ; Second hit on Space should unselect the whole selection*|
+| `Ctrl/Cmd + Space` | Selects/Unselects a row (equivalent to Ctrl + Click) |
+| `Shift + Space` | Having a row selected and hitting `Shift + Space` on another row should make a range selection between the two rows starting from the upper and ending with the lower |
+| `Shift + Up Arrow` | Selects the upper row. `GridSelectionMode.Single` - only upper row is selected. `GridSelectionMode.Multiple` - selection is extended. |
+| `Shift + Down Arrow` | Selects the upper row. `GridSelectionMode.Single` - only upper row is selected. `GridSelectionMode.Multiple` - selection is extended. |
+| `Enter` | In data cell with InCell EditMode - cell is open for edit. In expandable cell - expands the item. If the cell contains a template - focus is handled inside. In command cell focus is moved to first command button inside the cell. |
+| `F2` | In data cell with InCell EditMode - cell is open for edit. |
+| `Esc` | In data cell with InCell EditMode - if editor is opened, cancels the edit and closes the editor. In Command cell if focus is on a button, returns the focus back to the cell. |
+
+*When using a `CheckboxColumn` this is valid only when `CheckBoxOnlySelection = false`.
+
+**Command Column**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter`| Moves focus inside the command column. First button is focused. If a button is focused, triggers the button action. |
+| `Tab`| Moves focus to the next button in the column. If focus is already on the last button, focus is moved to the next element after the treelist.|
+| `Shift + Tab`| Moves focus to the previous button in the column. If focus is already on the first button, focus is moved to the element before the treelist.|
+| `Esc`| If a button is focused, returns focus to the command cell.|
+
+**Inline Edit Row**
+Triggering an edit in Inline mode focuses the first editor.
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Tab`| Moves to the next editor in the row. |
+| `Escape`| Cancels the row edit. The focus goes to the command cell from where the popup was opened.|
+
+**Incell Edit Cell**
+When editing mode is incell, we have an excel-like navigation. When an editor is opened and focus is inside it, the following key combinations are in use.
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Tab`| Moves to the next editor in the row (closing current editor). It skips cells with `Editable='false'` and command columns. If focus is already on the last editable cell on the row, focus is moved to the first editable cell on the next row, and it's editor is opened. If we're already on the last row of the treelist, focus remains on the cell, with the editor closed. |
+| `Shift + Tab`| Moves to the previous editor in the row (closing current editor). It skips cells with `Editable='false'` and command columns. If focus is already on the first editable cell on the row, focus is moved to the last editable cell on the previous row, and it's editor is opened. If we're already on the first row of the treelist, focus remains on the cell, with the editor closed. |
+| `Enter`| Commits changes for the edited item, and moves focus to the same cell on the row below, opening it for edit.|
+| `Escape`| Cancels the edit. The focus goes to the current cell.|
+
+**Popup editor**
+Opening the popup editor focuses the first editor.
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Tab`| Moves to the next editor in the form. |
+| `Escape`| Closes the editor. The focus goes to the command cell from where the popup was opened.|
+| `Enter`| Triggers a submit action for the editor, including validation.|
+
+**Pager**
+To access the pager press `Arrow Down` when focus is on the last row in the grid.
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Left/Right Arrow` | Moves focus to page buttons|
+| `Up Arrow` | Moves focus to first cell of last row in TreeList|
+| `Enter`| Selects the page|
+
+**Header**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Left/Right Arrow` | Moves focus to adjacent headers|
+| `Down Arrow` | Moves focus to the cell below (either FilterRow cell or content cell)|
+| `Enter`| If sorting is enabled toggles next sort mode|
+
+**Filter Row**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Arrow Keys`| `td` elements receive focus as standard navigation in grid|
+| `Enter` | Enters in the `td`. Meaning that all filter components gain `tabindex=0` |
+| `Tab`| Goes through the filter row components. If this is the last filter cell and the last filter component, the focus will go to the next focusable element on the page outside of the grid. |
+| `Esc`| Focus returns to the `td` element |
+
+**Filter Menu**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Tab` | When a header cell is focused, pressing `Tab` will move to the filter header icon (`Enter` key is reserved for sorting. After that navigation will be focused as a standard DropDownList navigation, e.g. `Alt + Down arrow` will open the DropDownList. |
+| `Shift + Tab` | When the FilterMenu is focused, moves focus back to the header cell. |
+| `Esc`| Closes the filter menu. Note that if a DropDownList inside the menu is currently opened, `Escape` will close the DropDownList instead of the filter menu (pressing `Escape` a second time will close the menu). |
+
+**Multi-checkbox Filter**
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Tab` | Moves focus between the search input, checkboxes and action buttons. |
+| `Space` | Toggles a checkbox (the default behavior). |
+| `Enter`| If the focus is on an action button, triggers its action. |
+| `Esc`| Closes the menu. |
+
+**Toolbar**
+
+As the toolbar inside the grid is currently just an HTML container and users decide which component will be added to it, we decided to provide developers with full control of what will be focused by using the TabIndex parameter of either `TelerikButton` or the grid command button components, so no explicit navigation will be added.
+
+**Note:** Due to the above, navigation to and out of the toolbar will be possible using the `Tab` key only.
+
+**Checkbox column**
+
+`CheckBoxOnlySelection` is set to `true`
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter`| Focus checkbox|
+| `Space`| Toggle checkbox only if it's focused. Toggling the checkbox selects/deselects a row.|
+| `Esc`| Returns focus to the cell|
+
+
+`CheckBoxOnlySelection` is explicitly set to `false` or not set at all
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter`| Focus checkbox |
+| `Space`| Toggle checkbox regardless if it's focused or not. Toggling the checkbox selects/deselects a row.|
+| `Esc`| Returns focus to the cell|
+
+
+Note: after toggling the checkbox, focus must be returned to the cell in order to navigate to adjacent cells or rows.
+
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/#treegrid
+[Telerik Blazor Grid](https://github.com/telerik/blazor/issues/555)

--- a/docs/accessibility/TreeView.md
+++ b/docs/accessibility/TreeView.md
@@ -1,0 +1,32 @@
+---
+title: Tree View
+category: components
+slug: tree-view
+position: 44
+---
+# TreeView Keyboard Support
+
+## Managing Focus
+
+- Roving tab index components strategy implemented. Meaning that only one node has tabindex in the tree.
+Interaction on a node should focus it.
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|----------|----------|
+| `Enter` | Selects focused tree view item when the selection mode is Single or Multiple. When the selection mode is Multiple and there are other selected items, they get deselected. |
+| `Space` | Checks the checkbox of the treeview node. |
+| `Arrow Up` | Goes to the previous tree node. Focus is moved to the prev node and its tabindex is set to 0. |
+| `Arrow Down` | Goes to the next tree node. Focus is moved to the next node and its tabindex is set to 0. |
+| `Arrow Left` | If the node is expanded - should collapse it. If the node is collapsed, focus is moved to its parent. |
+| `Arrow Right` | If the node is collapsed - should expand it. If the node is expanded, focus is moved to the first child node. |
+| `Home` | Moves focus to the first node in the tree without opening or closing a node. |
+| `End` | Moves focus to the last node in the tree that is focusable without opening a node. |
+| `Ctrl + Enter` | Selects focused item. When the item is already selected, it gets deselected. |
+| `Shift + Enter` | When Multiple selection is enabled, perform range selection from previous selected item to the current selected item. Equivalent to Shift+Click. |
+
+## Resources
+- https://www.w3.org/TR/wai-aria-practices/#TreeView
+- https://www.w3.org/TR/wai-aria-practices/#keyboard-interaction-22
+- https://www.w3.org/TR/wai-aria-practices/examples/treeview/treeview-1/treeview-1a.html

--- a/docs/accessibility/Upload.md
+++ b/docs/accessibility/Upload.md
@@ -1,0 +1,21 @@
+---
+title: Upload
+category: components
+slug: upload
+position: 45
+---
+# Upload Keyboard Support
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior                                                            |
+|----------|---------------------------------------------------------------------|
+| Tab      | Focuses the Select File Button, or the action buttons (Cancel, Upload) after the file list |
+| Space/Enter    | Opens the Select file dialog if the Select files button is focused.                     |
+| DownArrow   | Highlights the next file in the file list, or the Clear button if the end of the list is reached.          |
+| UpArrow | Highlights the previous file in the file list, or the Select files button if the top of the list is reached.        |
+| Enter    | Retries the upload of the failed file when the focus is on a file list item or starts the file upload for a valid file.                   |
+| Escape   | Cancels the upload of the highlighted file when the focus is on a file list item                                           |
+| Delete | Removes the highlighted file when the focus is on a file list item                                 |
+
+## Resources

--- a/docs/accessibility/Window.md
+++ b/docs/accessibility/Window.md
@@ -1,0 +1,24 @@
+---
+title: Window
+category: components
+slug: window
+position: 46
+---
+# Window Keyboard Support
+
+## Managing Focus
+
+- Initial focus - When opened, the Window should be focused.
+- Action buttons are accessed with `Tab` key
+
+## Keyboard Shortcuts
+
+| Shortcut | Behavior |
+|---------------------|---------------------|
+|`Alt + DownArrow`| Minimizes or restores the state, if the focused element is the window |
+|`Alt + UpArrow`| Maximizes or restores the state, if the focused element is the window|
+|`Escape`| Closes the windwo|
+
+## Resources
+
+https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html


### PR DESCRIPTION
Later we should put those into a dedicatd accessibility tab for each component. Currently we don't have that kind of infrastructure in the docs this is why this lives directly under components. Thoughts?