### PR TITLE
Docs new themes tag

### DIFF
--- a/packages/nouvelle/docs/_meta.yml
+++ b/packages/nouvelle/docs/_meta.yml
@@ -1,3 +1,4 @@
 title: Nouvelle Theme
 position: 999
 category: styling
+tag: beta

--- a/packages/nouvelle/docs/index.md
+++ b/packages/nouvelle/docs/index.md
@@ -7,6 +7,8 @@ position: 1
 
 # Nouvelle Theme Overview
 
+> Kendo UI Nouvelle Theme is currently in development stage and it is, currently, covering the base components. Please vote for it if you want a full coverage: https://feedback.telerik.com/themes/1432136-add-theme-based-on-css-variables.
+
 {% platform_content angular %}
 The Kendo UI for Angular Nouvelle theme is part of the Kendo UI for Angular library of UI components. It is distributed through NPM under the [kendo-theme-nouvelle package](https://www.npmjs.com/package/@progress/kendo-theme-nouvelle).
 {% endplatform_content %}


### PR DESCRIPTION
As part of https://github.com/telerik/katana/pull/1098 we plan to introduce the documentation for the new two themes and label them as `beta`.

![image](https://user-images.githubusercontent.com/30626787/133753715-865da429-bedd-4e2d-b9a8-c7146464aae5.png)
