### PR TITLE
Use lerna publish with predetermined version instead of --canary for dev releases

### DIFF
--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -44,10 +44,16 @@ jobs:
           npm run sass:flat
           npm run dist:swatches
 
+      - name: Determine correct version to publish
+        run: |
+          dev=$(npm info @progress/kendo-theme-default@dev version)
+          latest=$(npm info @progress/kendo-theme-default@latest version)
+          inc=$(node ./scripts/semver-dev-inc.js --dev $dev --latest $latest)
+
       - name: Lerna publish
         run: |
           printf "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
-          npx lerna publish --canary --preid dev --dist-tag dev --no-git-tag-version --no-push
+          npx lerna publish $inc --preid dev --dist-tag dev --no-git-tag-version --no-push
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7251,6 +7251,14 @@
           "requires": {
             "pify": "^4.0.1",
             "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
           }
         },
         "p-limit": {
@@ -11005,6 +11013,14 @@
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "make-fetch-happen": {
@@ -12454,6 +12470,12 @@
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
           "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -12589,6 +12611,14 @@
             "semver": "^5.7.1",
             "tar": "^4.4.12",
             "which": "^1.3.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
           }
         },
         "nopt": {
@@ -14552,6 +14582,12 @@
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -15850,10 +15886,30 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
     },
     "semver-compare": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "sass-lint": "^1.13.1",
     "sass-variable-parser": "^1.2.2",
     "sassdoc": "^2.7.3",
-    "sassdoc-extras": "^3.0.0"
+    "sassdoc-extras": "^3.0.0",
+    "semver": "^7.3.5"
   },
   "scripts": {
     "clean": "find . -name \"node_modules\" -type d -prune | grep -e \".git\" -v | xargs rm -rf",

--- a/scripts/semver-dev-inc.js
+++ b/scripts/semver-dev-inc.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const semver = require('semver');
+const { getArg } = require("@progress/kendo-theme-tasks/src/utils");
+
+const devVersion = getArg('--dev');
+const latestVersion = getArg('--latest');
+
+function inc( dev, latest ) {
+
+    if (semver.gt( dev, latest )) {
+        return semver.inc( dev, 'prerelease', 'dev' );
+    }
+
+    return semver.inc( latest, 'prerelease', 'dev' );
+}
+
+process.stdout.write( inc( devVersion, latestVersion) );


### PR DESCRIPTION
Lerna is having trouble determining the correct version for dev releases. I am reckoning that has something to do with our use of `--canary` and `--no-push`. Also, there are numerous reports where that particular approach may yield inconsistent results.

Considering all themes have and must have the same version, the following trickery this should do it:
* query the dev and latest version of default theme
* compare them with `semver.gt` to get the larger (semantically newer)
* increment the result with `semver.inc`
* pass that option to lerna publish