### PR TITLE
fix(panelbar): the arrow icons are not aligned correctly in IE

### DIFF
--- a/packages/default/scss/panelbar/_layout.scss
+++ b/packages/default/scss/panelbar/_layout.scss
@@ -185,3 +185,44 @@
     }
 
 }
+
+
+
+
+@include exports( "panelbar/layout/compatibility" ) {
+
+    .k-ie {
+
+        // Toggle icon
+        .k-panelbar-expand,
+        .k-panelbar-collapse,
+        .k-panelbar-toggle {
+            margin-left: auto;
+        }
+
+        .k-group .k-panelbar-expand,
+        .k-group .k-panelbar-collapse,
+        .k-panelbar-group .k-panelbar-toggle {
+            margin-right: calc( #{$panelbar-header-padding-x} - #{$panelbar-item-padding-x} );
+        }
+
+        .k-rtl &,
+        &.k-rtl,
+        &[dir = "rtl"] {
+            // Toggle icon
+            .k-panelbar-expand,
+            .k-panelbar-collapse,
+            .k-panelbar-toggle {
+                margin-left: initial;
+                margin-right: auto;
+            }
+
+            .k-group .k-panelbar-expand,
+            .k-group .k-panelbar-collapse,
+            .k-panelbar-group .k-panelbar-toggle {
+                margin-left: calc( #{$panelbar-header-padding-x} - #{$panelbar-item-padding-x} );
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
fixes https://github.com/telerik/kendo-themes/issues/2388

The fix is related to the CSS properties [margin-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start) and [margin-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end) that are not supported by IE.