### PR TITLE
fix(grid): apply correct styles for filer menu that is part of the po…

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -1265,7 +1265,12 @@
         .k-filter-menu-container {
             width: $grid-filter-menu-width;
         }
+    }
 
+    .k-filter-menu.k-popup,
+    .k-grid-filter-popup.k-popup,
+    .k-popup .k-filter-menu,
+    .k-popup .k-grid-filter-popup {
         .k-multicheck-wrap {
             .k-item {
                 padding: $grid-column-menu-list-item-padding-y 0;


### PR DESCRIPTION
…pup content

This change is needed as the KendoReact GridColumnMenuCheckboxFilter renders the filter menu as a content inside the popup, not as a popup itself. See the demo here: https://www.telerik.com/kendo-react-ui/components/grid/filtering/#toc-column-menu-filter.

The following change applies the items' paddings and 'Select all' option bottom border.