### PR TITLE
fix(editor): floating toolbar should take available width

### DIFF
--- a/packages/default/scss/toolbar/_layout.scss
+++ b/packages/default/scss/toolbar/_layout.scss
@@ -230,6 +230,7 @@
         .k-toolbar {
             padding: 0;
             border-width: 0;
+            flex-shrink: 1;
             color: inherit;
             background: none;
         }


### PR DESCRIPTION
targets: https://github.com/telerik/kendo-themes/issues/3175