### PR TITLE
Angular grid fixes

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -300,6 +300,8 @@
 
             .k-grid-header {
                 .k-header {
+                    z-index: 1;
+
                     &.k-first {
                         border-left-width: 0;
                         border-right-width: $grid-cell-vertical-border-width;


### PR DESCRIPTION
non sticky grid header cells should slide below sticky header cells