### PR TITLE
docs(a11y): update Grid pager spec

### DIFF
--- a/docs/accessibility/Grid.md
+++ b/docs/accessibility/Grid.md
@@ -78,15 +78,14 @@ Opening the popup editor focuses the first editor.
 | `Enter`| Triggers a submit action for the editor, including validation.|
 
 **Pager**
-To access the pager press `Arrow Down` when focus is on the last row in the grid.
+To access the pager press `Tab` when the focus is on a Grid cell.
 
 | Shortcut | Behavior |
 |----------|----------|
-| `Left/Right Arrow` | Moves focus to page buttons|
-| `Up Arrow` | Moves focus to first cell of last row in grid|
-| `Enter`| Selects the page|
-
-**Note:** After a discussion it was decided that selecting the go to first/last page of the pager will move the focus to the first/last number button in the pager (instead of focusing the first actionable button).
+| `Enter` | When the pager wrapper is focused, moves the focus to first focusable pager element|
+| `Tab` | When a pager element is focused, moves focus through all focusable pager elements sequentially. Tabbing out of the last element or shift-tabbing out of the first element moves the focus back to the pager wrapper.|
+| `Enter`| When a pager element is focused, triggers the default action, associated with the currently focused element.|
+| `Escape`| When a pager element is focused, brings the focus back to the pager wrapper. If a popup within the pager is currently opened, `Escape` will close the popup instead. Pressing `Escape` again brings the focus back to the pager wrapper.|
 
 **Header**
 


### PR DESCRIPTION
When we decided to add KB Navigation to the Kendo UI for Angular Grid pager, we performed a thorough research and discussions with @tsvetomir and @Raisolution that lead us to believe the following behavior is most suitable and appropriate:

- The navigable Grid (following the best practices for KB navigation of composite components) consists of separate single tab-stop sections - the pager (or pagers if both top and bottom pagers exist), and the Grid table (alongside its headers).
- Each section is a single tabstop meaning that the focus can be moved from one section to another with a single Tab press.
- The pager as a whole gets focused when tabbed into. The various scenarios include:
  - Tabbing from a focusable element before the Grid focuses the top pager wrapper (if such exists) or a Grid cell if there is no top pager
  - Tabbing from a focused Grid cell moves the focus to the bottom pager wrapper (if such exists) or outside of the Grid
  - Tabbing from the top pager wrapper focuses Grid cell
  - Shift-tabbing from the bottom pager focuses Grid cell
  - Pressing Enter when the Pager wrapper is focused moves the focus within the pager and focuses the first non-disabled focusable element
  - from there on the end user can tab through all focusable non-disabled pager elements sequentially
  - Pressing enter triggers the default action, associated with the currently focused element
  - Tabbing out of the last element and shift-tabbing from the first element brings the focus back to the whole pager
  - Pressing Escape while the focus is within the pager focuses the wrapper
  
The outlined behavior allows for consistent KB navigation UX regardless of the specific internal elements currently rendered in the Grid pager (subject to configuration, Grid width, etc.) It also allows the developer to provide consistent KB navigation when using the pager template with built-in or custom pager inner elements.

Further details are available in the following PR:

https://github.com/telerik/kendo-angular-grid/pull/1095#issue-656729744

// for visibility: @joneff @Raisolution 