### PR TITLE
chore(scheduler): prevent year view tooltip event from shrinking

### DIFF
--- a/packages/default/scss/scheduler/_layout.scss
+++ b/packages/default/scss/scheduler/_layout.scss
@@ -1089,6 +1089,7 @@
             display: flex;
             flex-direction: row;
             align-items: center;
+            flex-shrink: 0;
             position: relative;
             gap: $scheduler-tooltip-event-gap;
         }


### PR DESCRIPTION
Prevent event element from shrinking when the events container is scrollable in the Scheduler year view Tooltip.