### PR TITLE
chore(docs): use correct html markup for radio and checkbox docs

### DIFF
--- a/docs/components/checkbox/index.md
+++ b/docs/components/checkbox/index.md
@@ -16,18 +16,18 @@ Checkboxes can have various sizes. Use the smaller ones to create a compact them
 
 ```html
 <div class="k-d-flex k-gap-2">
-    <input 
+    <input
         type="checkbox"
         class="k-checkbox k-checkbox-sm k-roundend-md"
-    >
-     <input 
+    />
+    <input
         type="checkbox"
         class="k-checkbox k-checkbox-md k-roundend-md"
-    >
-     <input 
+    />
+    <input
         type="checkbox"
         class="k-checkbox k-checkbox-lg k-roundend-md"
-    >
+    />
 </div>
 ```
 
@@ -39,18 +39,18 @@ Checkboxes can have various rounded states depending on the border radius custom
 
 ```html
 <div class="k-d-flex k-gap-2">
-    <input 
+    <input
         type="checkbox"
         class="k-checkbox k-checkbox-md k-roundend-sm"
-    >
-     <input 
+    />
+     <input
         type="checkbox"
         class="k-checkbox k-checkbox-md k-roundend-md"
-    >
-     <input 
+    />
+     <input
         type="checkbox"
         class="k-checkbox k-checkbox-md k-roundend-lg"
-    >
+    />
 </div>
 ```
 

--- a/docs/components/radio/index.md
+++ b/docs/components/radio/index.md
@@ -14,21 +14,22 @@ Radio Buttons may render the following content:
 ## Sizes
 
 Radio Buttons can have various sizes. Use the smaller ones to create a compact theme or the larger ones on mobile devices.
-
+```html
 <div class="k-d-flex k-gap-2">
-    <input 
+    <input
         type="radio"
         class="k-radio k-radio-sm k-roundend-md"
-    >
-     <input 
+    />
+    <input
         type="radio"
         class="k-radio k-radio-md k-roundend-md"
-    >
-     <input 
+    />
+    <input
         type="radio"
         class="k-radio k-radio-lg k-roundend-md"
-    >
+    />
 </div>
+```
 
 > Note: When a radio is placed inside a label and the `size` is set differently than `medium`, the `line-height` of the `.k-radio-label` class has to be adjusted.
 


### PR DESCRIPTION
Incorrect markup causes the themes-docs site build to fail