### PR TITLE
fix(calendar): navigation animation adjustments for angular

### DIFF
--- a/packages/default/scss/calendar/_layout.scss
+++ b/packages/default/scss/calendar/_layout.scss
@@ -509,6 +509,7 @@
         table,
         .k-calendar-table {
             width: auto;
+            table-layout: auto;
         }
         table.k-meta-view,
         .k-calendar-table.k-meta-view {
@@ -547,6 +548,7 @@
             .k-calendar-view {
                 display: flex;
                 flex-direction: row;
+                box-sizing: content-box;
 
                 .k-animation-container-sm & {
                     flex-direction: column;


### PR DESCRIPTION
`box-sizing: content-box;` fixes the issue that can be seen in [this Stackblitz example](https://stackblitz.com/edit/angular-viwmso-fbz8v9) (Calendar gets bigger and bigger on each Prev/Next click), which is caused by the bootstrap reset styles.

`table-layout: auto;` fixes the issue that can be seen in [this Stackblitz example](https://stackblitz.com/edit/angular-viwmso-74ivef?file=app/app.component.ts) (currently in Firefox Developer Edition only) when animating the Prev/Next views.