### PR TITLE
fix(list): set item cursor to pointer

### DIFF
--- a/packages/default/scss/list/_layout.scss
+++ b/packages/default/scss/list/_layout.scss
@@ -67,7 +67,7 @@
         font-size: $kendo-list-item-font-size;
         line-height: $kendo-list-item-line-height;
         outline: none;
-        cursor: default;
+        cursor: pointer;
         display: flex;
         flex-flow: row nowrap;
         align-items: center;


### PR DESCRIPTION
item is selectable, thus changing the default cursor to pointer

targets: https://github.com/telerik/kendo-themes/issues/3108