### PR TITLE
chore(scheduler): add spacing to year view calendar in safari and ie

### DIFF
--- a/packages/default/scss/scheduler/_layout.scss
+++ b/packages/default/scss/scheduler/_layout.scss
@@ -1287,9 +1287,14 @@
 
 @include exports("scheduler/layout/compatibility") {
 
-    .k-ie {
+    .k-ie,
+    .k-safari {
         .k-scheduler-tooltip .k-tooltip-event:not(:last-child) {
             margin-bottom: $scheduler-tooltip-event-gap;
+        }
+
+        .k-scheduler-yearview .k-calendar-view .k-month {
+            margin: 0 ($scheduler-yearview-calendar-gap / 2);
         }
     }
 


### PR DESCRIPTION
Fallback for [gap support in flex layout](https://caniuse.com/flexbox-gap).

