### PR TITLE
chore(taskboard): set overflow wrapping for pane title

### DIFF
--- a/packages/default/scss/taskboard/_layout.scss
+++ b/packages/default/scss/taskboard/_layout.scss
@@ -129,6 +129,11 @@
         align-items: center;
     }
 
+    .k-taskboard-pane-header-text {
+        word-break: normal;
+        overflow-wrap: anywhere;
+    }
+
     .k-taskboard-pane-header-actions {
         flex-shrink: 0;
         align-self: flex-start;


### PR DESCRIPTION
Setting overflow wrapping for pane title to prevent the text from overflowing its line box.

similar to: https://github.com/telerik/kendo-themes/pull/2425