### PR TITLE
feat(listbox): use new list styling

### DIFF
--- a/packages/default/scss/listbox/_layout.scss
+++ b/packages/default/scss/listbox/_layout.scss
@@ -72,9 +72,18 @@
 
         .k-list-scroller {
             width: 100%;
+            height: inherit;
             border-width: $listbox-border-width;
             border-style: solid;
             box-sizing: border-box;
+
+            .k-list-scroller {
+                border-width: 0;
+            }
+
+            .k-list {
+                height: inherit;
+            }
         }
 
         .k-drop-hint {

--- a/tests/visual/src/misc/listbox.html
+++ b/tests/visual/src/misc/listbox.html
@@ -37,14 +37,14 @@
                     </ul>
                 </div>
                 <div class="k-list-scroller k-selectable">
-                    <ul class="k-reset k-list">
-                        <li class="k-item">Item</li>
-                        <li class="k-item k-state-hover">Hover</li>
-                        <li class="k-item k-state-focused">Focus</li>
-                        <li class="k-item k-state-selected">Selected</li>
-                        <li class="k-item k-state-hover k-state-selected">Hover selected</li>
-                        <li class="k-item k-state-disabled">Disabled</li>
-                    </ul>
+                    <select is="List">
+                        <option>Item</option>
+                        <option hover>Hover</option>
+                        <option focus>Focus</option>
+                        <option selected>Selected</option>
+                        <option hover selected>Hover selected</option>
+                        <option disabled>Disabled</option>
+                    </select>
                 </div>
             </div>
         </section>
@@ -60,14 +60,14 @@
                     </ul>
                 </div>
                 <div class="k-list-scroller k-selectable">
-                    <ul class="k-reset k-list">
-                        <li class="k-item">Item</li>
-                        <li class="k-item k-state-hover">Hover</li>
-                        <li class="k-item k-state-focused">Focus</li>
-                        <li class="k-item k-state-selected">Selected</li>
-                        <li class="k-item k-state-hover k-state-selected">Hover selected</li>
-                        <li class="k-item k-state-disabled">Disabled</li>
-                    </ul>
+                    <select is="List">
+                        <option>Item</option>
+                        <option hover>Hover</option>
+                        <option focus>Focus</option>
+                        <option selected>Selected</option>
+                        <option hover selected>Hover selected</option>
+                        <option disabled>Disabled</option>
+                    </select>
                 </div>
             </div>
         </section>
@@ -83,14 +83,14 @@
                     </ul>
                 </div>
                 <div class="k-list-scroller k-selectable">
-                    <ul class="k-reset k-list">
-                        <li class="k-item">Item</li>
-                        <li class="k-item k-state-hover">Hover</li>
-                        <li class="k-item k-state-focused">Focus</li>
-                        <li class="k-item k-state-selected">Selected</li>
-                        <li class="k-item k-state-hover k-state-selected">Hover selected</li>
-                        <li class="k-item k-state-disabled">Disabled</li>
-                    </ul>
+                    <select is="List">
+                        <option>Item</option>
+                        <option hover>Hover</option>
+                        <option focus>Focus</option>
+                        <option selected>Selected</option>
+                        <option hover selected>Hover selected</option>
+                        <option disabled>Disabled</option>
+                    </select>
                 </div>
             </div>
         </section>
@@ -106,14 +106,14 @@
                     </ul>
                 </div>
                 <div class="k-list-scroller k-selectable">
-                    <ul class="k-reset k-list">
-                        <li class="k-item">Item</li>
-                        <li class="k-item k-state-hover">Hover</li>
-                        <li class="k-item k-state-focused">Focus</li>
-                        <li class="k-item k-state-selected">Selected</li>
-                        <li class="k-item k-state-hover k-state-selected">Hover selected</li>
-                        <li class="k-item k-state-disabled">Disabled</li>
-                    </ul>
+                    <select is="List">
+                        <option>Item</option>
+                        <option hover>Hover</option>
+                        <option focus>Focus</option>
+                        <option selected>Selected</option>
+                        <option hover selected>Hover selected</option>
+                        <option disabled>Disabled</option>
+                    </select>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
targets: https://github.com/telerik/kendo-themes/issues/3144

This PR introduces a breaking change:

* use universal List rendering for the ListBox

```html
<div class="k-listbox k-listbox-toolbar-left">
    <div class="k-listbox-toolbar">... </div>
    <div class="k-list-scroller k-selectable">
        <div class="k-list k-list-md">
            <div class="k-list-content">
                <ul class="k-list-ul">
                    <li class="k-list-item">
                        <span class="k-list-item-text">Item</span>
                    </li>
                </ul>
            </div>
        </div>
    </div>
</div>
```

* state classes for list items are also changed from `k-state-hover`, `k-state-selected`, etc. to `k-hover`, `k-selected`, etc.


/cc @ag-petrov, @kspeyanski 