### PR TITLE
Expose variables to control chat width and height

### DIFF
--- a/packages/bootstrap/scss/chat/_variables.scss
+++ b/packages/bootstrap/scss/chat/_variables.scss
@@ -1,6 +1,8 @@
 // Chat
 $chat-padding-x: 16px !default;
 $chat-padding-y: 16px !default;
+$chat-width: 500px !default;
+$chat-height: 600px !default;
 $chat-border-width: 1px !default;
 $chat-font-family: $font-family !default;
 $chat-font-size: $font-size !default;

--- a/packages/classic/scss/chat/_variables.scss
+++ b/packages/classic/scss/chat/_variables.scss
@@ -1,6 +1,8 @@
 // Chat
 $chat-padding-x: 16px !default;
 $chat-padding-y: 16px !default;
+$chat-width: 500px !default;
+$chat-height: 600px !default;
 $chat-border-width: 1px !default;
 $chat-font-family: $font-family !default;
 $chat-font-size: $font-size !default;

--- a/packages/default/scss/chat/_layout.scss
+++ b/packages/default/scss/chat/_layout.scss
@@ -1,6 +1,10 @@
 @include exports("chat/layout") {
 
     .k-chat {
+        margin: auto;
+        max-width: $chat-width;
+        height: $chat-height;
+        max-height: 100%;
         border-width: $chat-border-width;
         border-style: solid;
         box-sizing: border-box;
@@ -8,17 +12,11 @@
         font-family: $chat-font-family;
         font-size: $chat-font-size;
         line-height: $chat-line-height;
-        height: 600px;
-        max-height: 100%;
         display: flex;
         flex-direction: column;
         overflow: hidden;
         -webkit-touch-callout: none;
         -webkit-tap-highlight-color: $rgba-transparent;
-
-
-        max-width: 500px;
-        margin: auto;
 
 
         // Message list

--- a/packages/default/scss/chat/_variables.scss
+++ b/packages/default/scss/chat/_variables.scss
@@ -1,6 +1,8 @@
 // Chat
 $chat-padding-x: 16px !default;
 $chat-padding-y: 16px !default;
+$chat-width: 500px !default;
+$chat-height: 600px !default;
 $chat-border-width: 1px !default;
 $chat-font-family: $font-family !default;
 $chat-font-size: $font-size !default;

--- a/packages/material/scss/chat/_variables.scss
+++ b/packages/material/scss/chat/_variables.scss
@@ -1,6 +1,8 @@
 // Chat
 $chat-padding-x: 16px !default;
 $chat-padding-y: 16px !default;
+$chat-width: 500px !default;
+$chat-height: 600px !default;
 $chat-border-width: 1px !default;
 $chat-font-family: $font-family !default;
 $chat-font-size: $font-size !default;


### PR DESCRIPTION
fixes #1182

Note: chat should probably be 100% wide and 100% tall and the size should be determined by the container. However, that might prove breaking when it comes to existing implementations. so we are going to wait for a breaking version.