### PR TITLE
fix(input): input button should not have a focus shadow

### DIFF
--- a/packages/default/scss/input/_layout.scss
+++ b/packages/default/scss/input/_layout.scss
@@ -192,6 +192,10 @@
             min-width: auto !important; // sass-lint:disable-line no-important
             min-height: auto !important; // sass-lint:disable-line no-important
         }
+
+        &:focus {
+            box-shadow: none;
+        }
     }
     .k-picker .k-input-button {
         color: inherit;


### PR DESCRIPTION
targets: https://github.com/telerik/kendo-themes/issues/3107