### PR TITLE
Style splitbar focus instead of active state

### DIFF
--- a/packages/default/scss/splitter/_theme.scss
+++ b/packages/default/scss/splitter/_theme.scss
@@ -20,7 +20,7 @@
         color: $splitbar-hover-text;
         background-color: $splitbar-hover-bg;
     }
-    .k-splitbar:active,
+    .k-splitbar:focus,
     .k-splitbar.k-state-focus,
     .k-splitbar.k-state-focused {
         color: $splitbar-selected-text;


### PR DESCRIPTION
fixes #2143.

Changed the selector from `:active` to `:focus`, because this is the correct selector: when the splitbar is clicked it's also focused. Actually, no element can be active without being focused... 