### PR TITLE
Task details tooltip should not wrap its content

### DIFF
--- a/packages/default/scss/gantt/_layout.scss
+++ b/packages/default/scss/gantt/_layout.scss
@@ -589,6 +589,7 @@
     // Task tooltip
     .k-task-details {
         padding: $padding-y $padding-x;
+        white-space: nowrap;
 
         strong {
             font-size: $font-size-lg;


### PR DESCRIPTION
There was `white-space: nowrap` missing.