### PR TITLE
fix: add kendo font sizes to the Bootstrap theme

### DIFF
--- a/packages/default/scss/utils/_text.scss
+++ b/packages/default/scss/utils/_text.scss
@@ -7,7 +7,7 @@
     $text-align: ( left, right, center, justify ) !default;
     $text-transform: ( lowercase, uppercase, capitalize ) !default;
 
-    $font-sizes: (
+    $kendo-font-sizes: (
         xs: $font-size-xs,
         sm: $font-size-sm,
         md: $font-size-md,
@@ -69,7 +69,7 @@
     }
 
     // Font Size
-    @each $name, $size in $font-sizes {
+    @each $name, $size in $kendo-font-sizes {
         .k-fs-#{$name}       { font-size: $size !important; } // sass-lint:disable-line no-important
     }
 


### PR DESCRIPTION
The motivation for this change is that the Typography's fontSize property uses the font-size enum to apply different sizes.