### PR TITLE
fix: reset margin for inputs and pickers direct children v5

### DIFF
--- a/packages/default/scss/input/_layout.scss
+++ b/packages/default/scss/input/_layout.scss
@@ -33,6 +33,11 @@
             outline: 0;
             box-shadow: none;
         }
+
+        // fix for Safari
+        & > * {
+            margin: 0;
+        }
     }
 
 


### PR DESCRIPTION
Fixes: https://github.com/telerik/kendo-themes/issues/3176