### PR TITLE
Remove redundant styles from adaptive scheduler / grid

### DIFF
--- a/packages/bootstrap/scss/adaptive/_theme.scss
+++ b/packages/bootstrap/scss/adaptive/_theme.scss
@@ -1,13 +1,1 @@
 @import "~@progress/kendo-theme-default/scss/adaptive/_theme.scss";
-
-@include exports("adaptive/theme/bootstrap") {
-    .k-pane-wrapper .k-pane {
-        .k-filter-menu,
-        .k-scheduler-edit-form {
-
-            .k-check {
-                border-radius: $border-radius;
-            }
-        }
-    }
-}

--- a/packages/material/scss/adaptive/_theme.scss
+++ b/packages/material/scss/adaptive/_theme.scss
@@ -1,14 +1,1 @@
 @import "~@progress/kendo-theme-default/scss/adaptive/_theme.scss";
-
-@include exports("adaptive/theme/material") {
-    .k-pane-wrapper .k-pane {
-        .k-filter-menu,
-        .k-scheduler-edit-form {
-
-            .k-check:focus,
-            .k-check.k-state-focused {
-                box-shadow: $button-shadow;
-            }
-        }
-    }
-}


### PR DESCRIPTION
Remove legacy `k-check` styles which were not used anywhere.