### PR TITLE
fix(grid): decrease column menu icon z-index

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -1056,7 +1056,7 @@
         }
 
         .k-grid-header .k-grid-column-menu {
-            z-index: 5;
+            z-index: 1;
         }
     }
 


### PR DESCRIPTION
fixes https://github.com/telerik/kendo-themes/issues/2576