### PR TITLE
Pivotgrid headers

### DIFF
--- a/packages/default/scss/pivotgrid/_layout.scss
+++ b/packages/default/scss/pivotgrid/_layout.scss
@@ -46,6 +46,11 @@
         table-layout: fixed;
 
         th {
+            font-weight: 400;
+            text-transform: initial;
+        }
+
+        .k-pivotgrid-header-root {
             font-weight: 600;
             text-transform: uppercase;
         }

--- a/tests/visual/src/misc/pivotgrid-settings-top.html
+++ b/tests/visual/src/misc/pivotgrid-settings-top.html
@@ -33,97 +33,95 @@
                             <tbody class="k-pivotgrid-tbody">
                                 <!-- Four Rows for Date.Calendar Column grouping field -->
                                 <tr class="k-pivotgrid-row k-pivotgrid-column-total">
-                                    <th colspan="9" class="k-pivotgrid-cell k-pivotgrid-expanded">
+                                    <th colspan="9" class="k-pivotgrid-cell k-pivotgrid-expanded k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-up"></span>
                                         <span class="k-pivotgrid-header-title">All Periods</span>
                                     </th>
-                                    <th colspan="1" rowspan="4"class="k-pivotgrid-cell k-pivotgrid-header-total">
+                                    <th colspan="1" rowspan="4"class="k-pivotgrid-cell k-pivotgrid-header-total k-pivotgrid-header-root">
                                         <span class="k-pivotgrid-header-title">All Periods</span>
                                     </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="6" class="k-pivotgrid-cell k-pivotgrid-expanded">
+                                    <th colspan="6" class="k-pivotgrid-cell k-pivotgrid-expanded">
                                         <span class="k-icon k-i-arrow-chevron-up"></span>
                                         <span class="k-pivotgrid-header-title">CY 2010</span>
-                                    </td>
-                                    <td colspan="1" rowspan="3" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" rowspan="3" class="k-pivotgrid-cell">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">CY 2011</span>
-                                    </td>
-                                    <td colspan="1" rowspan="3" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" rowspan="3" class="k-pivotgrid-cell">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">CY 2012</span>
-                                    </td>
-                                    <td colspan="1" rowspan="3" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" rowspan="3" class="k-pivotgrid-cell">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">CY 2013</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell k-pivotgrid-expanded">
+                                    <th colspan="1" class="k-pivotgrid-cell k-pivotgrid-expanded">
                                         <span class="k-icon k-i-arrow-chevron-up"></span>
                                         <span class="k-pivotgrid-header-title">H2 CY 2010</span>
-                                    </td>
-                                    <td colspan="5" rowspan="2" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="5" rowspan="2" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">H2 CY 2010</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">Q4 CY 2010</span>
-                                    </td>
+                                    </th>
                                 </tr>
 
                                 <!-- Table for Product.Category Column grouping field -->
                                 <tr class="k-pivotgrid-row k-pivotgrid-column-total">
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="4" class="k-pivotgrid-cell k-pivotgrid-expanded">
+                                    <th colspan="4" class="k-pivotgrid-cell k-pivotgrid-expanded k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-up"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-root">
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-total">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-total k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell k-first">
+                                    <th colspan="1" class="k-pivotgrid-cell k-first">
                                         <span class="k-pivotgrid-header-title">Accessories</span>
-                                    </td>
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Bikes</span>
-                                    </td>
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Clothing</span>
-                                    </td>
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Components</span>
-                                    </td>
+                                    </th>
                                 </tr>
                             </tbody>
                         </table>
                     </div>
-
-
                     <!-- Pivot Multi Row Headers -->
                     <div class="k-pivotgrid-row-headers">
                         <table class="k-pivotgrid-table">
@@ -133,53 +131,53 @@
                             </colgroup>
                             <tbody class="k-pivotgrid-tbody">
                                 <tr class="k-pivotgrid-row">
-                                    <th colspan="1" rowspan="9" class="k-pivotgrid-cell k-pivotgrid-row-total k-pivotgrid-expanded">
+                                    <th colspan="1" rowspan="9" class="k-pivotgrid-cell k-pivotgrid-row-total k-pivotgrid-expanded k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-up"></span>
                                         <span class="k-pivotgrid-header-title">All Geographies</span>
                                     </th>
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Austell</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Biloxi</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Braintree</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Casper</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Clearwater</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Destin</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Euclid</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Everett</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Fort Wayne</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
                                     <th colspan="2" class="k-pivotgrid-cell k-pivotgrid-header-total">

--- a/tests/visual/src/misc/pivotgrid.html
+++ b/tests/visual/src/misc/pivotgrid.html
@@ -35,91 +35,91 @@
                             <tbody class="k-pivotgrid-tbody">
                                 <!-- Four Rows for Date.Calendar Column grouping field -->
                                 <tr class="k-pivotgrid-row k-pivotgrid-column-total">
-                                    <th colspan="9" class="k-pivotgrid-cell k-pivotgrid-expanded">
+                                    <th colspan="9" class="k-pivotgrid-cell k-pivotgrid-expanded k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-up"></span>
                                         <span class="k-pivotgrid-header-title">All Periods</span>
                                     </th>
-                                    <th colspan="1" rowspan="4"class="k-pivotgrid-cell k-pivotgrid-header-total">
+                                    <th colspan="1" rowspan="4"class="k-pivotgrid-cell k-pivotgrid-header-total k-pivotgrid-header-root">
                                         <span class="k-pivotgrid-header-title">All Periods</span>
                                     </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="6" class="k-pivotgrid-cell k-pivotgrid-expanded">
+                                    <th colspan="6" class="k-pivotgrid-cell k-pivotgrid-expanded">
                                         <span class="k-icon k-i-arrow-chevron-up"></span>
                                         <span class="k-pivotgrid-header-title">CY 2010</span>
-                                    </td>
-                                    <td colspan="1" rowspan="3" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" rowspan="3" class="k-pivotgrid-cell">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">CY 2011</span>
-                                    </td>
-                                    <td colspan="1" rowspan="3" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" rowspan="3" class="k-pivotgrid-cell">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">CY 2012</span>
-                                    </td>
-                                    <td colspan="1" rowspan="3" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" rowspan="3" class="k-pivotgrid-cell">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">CY 2013</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell k-pivotgrid-expanded">
+                                    <th colspan="1" class="k-pivotgrid-cell k-pivotgrid-expanded">
                                         <span class="k-icon k-i-arrow-chevron-up"></span>
                                         <span class="k-pivotgrid-header-title">H2 CY 2010</span>
-                                    </td>
-                                    <td colspan="5" rowspan="2" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="5" rowspan="2" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">H2 CY 2010</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">Q4 CY 2010</span>
-                                    </td>
+                                    </th>
                                 </tr>
 
                                 <!-- Table for Product.Category Column grouping field -->
                                 <tr class="k-pivotgrid-row k-pivotgrid-column-total">
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="4" class="k-pivotgrid-cell k-pivotgrid-expanded">
+                                    <th colspan="4" class="k-pivotgrid-cell k-pivotgrid-expanded k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-up"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-root">
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
-                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-total">
+                                    <th colspan="1" rowspan="2" class="k-pivotgrid-cell k-pivotgrid-header-total k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-down"></span>
                                         <span class="k-pivotgrid-header-title">All Products</span>
                                     </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell k-first">
+                                    <th colspan="1" class="k-pivotgrid-cell k-first">
                                         <span class="k-pivotgrid-header-title">Accessories</span>
-                                    </td>
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Bikes</span>
-                                    </td>
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Clothing</span>
-                                    </td>
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    </th>
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Components</span>
-                                    </td>
+                                    </th>
                                 </tr>
                             </tbody>
                         </table>
@@ -133,53 +133,53 @@
                             </colgroup>
                             <tbody class="k-pivotgrid-tbody">
                                 <tr class="k-pivotgrid-row">
-                                    <th colspan="1" rowspan="9" class="k-pivotgrid-cell k-pivotgrid-row-total k-pivotgrid-expanded">
+                                    <th colspan="1" rowspan="9" class="k-pivotgrid-cell k-pivotgrid-row-total k-pivotgrid-expanded k-pivotgrid-header-root">
                                         <span class="k-icon k-i-arrow-chevron-up"></span>
                                         <span class="k-pivotgrid-header-title">All Geographies</span>
                                     </th>
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Austell</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Biloxi</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Braintree</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Casper</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Clearwater</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Destin</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Euclid</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Everett</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
-                                    <td colspan="1" class="k-pivotgrid-cell">
+                                    <th colspan="1" class="k-pivotgrid-cell">
                                         <span class="k-pivotgrid-header-title">Fort Wayne</span>
-                                    </td>
+                                    </th>
                                 </tr>
                                 <tr class="k-pivotgrid-row">
                                     <th colspan="2" class="k-pivotgrid-cell k-pivotgrid-header-total">


### PR DESCRIPTION
The change was initially requested by the React team as till now, the headers had both `th` and `td` HTML elements where `th` elements were the root cells (with bold and uppercase text styling).

This change provides a new class named `k-pivotgrid-header-root` that will be applied to the root cells (at level 0) that will apply the bolder and uppercase styling. The rest of the `th` elements will have normal font-weight and text-transform.

Please check the visual tests for more info.

cc/ @kspeyanski @ag-petrov 