### PR TITLE
fix(grid): do not apply pager focus styles on non-navigable grid

### DIFF
--- a/packages/default/scss/grid/_theme.scss
+++ b/packages/default/scss/grid/_theme.scss
@@ -94,8 +94,7 @@
         .k-grouping-row > td:focus,
         .k-detail-row > td:focus,
         .k-group-footer > td:focus,
-        .k-grid-pager.k-state-focused,
-        .k-grid-pager:focus {
+        .k-grid-pager.k-state-focused {
             box-shadow: $grid-focused-shadow;
         }
 


### PR DESCRIPTION
related to https://github.com/telerik/kendo-themes/issues/2500

The [Grid keyboard navigation](https://www.telerik.com/kendo-angular-ui/components/grid/keyboard-navigation/) is disabled by default.
If this is the case, no `focus` styles should be applied.