### PR TITLE
fix(grid): replace hardcoded vertical border width

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -555,7 +555,7 @@
     .k-grid-footer-wrap {
         margin-right: -1px;
         width: 100%;
-        border-width: 0 1px 0 0;
+        border-width: 0 $grid-cell-vertical-border-width 0 0;
         border-style: solid;
         border-color: inherit;
         position: relative;


### PR DESCRIPTION
closes https://github.com/telerik/kendo-themes/issues/2773