### PR TITLE
fix(taskboard): scope category border selector in rtl

### DIFF
--- a/packages/default/scss/taskboard/_layout.scss
+++ b/packages/default/scss/taskboard/_layout.scss
@@ -206,9 +206,11 @@
 
 @include exports( "taskboard/layout/rtl" ) {
 
-    .k-rtl,
-    [dir="rtl"] {
-        .k-taskboard-card.k-taskboard-card-category {
+    .k-taskboard-card.k-taskboard-card-category {
+        .k-rtl &,
+        &.k-rtl,
+        [dir="rtl"] &,
+        &[dir="rtl"] {
             border-left-width: $taskboard-card-border-width;
             border-right-width: $taskboard-card-category-border-width;
         }


### PR DESCRIPTION
related to: #2227

The idea of this refactoring is to handle cases where the drag hint that contains a card is appended to the <body> element. 