### PR TITLE
Docs escape values

### DIFF
--- a/docs/templates/includes/theme-variables-row.md.njk
+++ b/docs/templates/includes/theme-variables-row.md.njk
@@ -1,8 +1,17 @@
 <tr>
     <td>${{ variable.context.name }}</td>
     <td>{{ variable.type }}</td>
-    <td>{% if variable.context.value | is_color === true %}<span class="color-preview" style="background-color: {{variable.context.value}}"></span>{% endif %}{{ variable.context.value }}</td>
-    <td>{% if variable.resolvedValue | is_color === true %}<span class="color-preview" style="background-color: {{variable.resolvedValue}}"></span>{% endif %}{{ variable.resolvedValue }}</td>
+<td>
+{% if variable.context.value | is_color === true %}<span class="color-preview" style="background-color: {{variable.context.value}}"></span>{% endif %}
+
+{% if variable.context.value %}`{{ variable.context.value }}`{% endif %}
+
+</td>
+<td>{% if variable.resolvedValue | is_color === true %}<span class="color-preview" style="background-color: {{variable.resolvedValue}}"></span>{% endif %}
+
+{% if variable.resolvedValue %}`{{ variable.resolvedValue }}`{% endif %}
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container">

--- a/packages/bootstrap/docs/customization-avatar.md
+++ b/packages/bootstrap/docs/customization-avatar.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$avatar-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of the avatar.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>$font-family-sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`$font-family-sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the avatar.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>$font-size-base</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`$font-size-base`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the avatar.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>$line-height-base</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`$line-height-base`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the avatar.</div></div>
@@ -68,16 +104,25 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-sizes</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sizes of the avatar.</div></div>

--- a/packages/bootstrap/docs/customization-button.md
+++ b/packages/bootstrap/docs/customization-button.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$button-border-width</td>
     <td></td>
-    <td>$btn-border-width</td>
-    <td></td>
+<td>
+
+
+`$btn-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of the border around the button.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>$border-radius</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`$border-radius`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of the button.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-padding-x</td>
     <td></td>
-    <td>$btn-padding-x</td>
-    <td></td>
+<td>
+
+
+`$btn-padding-x`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of the button.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-padding-y</td>
     <td></td>
-    <td>$btn-padding-y</td>
-    <td></td>
+<td>
+
+
+`$btn-padding-y`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of the button.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>$font-family-sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`$font-family-sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the button.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>$font-size-base</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`$font-size-base`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the button.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-line-height</td>
     <td></td>
-    <td>$btn-line-height</td>
-    <td></td>
+<td>
+
+
+`$btn-line-height`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated height of the button.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-inner-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated inner height of the button. Without the border width.</div></div>
@@ -118,7 +199,10 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-theme-colors</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -129,8 +213,12 @@ The following table lists the available variables for customization.
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -141,7 +229,9 @@ The following table lists the available variables for customization.
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Theme colors map for the button.</div></div>
@@ -150,8 +240,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-bg</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #e4e7eb"></span>#e4e7eb</td>
-    <td><span class="color-preview" style="background-color: #e4e7eb"></span>#e4e7eb</td>
+<td>
+<span class="color-preview" style="background-color: #e4e7eb"></span>
+
+`#e4e7eb`
+
+</td>
+<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+
+`#e4e7eb`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the buttons.</div></div>
@@ -160,8 +259,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-text</td>
     <td></td>
-    <td>contrast-wcag( $button-bg, $gray-900 )</td>
-    <td>contrast-wcag( $button-bg, $gray-900 )</td>
+<td>
+
+
+`contrast-wcag( $button-bg, $gray-900 )`
+
+</td>
+<td>
+
+`contrast-wcag( $button-bg, $gray-900 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the buttons.</div></div>
@@ -170,8 +278,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-border</td>
     <td></td>
-    <td>$button-bg</td>
-    <td><span class="color-preview" style="background-color: #e4e7eb"></span>#e4e7eb</td>
+<td>
+
+
+`$button-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+
+`#e4e7eb`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the buttons.</div></div>
@@ -180,8 +297,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of the buttons.</div></div>
@@ -190,8 +316,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-bg</td>
     <td></td>
-    <td>try-darken( $button-bg, 7.5% )</td>
-    <td>try-darken( $button-bg, 7.5% )</td>
+<td>
+
+
+`try-darken( $button-bg, 7.5% )`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 7.5% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered buttons.</div></div>
@@ -200,8 +335,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered buttons.</div></div>
@@ -210,8 +354,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-border</td>
     <td></td>
-    <td>try-darken( $button-bg, 10% )</td>
-    <td>try-darken( $button-bg, 10% )</td>
+<td>
+
+
+`try-darken( $button-bg, 10% )`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 10% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered buttons.</div></div>
@@ -220,8 +373,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of hovered buttons.</div></div>
@@ -230,8 +392,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-bg</td>
     <td></td>
-    <td>try-darken( $button-bg, 10% )</td>
-    <td>try-darken( $button-bg, 10% )</td>
+<td>
+
+
+`try-darken( $button-bg, 10% )`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 10% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of active buttons.</div></div>
@@ -240,8 +411,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of active buttons.</div></div>
@@ -250,8 +430,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-border</td>
     <td></td>
-    <td>try-darken( $button-bg, 12.5% )</td>
-    <td>try-darken( $button-bg, 12.5% )</td>
+<td>
+
+
+`try-darken( $button-bg, 12.5% )`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 12.5% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of active buttons.</div></div>
@@ -260,8 +449,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of active buttons.</div></div>
@@ -270,8 +468,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-bg</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>try-darken( $button-bg, 10% )</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 10% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of selected buttons.</div></div>
@@ -280,8 +487,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-text</td>
     <td></td>
-    <td>$button-active-text</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected buttons.</div></div>
@@ -290,8 +506,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-border</td>
     <td></td>
-    <td>$button-active-border</td>
-    <td>try-darken( $button-bg, 12.5% )</td>
+<td>
+
+
+`$button-active-border`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 12.5% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected buttons.</div></div>
@@ -300,8 +525,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of selected buttons.</div></div>
@@ -310,8 +544,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-focused-shadow</td>
     <td></td>
-    <td>0 0 0 .25rem rgba( $button-border, .5 )</td>
-    <td>0 0 0 .25rem rgba( $button-border, .5 )</td>
+<td>
+
+
+`0 0 0 .25rem rgba( $button-border, .5 )`
+
+</td>
+<td>
+
+`0 0 0 .25rem rgba( $button-border, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The shadow of focused buttons.</div></div>

--- a/packages/bootstrap/docs/customization-charts.md
+++ b/packages/bootstrap/docs/customization-charts.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$series-a</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #0275d8"></span>#0275d8</td>
-    <td><span class="color-preview" style="background-color: #0275d8"></span>#0275d8</td>
+<td>
+<span class="color-preview" style="background-color: #0275d8"></span>
+
+`#0275d8`
+
+</td>
+<td><span class="color-preview" style="background-color: #0275d8"></span>
+
+`#0275d8`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The first base series color and its light and dark shades.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-b</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #5bc0de"></span>#5bc0de</td>
-    <td><span class="color-preview" style="background-color: #5bc0de"></span>#5bc0de</td>
+<td>
+<span class="color-preview" style="background-color: #5bc0de"></span>
+
+`#5bc0de`
+
+</td>
+<td><span class="color-preview" style="background-color: #5bc0de"></span>
+
+`#5bc0de`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The second base series color and its light and dark shades.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-c</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #5cb85c"></span>#5cb85c</td>
-    <td><span class="color-preview" style="background-color: #5cb85c"></span>#5cb85c</td>
+<td>
+<span class="color-preview" style="background-color: #5cb85c"></span>
+
+`#5cb85c`
+
+</td>
+<td><span class="color-preview" style="background-color: #5cb85c"></span>
+
+`#5cb85c`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The third base series color and its light and dark shades.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-d</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #f0ad4e"></span>#f0ad4e</td>
-    <td><span class="color-preview" style="background-color: #f0ad4e"></span>#f0ad4e</td>
+<td>
+<span class="color-preview" style="background-color: #f0ad4e"></span>
+
+`#f0ad4e`
+
+</td>
+<td><span class="color-preview" style="background-color: #f0ad4e"></span>
+
+`#f0ad4e`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fourth base series color and its light and dark shades.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-e</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #e67d4a"></span>#e67d4a</td>
-    <td><span class="color-preview" style="background-color: #e67d4a"></span>#e67d4a</td>
+<td>
+<span class="color-preview" style="background-color: #e67d4a"></span>
+
+`#e67d4a`
+
+</td>
+<td><span class="color-preview" style="background-color: #e67d4a"></span>
+
+`#e67d4a`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fifth base series color and its light and dark shades.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-f</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #d9534f"></span>#d9534f</td>
-    <td><span class="color-preview" style="background-color: #d9534f"></span>#d9534f</td>
+<td>
+<span class="color-preview" style="background-color: #d9534f"></span>
+
+`#d9534f`
+
+</td>
+<td><span class="color-preview" style="background-color: #d9534f"></span>
+
+`#d9534f`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sixth base series color and its light and dark shades.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-1</td>
     <td></td>
-    <td>$series-a</td>
-    <td><span class="color-preview" style="background-color: #0275d8"></span>#0275d8</td>
+<td>
+
+
+`$series-a`
+
+</td>
+<td><span class="color-preview" style="background-color: #0275d8"></span>
+
+`#0275d8`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The series colors in order:<br />base, light, dark, lighter, darker</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$chart-major-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (major).</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$chart-minor-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (minor).</div></div>

--- a/packages/bootstrap/docs/customization-checkbox.md
+++ b/packages/bootstrap/docs/customization-checkbox.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$checkbox-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of checkbox.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checkbox.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-border</td>
     <td></td>
-    <td>contrast-wcag( $input-bg, $gray-400, $gray-600 )</td>
-    <td>contrast-wcag( $input-bg, $gray-400, $gray-600 )</td>
+<td>
+
+
+`contrast-wcag( $input-bg, $gray-400, $gray-600 )`
+
+</td>
+<td>
+
+`contrast-wcag( $input-bg, $gray-400, $gray-600 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checkbox.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered checkbox.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered checkbox.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered checkbox.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td>$primary</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked checkbox.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-text</td>
     <td></td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked checkbox.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked checkbox.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of indeterminate checkbox.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-text</td>
     <td></td>
-    <td>$checkbox-checked-text</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`$checkbox-checked-text`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of indeterminate checkbox.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of indeterminate checkbox.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-border</td>
     <td></td>
-    <td>try-tint( $primary, 50% )</td>
-    <td>try-tint( $primary, 50% )</td>
+<td>
+
+
+`try-tint( $primary, 50% )`
+
+</td>
+<td>
+
+`try-tint( $primary, 50% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused checkbox.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-shadow</td>
     <td></td>
-    <td>0 0 0 .25rem rgba( $primary, .25 )</td>
-    <td>0 0 0 .25rem rgba( $primary, .25 )</td>
+<td>
+
+
+`0 0 0 .25rem rgba( $primary, .25 )`
+
+</td>
+<td>
+
+`0 0 0 .25rem rgba( $primary, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused checkbox.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked checkbox.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-checked-shadow</td>
     <td></td>
-    <td>$checkbox-focused-shadow</td>
-    <td>0 0 0 .25rem rgba( $primary, .25 )</td>
+<td>
+
+
+`$checkbox-focused-shadow`
+
+</td>
+<td>
+
+`0 0 0 .25rem rgba( $primary, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked checkbox.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled checkbox.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled checkbox.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled checkbox.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked checkbox.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked checkbox.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked checkbox.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid checkbox.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-text</td>
     <td></td>
-    <td>$invalid-text</td>
-    <td></td>
+<td>
+
+
+`$invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid checkbox.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-border</td>
     <td></td>
-    <td>$invalid-border</td>
-    <td></td>
+<td>
+
+
+`$invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid checkbox.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of checkbox indicator.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-glyph-font-family</td>
     <td></td>
-    <td>"WebComponentsIcons", monospace</td>
-    <td>"WebComponentsIcons", monospace</td>
+<td>
+
+
+`"WebComponentsIcons", monospace`
+
+</td>
+<td>
+
+`"WebComponentsIcons", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph font family of checkbox indicator.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-glyph</td>
     <td></td>
-    <td>"\e118"</td>
-    <td>"\e118"</td>
+<td>
+
+
+`"\e118"`
+
+</td>
+<td>
+
+`"\e118"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of checkbox indicator.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-glyph</td>
     <td></td>
-    <td>"\e121"</td>
-    <td>"\e121"</td>
+<td>
+
+
+`"\e121"`
+
+</td>
+<td>
+
+`"\e121"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of indeterminate checkbox indicator.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -338,8 +617,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -348,8 +636,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal checkbox list.</div></div>
@@ -358,8 +655,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of checkbox list items.</div></div>
@@ -368,8 +674,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of checkbox list items.</div></div>
@@ -378,8 +693,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-ripple-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox ripple.</div></div>
@@ -388,8 +712,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of checkbox ripple.</div></div>

--- a/packages/bootstrap/docs/customization-color-system.md
+++ b/packages/bootstrap/docs/customization-color-system.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$accent</td>
     <td>Color</td>
-    <td>$primary</td>
-    <td>$primary</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Deprecated</b><div class="theme-variables-description">Will be removed in v5. Use `$primary` variable instead.</div></div><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$accent-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $accent )</td>
-    <td>contrast-wcag( $accent )</td>
+<td>
+
+
+`contrast-wcag( $accent )`
+
+</td>
+<td>
+
+`contrast-wcag( $accent )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Deprecated</b><div class="theme-variables-description">Will be removed in v5. Use `$primary-contrast` variable instead.</div></div><div><b>Description</b><div class="theme-variables-description">The color used along with the primary color denoted by $primary.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$primary</td>
     <td>Color</td>
-    <td>$primary</td>
-    <td>$primary</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.<br />Used for primary buttons and for elements of primary importance across the theme.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$primary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $primary )</td>
-    <td>contrast-wcag( $primary )</td>
+<td>
+
+
+`contrast-wcag( $primary )`
+
+</td>
+<td>
+
+`contrast-wcag( $primary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the primary color denoted by $primary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$secondary</td>
     <td>Color</td>
-    <td>$secondary</td>
-    <td>$secondary</td>
+<td>
+
+
+`$secondary`
+
+</td>
+<td>
+
+`$secondary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The secondary color of the theme.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$secondary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $secondary )</td>
-    <td>contrast-wcag( $secondary )</td>
+<td>
+
+
+`contrast-wcag( $secondary )`
+
+</td>
+<td>
+
+`contrast-wcag( $secondary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the secondary color denoted by $secondary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tertiary</td>
     <td>Color</td>
-    <td>$purple</td>
-    <td></td>
+<td>
+
+
+`$purple`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tertiary color of the theme.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tertiary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $tertiary )</td>
-    <td>contrast-wcag( $tertiary )</td>
+<td>
+
+
+`contrast-wcag( $tertiary )`
+
+</td>
+<td>
+
+`contrast-wcag( $tertiary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the tertiary color denoted by $tertiary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$info</td>
     <td>Color</td>
-    <td>$info</td>
-    <td>$info</td>
+<td>
+
+
+`$info`
+
+</td>
+<td>
+
+`$info`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for informational messages and states.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$success</td>
     <td>Color</td>
-    <td>$success</td>
-    <td>$success</td>
+<td>
+
+
+`$success`
+
+</td>
+<td>
+
+`$success`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for success messages and states.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$warning</td>
     <td>Color</td>
-    <td>$warning</td>
-    <td>$warning</td>
+<td>
+
+
+`$warning`
+
+</td>
+<td>
+
+`$warning`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for warning messages and states.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$error</td>
     <td>Color</td>
-    <td>$danger</td>
-    <td></td>
+<td>
+
+
+`$danger`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for error messages and states.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dark</td>
     <td>Color</td>
-    <td>$dark</td>
-    <td>$dark</td>
+<td>
+
+
+`$dark`
+
+</td>
+<td>
+
+`$dark`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The dark color of the theme.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$light</td>
     <td>Color</td>
-    <td>$light</td>
-    <td>$light</td>
+<td>
+
+
+`$light`
+
+</td>
+<td>
+
+`$light`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The light color of the theme.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$inverse</td>
     <td></td>
-    <td>if( $dark-theme, $light, $dark )</td>
-    <td>if( $dark-theme, $light, $dark )</td>
+<td>
+
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
+<td>
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Inverse color of the theme. Depending on the theme luminance dark or lught, it will be light or dark</div></div>

--- a/packages/bootstrap/docs/customization-common.md
+++ b/packages/bootstrap/docs/customization-common.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>$border-radius</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`$border-radius`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius for all components.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-bg</td>
     <td></td>
-    <td>$gray-100</td>
-    <td></td>
+<td>
+
+
+`$gray-100`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the components' chrome area.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the components' chrome area.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-border</td>
     <td></td>
-    <td>try-shade( $base-bg, 1 )</td>
-    <td>try-shade( $base-bg, 1 )</td>
+<td>
+
+
+`try-shade( $base-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the components' chrome area.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of the components' chrome area.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-bg</td>
     <td></td>
-    <td>$gray-200</td>
-    <td></td>
+<td>
+
+
+`$gray-200`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered items.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td></td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered items.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-border</td>
     <td></td>
-    <td>try-shade( $hovered-bg, 1 )</td>
-    <td>try-shade( $hovered-bg, 1 )</td>
+<td>
+
+
+`try-shade( $hovered-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $hovered-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered items.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of hovered items.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td>$primary</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of selected items.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-text</td>
     <td></td>
-    <td>contrast-wcag( $selected-bg )</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`contrast-wcag( $selected-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected items.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-border</td>
     <td></td>
-    <td>try-shade( $selected-bg, 1 )</td>
-    <td>try-shade( $selected-bg, 1 )</td>
+<td>
+
+
+`try-shade( $selected-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $selected-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of selected items.</div></div>

--- a/packages/bootstrap/docs/customization-component.md
+++ b/packages/bootstrap/docs/customization-component.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$component-bg</td>
     <td></td>
-    <td>$body-bg</td>
-    <td></td>
+<td>
+
+
+`$body-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-bg` e.g. `$grid-bg: $component-bg !defualt;`.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$component-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-text` e.g. `$grid-text: component-text !default;`.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$component-border</td>
     <td></td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-border` e.g. `$grid-border: component-border !default;`.</div></div>

--- a/packages/bootstrap/docs/customization-grid.md
+++ b/packages/bootstrap/docs/customization-grid.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$grid-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the grid component</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the grid component</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the grid component</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-bg</td>
     <td></td>
-    <td>$header-bg</td>
-    <td></td>
+<td>
+
+
+`$header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid header</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-text</td>
     <td></td>
-    <td>$header-text</td>
-    <td></td>
+<td>
+
+
+`$header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid header</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-border</td>
     <td></td>
-    <td>$header-border</td>
-    <td></td>
+<td>
+
+
+`$header-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid header</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-gradient</td>
     <td></td>
-    <td>$header-gradient</td>
-    <td></td>
+<td>
+
+
+`$header-gradient`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of grid header</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid footer</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid footer</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td></td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid footer</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-bg</td>
     <td></td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in grid</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in grid</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in grid</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-bg</td>
     <td></td>
-    <td>rgba( contrast-wcag( $grid-bg ), .08 )</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .08 )</td>
+<td>
+
+
+`rgba( contrast-wcag( $grid-bg ), .08 )`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in grid</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in grid</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in grid</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-bg</td>
     <td></td>
-    <td>rgba( $selected-bg, .25 )</td>
-    <td>rgba( $selected-bg, .25 )</td>
+<td>
+
+
+`rgba( $selected-bg, .25 )`
+
+</td>
+<td>
+
+`rgba( $selected-bg, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in grid</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-text</td>
     <td></td>
-    <td>$grid-text</td>
-    <td></td>
+<td>
+
+
+`$grid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in grid</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in grid</div></div>

--- a/packages/bootstrap/docs/customization-icons.md
+++ b/packages/bootstrap/docs/customization-icons.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$icon-font-url</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The URL to the icon font that will be used by the theme<br />The default value of `null` embeds the package font with a `data:` URL</div></div>

--- a/packages/bootstrap/docs/customization-list.md
+++ b/packages/bootstrap/docs/customization-list.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$list-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the list component.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the list component.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of list items.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of list items.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the list component.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the list component.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the list component.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list header.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list header.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-border</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of list header.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of list header.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list items.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>$gray-200</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`$gray-200`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered list items.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered list items.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused list items.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused list items.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-shadow</td>
     <td></td>
-    <td>inset 0 0 0 3px rgba( $list-item-text, .15 )</td>
-    <td>inset 0 0 0 3px rgba( $list-item-text, .15 )</td>
+<td>
+
+
+`inset 0 0 0 3px rgba( $list-item-text, .15 )`
+
+</td>
+<td>
+
+`inset 0 0 0 3px rgba( $list-item-text, .15 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused list items.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected list items.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected list items.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-no-data-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the 'No Data' text.</div></div>

--- a/packages/bootstrap/docs/customization-radio.md
+++ b/packages/bootstrap/docs/customization-radio.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$radio-radius</td>
     <td></td>
-    <td>50%</td>
-    <td>50%</td>
+<td>
+
+
+`50%`
+
+</td>
+<td>
+
+`50%`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of radio button.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of radio button.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-text</td>
     <td></td>
-    <td>$checkbox-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of radio button.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>contrast-wcag( $input-bg, $gray-400, $gray-600 )</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`contrast-wcag( $input-bg, $gray-400, $gray-600 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of radio button.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-bg</td>
     <td></td>
-    <td>$checkbox-hovered-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered radio button.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-text</td>
     <td></td>
-    <td>$checkbox-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered radio button.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered radio button.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked radio button.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-text</td>
     <td></td>
-    <td>$checkbox-checked-text</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`$checkbox-checked-text`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked radio button.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked radio button.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused radio button.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-shadow</td>
     <td></td>
-    <td>$checkbox-focused-shadow</td>
-    <td>0 0 0 .25rem rgba( $primary, .25 )</td>
+<td>
+
+
+`$checkbox-focused-shadow`
+
+</td>
+<td>
+
+`0 0 0 .25rem rgba( $primary, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused radio button.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked radio button.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-checked-shadow</td>
     <td></td>
-    <td>$checkbox-focused-checked-shadow</td>
-    <td>0 0 0 .25rem rgba( $primary, .25 )</td>
+<td>
+
+
+`$checkbox-focused-checked-shadow`
+
+</td>
+<td>
+
+`0 0 0 .25rem rgba( $primary, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked radio button.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-bg</td>
     <td></td>
-    <td>$checkbox-disabled-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled radio button.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-text</td>
     <td></td>
-    <td>$checkbox-disabled-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled radio button.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-border</td>
     <td></td>
-    <td>$checkbox-disabled-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled radio button.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-bg</td>
     <td></td>
-    <td>$checkbox-disabled-checked-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked radio button.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-text</td>
     <td></td>
-    <td>$checkbox-disabled-checked-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked radio button.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-border</td>
     <td></td>
-    <td>$checkbox-disabled-checked-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked radio button.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-bg</td>
     <td></td>
-    <td>$checkbox-invalid-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-invalid-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid radio button.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-text</td>
     <td></td>
-    <td>$checkbox-invalid-text</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid radio button.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-border</td>
     <td></td>
-    <td>$checkbox-invalid-border</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid radio button.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of radio button indicator.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-glyph</td>
     <td></td>
-    <td>"\e308"</td>
-    <td>"\e308"</td>
+<td>
+
+
+`"\e308"`
+
+</td>
+<td>
+
+`"\e308"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of radio button indicator.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$radio-checked-text}'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$radio-checked-text}'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked radio button indicator.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-image</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of disabled and checked radio button indicator.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal radio button list.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of radio button list items.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of radio button list items.</div></div>
@@ -338,8 +617,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-ripple-bg</td>
     <td></td>
-    <td>$radio-checked-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$radio-checked-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button ripple.</div></div>
@@ -348,8 +636,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of radio button ripple.</div></div>

--- a/packages/bootstrap/docs/customization-table.md
+++ b/packages/bootstrap/docs/customization-table.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$table-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of the table border.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-vertical-border-width</td>
     <td></td>
-    <td>$grid-cell-vertical-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-vertical-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of vertical border of table cells.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-horizontal-border-width</td>
     <td></td>
-    <td>$grid-cell-horizontal-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-horizontal-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of horizontal border of table cells.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>$font-size-base</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`$font-size-base`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font size of the table if no size is specified.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the cells in the table if no size is specified.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the cells in the table if no size is specified.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-bg</td>
     <td></td>
-    <td>$grid-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tables.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-text</td>
     <td></td>
-    <td>$grid-text</td>
-    <td></td>
+<td>
+
+
+`$grid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tables.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tables.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table headers.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table headers.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td></td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table headers.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-bg</td>
     <td></td>
-    <td>$grid-footer-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table footers.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-text</td>
     <td></td>
-    <td>$grid-footer-text</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table footers.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-border</td>
     <td></td>
-    <td>$grid-footer-border</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table footers.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-bg</td>
     <td></td>
-    <td>$table-header-bg</td>
-    <td></td>
+<td>
+
+
+`$table-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of group rows in table.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-text</td>
     <td></td>
-    <td>$table-header-text</td>
-    <td></td>
+<td>
+
+
+`$table-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of group rows in table.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-border</td>
     <td></td>
-    <td>$table-header-border</td>
-    <td></td>
+<td>
+
+
+`$table-header-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of group rows in table.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-bg</td>
     <td></td>
-    <td>$grid-alt-bg</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`$grid-alt-bg`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in table.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-text</td>
     <td></td>
-    <td>$grid-alt-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in table.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-border</td>
     <td></td>
-    <td>$grid-alt-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in table.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-bg</td>
     <td></td>
-    <td>$grid-hovered-bg</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .08 )</td>
+<td>
+
+
+`$grid-hovered-bg`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in table.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-text</td>
     <td></td>
-    <td>$grid-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in table.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-border</td>
     <td></td>
-    <td>$grid-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in table.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused rows in table.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused rows in table.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused rows in table.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-shadow</td>
     <td></td>
-    <td>$grid-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$grid-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused rows in table.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-bg</td>
     <td></td>
-    <td>$grid-selected-bg</td>
-    <td>rgba( $selected-bg, .25 )</td>
+<td>
+
+
+`$grid-selected-bg`
+
+</td>
+<td>
+
+`rgba( $selected-bg, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in table.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-text</td>
     <td></td>
-    <td>$grid-selected-text</td>
-    <td></td>
+<td>
+
+
+`$grid-selected-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in table.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-border</td>
     <td></td>
-    <td>$grid-selected-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$grid-selected-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in table.</div></div>

--- a/packages/bootstrap/docs/customization-tabstrip.md
+++ b/packages/bootstrap/docs/customization-tabstrip.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$tabstrip-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip component</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip component</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip component</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-padding-x</td>
     <td></td>
-    <td>$nav-item-padding-x</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-x`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabs</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-padding-y</td>
     <td></td>
-    <td>$nav-item-padding-y</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-y`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabs</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabs</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border-radius</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of tabs</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-gap</td>
     <td></td>
-    <td>$nav-item-margin</td>
-    <td></td>
+<td>
+
+
+`$nav-item-margin`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between tabs</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabs</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-text</td>
     <td></td>
-    <td>$link-text</td>
-    <td></td>
+<td>
+
+
+`$link-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabs</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabs</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of tabs</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered tabs</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered tabs</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-border</td>
     <td></td>
-    <td>$gray-200</td>
-    <td></td>
+<td>
+
+
+`$gray-200`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered tabs</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered tabs</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected tabs</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected tabs</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected tabs</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected tabs</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabstrip content</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabstrip content</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border-width</td>
     <td></td>
-    <td>$tabstrip-border-width</td>
-    <td></td>
+<td>
+
+
+`$tabstrip-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabstrip content</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip content</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip content</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip content</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border-focused</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip focused content</div></div>

--- a/packages/bootstrap/docs/customization-toolbar.md
+++ b/packages/bootstrap/docs/customization-toolbar.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$toolbar-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the container.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$toolbar-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the container.</div></div>

--- a/packages/bootstrap/docs/customization-treeview.md
+++ b/packages/bootstrap/docs/customization-treeview.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$treeview-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>$font-family-sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`$font-family-sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the treeview component.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the treeview component.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the treeview component.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-indent</td>
     <td></td>
-    <td>16px</td>
-    <td>16px</td>
+<td>
+
+
+`16px`
+
+</td>
+<td>
+
+`16px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Indentation of child groups in treeview component.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 3 )</td>
-    <td>map-get( $spacing, 3 )</td>
+<td>
+
+
+`map-get( $spacing, 3 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of treeview items.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of treeview items.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of treeview items.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-border-radius</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of treeview items.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the treeview component.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the treeview component.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the treeview component.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>$gray-200</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`$gray-200`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered treeview items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered treeview items.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-border</td>
     <td></td>
-    <td>$treeview-item-hovered-bg</td>
-    <td>$gray-200</td>
+<td>
+
+
+`$treeview-item-hovered-bg`
+
+</td>
+<td>
+
+`$gray-200`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered treeview items.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered treeview items.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected treeview items.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected treeview items.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-border</td>
     <td></td>
-    <td>$treeview-item-selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$treeview-item-selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected treeview items.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected treeview items.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-focused-shadow</td>
     <td></td>
-    <td>inset 0 0 0 2px rgba( $treeview-text, .15 )</td>
-    <td>inset 0 0 0 2px rgba( $treeview-text, .15 )</td>
+<td>
+
+
+`inset 0 0 0 2px rgba( $treeview-text, .15 )`
+
+</td>
+<td>
+
+`inset 0 0 0 2px rgba( $treeview-text, .15 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused treeview items.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of load more.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-text</td>
     <td></td>
-    <td>$link-text</td>
-    <td></td>
+<td>
+
+
+`$link-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of load more.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of load more.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a hovered load more.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a hovered load more.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a hovered load more.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a focused load more.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a focused load more.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a focused load more.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-shadow</td>
     <td></td>
-    <td>$treeview-item-focused-shadow</td>
-    <td>inset 0 0 0 2px rgba( $treeview-text, .15 )</td>
+<td>
+
+
+`$treeview-item-focused-shadow`
+
+</td>
+<td>
+
+`inset 0 0 0 2px rgba( $treeview-text, .15 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of a focused load more.</div></div>

--- a/packages/bootstrap/docs/customization-typography.md
+++ b/packages/bootstrap/docs/customization-typography.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$enable-typography</td>
     <td></td>
-    <td>false</td>
-    <td>false</td>
+<td>
+
+
+`false`
+
+</td>
+<td>
+
+`false`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Global typography styles for the Kendo Bootstrap theme.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-size</td>
     <td></td>
-    <td>$font-size-base</td>
-    <td></td>
+<td>
+
+
+`$font-size-base`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Base font size across all components.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-family</td>
     <td></td>
-    <td>$font-family-sans-serif</td>
-    <td></td>
+<td>
+
+
+`$font-family-sans-serif`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family across all components.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-family-monospace</td>
     <td></td>
-    <td>$font-family-monospace</td>
-    <td>$font-family-monospace</td>
+<td>
+
+
+`$font-family-monospace`
+
+</td>
+<td>
+
+`$font-family-monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family for monospaced text. Used for styling the code.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$line-height</td>
     <td></td>
-    <td>$line-height-base</td>
-    <td></td>
+<td>
+
+
+`$line-height-base`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>

--- a/packages/bootstrap/docs/customization.md
+++ b/packages/bootstrap/docs/customization.md
@@ -32,8 +32,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>$border-radius</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`$border-radius`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius for all components.</div></div>
@@ -42,8 +51,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$base-bg</td>
     <td></td>
-    <td>$gray-100</td>
-    <td></td>
+<td>
+
+
+`$gray-100`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the components' chrome area.</div></div>
@@ -52,8 +70,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$base-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the components' chrome area.</div></div>
@@ -62,8 +89,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$base-border</td>
     <td></td>
-    <td>try-shade( $base-bg, 1 )</td>
-    <td>try-shade( $base-bg, 1 )</td>
+<td>
+
+
+`try-shade( $base-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the components' chrome area.</div></div>
@@ -72,8 +108,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$base-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of the components' chrome area.</div></div>
@@ -82,8 +127,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$hovered-bg</td>
     <td></td>
-    <td>$gray-200</td>
-    <td></td>
+<td>
+
+
+`$gray-200`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered items.</div></div>
@@ -92,8 +146,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$hovered-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td></td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered items.</div></div>
@@ -102,8 +165,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$hovered-border</td>
     <td></td>
-    <td>try-shade( $hovered-bg, 1 )</td>
-    <td>try-shade( $hovered-bg, 1 )</td>
+<td>
+
+
+`try-shade( $hovered-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $hovered-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered items.</div></div>
@@ -112,8 +184,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of hovered items.</div></div>
@@ -122,8 +203,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$selected-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td>$primary</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of selected items.</div></div>
@@ -132,8 +222,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$selected-text</td>
     <td></td>
-    <td>contrast-wcag( $selected-bg )</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`contrast-wcag( $selected-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected items.</div></div>
@@ -142,8 +241,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$selected-border</td>
     <td></td>
-    <td>try-shade( $selected-bg, 1 )</td>
-    <td>try-shade( $selected-bg, 1 )</td>
+<td>
+
+
+`try-shade( $selected-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $selected-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected items.</div></div>
@@ -152,8 +260,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of selected items.</div></div>
@@ -183,8 +300,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$avatar-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of the avatar.</div></div>
@@ -193,8 +319,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$avatar-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>$font-family-sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`$font-family-sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the avatar.</div></div>
@@ -203,8 +338,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$avatar-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>$font-size-base</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`$font-size-base`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the avatar.</div></div>
@@ -213,8 +357,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$avatar-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>$line-height-base</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`$line-height-base`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the avatar.</div></div>
@@ -223,16 +376,25 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$avatar-sizes</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sizes of the avatar.</div></div>
@@ -262,8 +424,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$button-border-width</td>
     <td></td>
-    <td>$btn-border-width</td>
-    <td></td>
+<td>
+
+
+`$btn-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of the border around the button.</div></div>
@@ -272,8 +443,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>$border-radius</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`$border-radius`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of the button.</div></div>
@@ -282,8 +462,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-padding-x</td>
     <td></td>
-    <td>$btn-padding-x</td>
-    <td></td>
+<td>
+
+
+`$btn-padding-x`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of the button.</div></div>
@@ -292,8 +481,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-padding-y</td>
     <td></td>
-    <td>$btn-padding-y</td>
-    <td></td>
+<td>
+
+
+`$btn-padding-y`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of the button.</div></div>
@@ -302,8 +500,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>$font-family-sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`$font-family-sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the button.</div></div>
@@ -312,8 +519,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>$font-size-base</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`$font-size-base`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the button.</div></div>
@@ -322,8 +538,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-line-height</td>
     <td></td>
-    <td>$btn-line-height</td>
-    <td></td>
+<td>
+
+
+`$btn-line-height`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>
@@ -332,8 +557,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated height of the button.</div></div>
@@ -342,8 +576,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-inner-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated inner height of the button. Without the border width.</div></div>
@@ -352,7 +595,10 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-theme-colors</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -363,8 +609,12 @@ The following table lists the available variables for customizing the Bootstrap 
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -375,7 +625,9 @@ The following table lists the available variables for customizing the Bootstrap 
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Theme colors map for the button.</div></div>
@@ -384,8 +636,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-bg</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #e4e7eb"></span>#e4e7eb</td>
-    <td><span class="color-preview" style="background-color: #e4e7eb"></span>#e4e7eb</td>
+<td>
+<span class="color-preview" style="background-color: #e4e7eb"></span>
+
+`#e4e7eb`
+
+</td>
+<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+
+`#e4e7eb`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the buttons.</div></div>
@@ -394,8 +655,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-text</td>
     <td></td>
-    <td>contrast-wcag( $button-bg, $gray-900 )</td>
-    <td>contrast-wcag( $button-bg, $gray-900 )</td>
+<td>
+
+
+`contrast-wcag( $button-bg, $gray-900 )`
+
+</td>
+<td>
+
+`contrast-wcag( $button-bg, $gray-900 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the buttons.</div></div>
@@ -404,8 +674,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-border</td>
     <td></td>
-    <td>$button-bg</td>
-    <td><span class="color-preview" style="background-color: #e4e7eb"></span>#e4e7eb</td>
+<td>
+
+
+`$button-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+
+`#e4e7eb`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the buttons.</div></div>
@@ -414,8 +693,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of the buttons.</div></div>
@@ -424,8 +712,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-hovered-bg</td>
     <td></td>
-    <td>try-darken( $button-bg, 7.5% )</td>
-    <td>try-darken( $button-bg, 7.5% )</td>
+<td>
+
+
+`try-darken( $button-bg, 7.5% )`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 7.5% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered buttons.</div></div>
@@ -434,8 +731,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered buttons.</div></div>
@@ -444,8 +750,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-hovered-border</td>
     <td></td>
-    <td>try-darken( $button-bg, 10% )</td>
-    <td>try-darken( $button-bg, 10% )</td>
+<td>
+
+
+`try-darken( $button-bg, 10% )`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 10% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered buttons.</div></div>
@@ -454,8 +769,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of hovered buttons.</div></div>
@@ -464,8 +788,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-active-bg</td>
     <td></td>
-    <td>try-darken( $button-bg, 10% )</td>
-    <td>try-darken( $button-bg, 10% )</td>
+<td>
+
+
+`try-darken( $button-bg, 10% )`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 10% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of active buttons.</div></div>
@@ -474,8 +807,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-active-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of active buttons.</div></div>
@@ -484,8 +826,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-active-border</td>
     <td></td>
-    <td>try-darken( $button-bg, 12.5% )</td>
-    <td>try-darken( $button-bg, 12.5% )</td>
+<td>
+
+
+`try-darken( $button-bg, 12.5% )`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 12.5% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of active buttons.</div></div>
@@ -494,8 +845,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-active-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of active buttons.</div></div>
@@ -504,8 +864,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-selected-bg</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>try-darken( $button-bg, 10% )</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 10% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of selected buttons.</div></div>
@@ -514,8 +883,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-selected-text</td>
     <td></td>
-    <td>$button-active-text</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected buttons.</div></div>
@@ -524,8 +902,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-selected-border</td>
     <td></td>
-    <td>$button-active-border</td>
-    <td>try-darken( $button-bg, 12.5% )</td>
+<td>
+
+
+`$button-active-border`
+
+</td>
+<td>
+
+`try-darken( $button-bg, 12.5% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected buttons.</div></div>
@@ -534,8 +921,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of selected buttons.</div></div>
@@ -544,8 +940,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$button-focused-shadow</td>
     <td></td>
-    <td>0 0 0 .25rem rgba( $button-border, .5 )</td>
-    <td>0 0 0 .25rem rgba( $button-border, .5 )</td>
+<td>
+
+
+`0 0 0 .25rem rgba( $button-border, .5 )`
+
+</td>
+<td>
+
+`0 0 0 .25rem rgba( $button-border, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The shadow of focused buttons.</div></div>
@@ -575,8 +980,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$series-a</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #0275d8"></span>#0275d8</td>
-    <td><span class="color-preview" style="background-color: #0275d8"></span>#0275d8</td>
+<td>
+<span class="color-preview" style="background-color: #0275d8"></span>
+
+`#0275d8`
+
+</td>
+<td><span class="color-preview" style="background-color: #0275d8"></span>
+
+`#0275d8`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The first base series color and its light and dark shades.</div></div>
@@ -585,8 +999,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$series-b</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #5bc0de"></span>#5bc0de</td>
-    <td><span class="color-preview" style="background-color: #5bc0de"></span>#5bc0de</td>
+<td>
+<span class="color-preview" style="background-color: #5bc0de"></span>
+
+`#5bc0de`
+
+</td>
+<td><span class="color-preview" style="background-color: #5bc0de"></span>
+
+`#5bc0de`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The second base series color and its light and dark shades.</div></div>
@@ -595,8 +1018,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$series-c</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #5cb85c"></span>#5cb85c</td>
-    <td><span class="color-preview" style="background-color: #5cb85c"></span>#5cb85c</td>
+<td>
+<span class="color-preview" style="background-color: #5cb85c"></span>
+
+`#5cb85c`
+
+</td>
+<td><span class="color-preview" style="background-color: #5cb85c"></span>
+
+`#5cb85c`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The third base series color and its light and dark shades.</div></div>
@@ -605,8 +1037,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$series-d</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #f0ad4e"></span>#f0ad4e</td>
-    <td><span class="color-preview" style="background-color: #f0ad4e"></span>#f0ad4e</td>
+<td>
+<span class="color-preview" style="background-color: #f0ad4e"></span>
+
+`#f0ad4e`
+
+</td>
+<td><span class="color-preview" style="background-color: #f0ad4e"></span>
+
+`#f0ad4e`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fourth base series color and its light and dark shades.</div></div>
@@ -615,8 +1056,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$series-e</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #e67d4a"></span>#e67d4a</td>
-    <td><span class="color-preview" style="background-color: #e67d4a"></span>#e67d4a</td>
+<td>
+<span class="color-preview" style="background-color: #e67d4a"></span>
+
+`#e67d4a`
+
+</td>
+<td><span class="color-preview" style="background-color: #e67d4a"></span>
+
+`#e67d4a`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fifth base series color and its light and dark shades.</div></div>
@@ -625,8 +1075,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$series-f</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #d9534f"></span>#d9534f</td>
-    <td><span class="color-preview" style="background-color: #d9534f"></span>#d9534f</td>
+<td>
+<span class="color-preview" style="background-color: #d9534f"></span>
+
+`#d9534f`
+
+</td>
+<td><span class="color-preview" style="background-color: #d9534f"></span>
+
+`#d9534f`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sixth base series color and its light and dark shades.</div></div>
@@ -635,8 +1094,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$series-1</td>
     <td></td>
-    <td>$series-a</td>
-    <td><span class="color-preview" style="background-color: #0275d8"></span>#0275d8</td>
+<td>
+
+
+`$series-a`
+
+</td>
+<td><span class="color-preview" style="background-color: #0275d8"></span>
+
+`#0275d8`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The series colors in order:<br />base, light, dark, lighter, darker</div></div>
@@ -645,8 +1113,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$chart-major-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (major).</div></div>
@@ -655,8 +1132,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$chart-minor-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (minor).</div></div>
@@ -686,8 +1172,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$checkbox-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of checkbox.</div></div>
@@ -696,8 +1191,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox.</div></div>
@@ -706,8 +1210,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checkbox.</div></div>
@@ -716,8 +1229,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-border</td>
     <td></td>
-    <td>contrast-wcag( $input-bg, $gray-400, $gray-600 )</td>
-    <td>contrast-wcag( $input-bg, $gray-400, $gray-600 )</td>
+<td>
+
+
+`contrast-wcag( $input-bg, $gray-400, $gray-600 )`
+
+</td>
+<td>
+
+`contrast-wcag( $input-bg, $gray-400, $gray-600 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checkbox.</div></div>
@@ -726,8 +1248,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered checkbox.</div></div>
@@ -736,8 +1267,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered checkbox.</div></div>
@@ -746,8 +1286,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered checkbox.</div></div>
@@ -756,8 +1305,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-checked-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td>$primary</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked checkbox.</div></div>
@@ -766,8 +1324,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-checked-text</td>
     <td></td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked checkbox.</div></div>
@@ -776,8 +1343,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked checkbox.</div></div>
@@ -786,8 +1362,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-indeterminate-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of indeterminate checkbox.</div></div>
@@ -796,8 +1381,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-indeterminate-text</td>
     <td></td>
-    <td>$checkbox-checked-text</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`$checkbox-checked-text`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of indeterminate checkbox.</div></div>
@@ -806,8 +1400,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-indeterminate-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of indeterminate checkbox.</div></div>
@@ -816,8 +1419,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-focused-border</td>
     <td></td>
-    <td>try-tint( $primary, 50% )</td>
-    <td>try-tint( $primary, 50% )</td>
+<td>
+
+
+`try-tint( $primary, 50% )`
+
+</td>
+<td>
+
+`try-tint( $primary, 50% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused checkbox.</div></div>
@@ -826,8 +1438,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-focused-shadow</td>
     <td></td>
-    <td>0 0 0 .25rem rgba( $primary, .25 )</td>
-    <td>0 0 0 .25rem rgba( $primary, .25 )</td>
+<td>
+
+
+`0 0 0 .25rem rgba( $primary, .25 )`
+
+</td>
+<td>
+
+`0 0 0 .25rem rgba( $primary, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused checkbox.</div></div>
@@ -836,8 +1457,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-focused-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked checkbox.</div></div>
@@ -846,8 +1476,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-focused-checked-shadow</td>
     <td></td>
-    <td>$checkbox-focused-shadow</td>
-    <td>0 0 0 .25rem rgba( $primary, .25 )</td>
+<td>
+
+
+`$checkbox-focused-shadow`
+
+</td>
+<td>
+
+`0 0 0 .25rem rgba( $primary, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked checkbox.</div></div>
@@ -856,8 +1495,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-disabled-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled checkbox.</div></div>
@@ -866,8 +1514,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-disabled-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled checkbox.</div></div>
@@ -876,8 +1533,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-disabled-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled checkbox.</div></div>
@@ -886,8 +1552,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-disabled-checked-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked checkbox.</div></div>
@@ -896,8 +1571,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-disabled-checked-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked checkbox.</div></div>
@@ -906,8 +1590,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-disabled-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked checkbox.</div></div>
@@ -916,8 +1609,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-invalid-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid checkbox.</div></div>
@@ -926,8 +1628,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-invalid-text</td>
     <td></td>
-    <td>$invalid-text</td>
-    <td></td>
+<td>
+
+
+`$invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid checkbox.</div></div>
@@ -936,8 +1647,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-invalid-border</td>
     <td></td>
-    <td>$invalid-border</td>
-    <td></td>
+<td>
+
+
+`$invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid checkbox.</div></div>
@@ -946,8 +1666,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of checkbox indicator.</div></div>
@@ -956,8 +1685,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-glyph-font-family</td>
     <td></td>
-    <td>"WebComponentsIcons", monospace</td>
-    <td>"WebComponentsIcons", monospace</td>
+<td>
+
+
+`"WebComponentsIcons", monospace`
+
+</td>
+<td>
+
+`"WebComponentsIcons", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph font family of checkbox indicator.</div></div>
@@ -966,8 +1704,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-checked-glyph</td>
     <td></td>
-    <td>"\e118"</td>
-    <td>"\e118"</td>
+<td>
+
+
+`"\e118"`
+
+</td>
+<td>
+
+`"\e118"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of checkbox indicator.</div></div>
@@ -976,8 +1723,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-indeterminate-glyph</td>
     <td></td>
-    <td>"\e121"</td>
-    <td>"\e121"</td>
+<td>
+
+
+`"\e121"`
+
+</td>
+<td>
+
+`"\e121"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of indeterminate checkbox indicator.</div></div>
@@ -986,8 +1742,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -996,8 +1761,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-indeterminate-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -1006,8 +1780,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal checkbox list.</div></div>
@@ -1016,8 +1799,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of checkbox list items.</div></div>
@@ -1026,8 +1818,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of checkbox list items.</div></div>
@@ -1036,8 +1837,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-ripple-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox ripple.</div></div>
@@ -1046,8 +1856,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$checkbox-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of checkbox ripple.</div></div>
@@ -1077,8 +1896,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$accent</td>
     <td>Color</td>
-    <td>$primary</td>
-    <td>$primary</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Deprecated</b><div class="theme-variables-description">Will be removed in v5. Use `$primary` variable instead.</div></div><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.</div></div>
@@ -1087,8 +1915,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$accent-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $accent )</td>
-    <td>contrast-wcag( $accent )</td>
+<td>
+
+
+`contrast-wcag( $accent )`
+
+</td>
+<td>
+
+`contrast-wcag( $accent )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Deprecated</b><div class="theme-variables-description">Will be removed in v5. Use `$primary-contrast` variable instead.</div></div><div><b>Description</b><div class="theme-variables-description">The color used along with the primary color denoted by $primary.</div></div>
@@ -1097,8 +1934,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$primary</td>
     <td>Color</td>
-    <td>$primary</td>
-    <td>$primary</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.<br />Used for primary buttons and for elements of primary importance across the theme.</div></div>
@@ -1107,8 +1953,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$primary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $primary )</td>
-    <td>contrast-wcag( $primary )</td>
+<td>
+
+
+`contrast-wcag( $primary )`
+
+</td>
+<td>
+
+`contrast-wcag( $primary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the primary color denoted by $primary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1117,8 +1972,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$secondary</td>
     <td>Color</td>
-    <td>$secondary</td>
-    <td>$secondary</td>
+<td>
+
+
+`$secondary`
+
+</td>
+<td>
+
+`$secondary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The secondary color of the theme.</div></div>
@@ -1127,8 +1991,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$secondary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $secondary )</td>
-    <td>contrast-wcag( $secondary )</td>
+<td>
+
+
+`contrast-wcag( $secondary )`
+
+</td>
+<td>
+
+`contrast-wcag( $secondary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the secondary color denoted by $secondary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1137,8 +2010,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tertiary</td>
     <td>Color</td>
-    <td>$purple</td>
-    <td></td>
+<td>
+
+
+`$purple`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tertiary color of the theme.</div></div>
@@ -1147,8 +2029,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tertiary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $tertiary )</td>
-    <td>contrast-wcag( $tertiary )</td>
+<td>
+
+
+`contrast-wcag( $tertiary )`
+
+</td>
+<td>
+
+`contrast-wcag( $tertiary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the tertiary color denoted by $tertiary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1157,8 +2048,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$info</td>
     <td>Color</td>
-    <td>$info</td>
-    <td>$info</td>
+<td>
+
+
+`$info`
+
+</td>
+<td>
+
+`$info`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for informational messages and states.</div></div>
@@ -1167,8 +2067,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$success</td>
     <td>Color</td>
-    <td>$success</td>
-    <td>$success</td>
+<td>
+
+
+`$success`
+
+</td>
+<td>
+
+`$success`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for success messages and states.</div></div>
@@ -1177,8 +2086,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$warning</td>
     <td>Color</td>
-    <td>$warning</td>
-    <td>$warning</td>
+<td>
+
+
+`$warning`
+
+</td>
+<td>
+
+`$warning`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for warning messages and states.</div></div>
@@ -1187,8 +2105,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$error</td>
     <td>Color</td>
-    <td>$danger</td>
-    <td></td>
+<td>
+
+
+`$danger`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for error messages and states.</div></div>
@@ -1197,8 +2124,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$dark</td>
     <td>Color</td>
-    <td>$dark</td>
-    <td>$dark</td>
+<td>
+
+
+`$dark`
+
+</td>
+<td>
+
+`$dark`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The dark color of the theme.</div></div>
@@ -1207,8 +2143,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$light</td>
     <td>Color</td>
-    <td>$light</td>
-    <td>$light</td>
+<td>
+
+
+`$light`
+
+</td>
+<td>
+
+`$light`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The light color of the theme.</div></div>
@@ -1217,8 +2162,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$inverse</td>
     <td></td>
-    <td>if( $dark-theme, $light, $dark )</td>
-    <td>if( $dark-theme, $light, $dark )</td>
+<td>
+
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
+<td>
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Inverse color of the theme. Depending on the theme luminance dark or lught, it will be light or dark</div></div>
@@ -1248,8 +2202,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$component-bg</td>
     <td></td>
-    <td>$body-bg</td>
-    <td></td>
+<td>
+
+
+`$body-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-bg` e.g. `$grid-bg: $component-bg !defualt;`.</div></div>
@@ -1258,8 +2221,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$component-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-text` e.g. `$grid-text: component-text !default;`.</div></div>
@@ -1268,8 +2240,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$component-border</td>
     <td></td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-border` e.g. `$grid-border: component-border !default;`.</div></div>
@@ -1299,8 +2280,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$grid-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the grid component</div></div>
@@ -1309,8 +2299,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the grid component</div></div>
@@ -1319,8 +2318,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the grid component</div></div>
@@ -1329,8 +2337,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-header-bg</td>
     <td></td>
-    <td>$header-bg</td>
-    <td></td>
+<td>
+
+
+`$header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid header</div></div>
@@ -1339,8 +2356,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-header-text</td>
     <td></td>
-    <td>$header-text</td>
-    <td></td>
+<td>
+
+
+`$header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid header</div></div>
@@ -1349,8 +2375,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-header-border</td>
     <td></td>
-    <td>$header-border</td>
-    <td></td>
+<td>
+
+
+`$header-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid header</div></div>
@@ -1359,8 +2394,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-header-gradient</td>
     <td></td>
-    <td>$header-gradient</td>
-    <td></td>
+<td>
+
+
+`$header-gradient`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of grid header</div></div>
@@ -1369,8 +2413,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-footer-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid footer</div></div>
@@ -1379,8 +2432,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-footer-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid footer</div></div>
@@ -1389,8 +2451,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-footer-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td></td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid footer</div></div>
@@ -1399,8 +2470,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-alt-bg</td>
     <td></td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in grid</div></div>
@@ -1409,8 +2489,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-alt-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in grid</div></div>
@@ -1419,8 +2508,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-alt-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in grid</div></div>
@@ -1429,8 +2527,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-hovered-bg</td>
     <td></td>
-    <td>rgba( contrast-wcag( $grid-bg ), .08 )</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .08 )</td>
+<td>
+
+
+`rgba( contrast-wcag( $grid-bg ), .08 )`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in grid</div></div>
@@ -1439,8 +2546,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in grid</div></div>
@@ -1449,8 +2565,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in grid</div></div>
@@ -1459,8 +2584,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-selected-bg</td>
     <td></td>
-    <td>rgba( $selected-bg, .25 )</td>
-    <td>rgba( $selected-bg, .25 )</td>
+<td>
+
+
+`rgba( $selected-bg, .25 )`
+
+</td>
+<td>
+
+`rgba( $selected-bg, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in grid</div></div>
@@ -1469,8 +2603,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-selected-text</td>
     <td></td>
-    <td>$grid-text</td>
-    <td></td>
+<td>
+
+
+`$grid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in grid</div></div>
@@ -1479,8 +2622,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$grid-selected-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in grid</div></div>
@@ -1510,8 +2662,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$icon-font-url</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The URL to the icon font that will be used by the theme<br />The default value of `null` embeds the package font with a `data:` URL</div></div>
@@ -1541,8 +2702,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$list-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the list component.</div></div>
@@ -1551,8 +2721,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the list component.</div></div>
@@ -1561,8 +2740,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of list items.</div></div>
@@ -1571,8 +2759,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of list items.</div></div>
@@ -1581,8 +2778,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the list component.</div></div>
@@ -1591,8 +2797,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the list component.</div></div>
@@ -1601,8 +2816,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the list component.</div></div>
@@ -1611,8 +2835,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-header-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list header.</div></div>
@@ -1621,8 +2854,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-header-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list header.</div></div>
@@ -1631,8 +2873,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-header-border</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of list header.</div></div>
@@ -1641,8 +2892,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-header-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of list header.</div></div>
@@ -1651,8 +2911,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list items.</div></div>
@@ -1661,8 +2930,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-item-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list items.</div></div>
@@ -1671,8 +2949,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>$gray-200</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`$gray-200`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered list items.</div></div>
@@ -1681,8 +2968,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered list items.</div></div>
@@ -1691,8 +2987,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-item-focused-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused list items.</div></div>
@@ -1701,8 +3006,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-item-focused-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused list items.</div></div>
@@ -1711,8 +3025,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-item-focused-shadow</td>
     <td></td>
-    <td>inset 0 0 0 3px rgba( $list-item-text, .15 )</td>
-    <td>inset 0 0 0 3px rgba( $list-item-text, .15 )</td>
+<td>
+
+
+`inset 0 0 0 3px rgba( $list-item-text, .15 )`
+
+</td>
+<td>
+
+`inset 0 0 0 3px rgba( $list-item-text, .15 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused list items.</div></div>
@@ -1721,8 +3044,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected list items.</div></div>
@@ -1731,8 +3063,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected list items.</div></div>
@@ -1741,8 +3082,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$list-no-data-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the 'No Data' text.</div></div>
@@ -1772,8 +3122,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$radio-radius</td>
     <td></td>
-    <td>50%</td>
-    <td>50%</td>
+<td>
+
+
+`50%`
+
+</td>
+<td>
+
+`50%`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of radio button.</div></div>
@@ -1782,8 +3141,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of radio button.</div></div>
@@ -1792,8 +3160,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button.</div></div>
@@ -1802,8 +3179,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-text</td>
     <td></td>
-    <td>$checkbox-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of radio button.</div></div>
@@ -1812,8 +3198,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>contrast-wcag( $input-bg, $gray-400, $gray-600 )</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`contrast-wcag( $input-bg, $gray-400, $gray-600 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of radio button.</div></div>
@@ -1822,8 +3217,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-hovered-bg</td>
     <td></td>
-    <td>$checkbox-hovered-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered radio button.</div></div>
@@ -1832,8 +3236,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-hovered-text</td>
     <td></td>
-    <td>$checkbox-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered radio button.</div></div>
@@ -1842,8 +3255,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-hovered-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered radio button.</div></div>
@@ -1852,8 +3274,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-checked-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked radio button.</div></div>
@@ -1862,8 +3293,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-checked-text</td>
     <td></td>
-    <td>$checkbox-checked-text</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`$checkbox-checked-text`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked radio button.</div></div>
@@ -1872,8 +3312,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked radio button.</div></div>
@@ -1882,8 +3331,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-focused-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused radio button.</div></div>
@@ -1892,8 +3350,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-focused-shadow</td>
     <td></td>
-    <td>$checkbox-focused-shadow</td>
-    <td>0 0 0 .25rem rgba( $primary, .25 )</td>
+<td>
+
+
+`$checkbox-focused-shadow`
+
+</td>
+<td>
+
+`0 0 0 .25rem rgba( $primary, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused radio button.</div></div>
@@ -1902,8 +3369,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-focused-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>$primary</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked radio button.</div></div>
@@ -1912,8 +3388,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-focused-checked-shadow</td>
     <td></td>
-    <td>$checkbox-focused-checked-shadow</td>
-    <td>0 0 0 .25rem rgba( $primary, .25 )</td>
+<td>
+
+
+`$checkbox-focused-checked-shadow`
+
+</td>
+<td>
+
+`0 0 0 .25rem rgba( $primary, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked radio button.</div></div>
@@ -1922,8 +3407,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-disabled-bg</td>
     <td></td>
-    <td>$checkbox-disabled-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled radio button.</div></div>
@@ -1932,8 +3426,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-disabled-text</td>
     <td></td>
-    <td>$checkbox-disabled-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled radio button.</div></div>
@@ -1942,8 +3445,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-disabled-border</td>
     <td></td>
-    <td>$checkbox-disabled-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled radio button.</div></div>
@@ -1952,8 +3464,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-disabled-checked-bg</td>
     <td></td>
-    <td>$checkbox-disabled-checked-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked radio button.</div></div>
@@ -1962,8 +3483,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-disabled-checked-text</td>
     <td></td>
-    <td>$checkbox-disabled-checked-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked radio button.</div></div>
@@ -1972,8 +3502,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-disabled-checked-border</td>
     <td></td>
-    <td>$checkbox-disabled-checked-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked radio button.</div></div>
@@ -1982,8 +3521,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-invalid-bg</td>
     <td></td>
-    <td>$checkbox-invalid-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-invalid-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid radio button.</div></div>
@@ -1992,8 +3540,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-invalid-text</td>
     <td></td>
-    <td>$checkbox-invalid-text</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid radio button.</div></div>
@@ -2002,8 +3559,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-invalid-border</td>
     <td></td>
-    <td>$checkbox-invalid-border</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid radio button.</div></div>
@@ -2012,8 +3578,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of radio button indicator.</div></div>
@@ -2022,8 +3597,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-checked-glyph</td>
     <td></td>
-    <td>"\e308"</td>
-    <td>"\e308"</td>
+<td>
+
+
+`"\e308"`
+
+</td>
+<td>
+
+`"\e308"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of radio button indicator.</div></div>
@@ -2032,8 +3616,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$radio-checked-text}'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$radio-checked-text}'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked radio button indicator.</div></div>
@@ -2042,8 +3635,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-disabled-checked-image</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of disabled and checked radio button indicator.</div></div>
@@ -2052,8 +3654,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal radio button list.</div></div>
@@ -2062,8 +3673,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of radio button list items.</div></div>
@@ -2072,8 +3692,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of radio button list items.</div></div>
@@ -2082,8 +3711,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-ripple-bg</td>
     <td></td>
-    <td>$radio-checked-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$radio-checked-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button ripple.</div></div>
@@ -2092,8 +3730,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$radio-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of radio button ripple.</div></div>
@@ -2123,8 +3770,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$table-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of the table border.</div></div>
@@ -2133,8 +3789,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-cell-vertical-border-width</td>
     <td></td>
-    <td>$grid-cell-vertical-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-vertical-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of vertical border of table cells.</div></div>
@@ -2143,8 +3808,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-cell-horizontal-border-width</td>
     <td></td>
-    <td>$grid-cell-horizontal-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-horizontal-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of horizontal border of table cells.</div></div>
@@ -2153,8 +3827,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>$font-size-base</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`$font-size-base`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font size of the table if no size is specified.</div></div>
@@ -2163,8 +3846,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-cell-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the cells in the table if no size is specified.</div></div>
@@ -2173,8 +3865,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-cell-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the cells in the table if no size is specified.</div></div>
@@ -2183,8 +3884,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-bg</td>
     <td></td>
-    <td>$grid-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tables.</div></div>
@@ -2193,8 +3903,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-text</td>
     <td></td>
-    <td>$grid-text</td>
-    <td></td>
+<td>
+
+
+`$grid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tables.</div></div>
@@ -2203,8 +3922,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tables.</div></div>
@@ -2213,8 +3941,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-header-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table headers.</div></div>
@@ -2223,8 +3960,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-header-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table headers.</div></div>
@@ -2233,8 +3979,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-header-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td></td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table headers.</div></div>
@@ -2243,8 +3998,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-footer-bg</td>
     <td></td>
-    <td>$grid-footer-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table footers.</div></div>
@@ -2253,8 +4017,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-footer-text</td>
     <td></td>
-    <td>$grid-footer-text</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table footers.</div></div>
@@ -2263,8 +4036,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-footer-border</td>
     <td></td>
-    <td>$grid-footer-border</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table footers.</div></div>
@@ -2273,8 +4055,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-group-row-bg</td>
     <td></td>
-    <td>$table-header-bg</td>
-    <td></td>
+<td>
+
+
+`$table-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of group rows in table.</div></div>
@@ -2283,8 +4074,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-group-row-text</td>
     <td></td>
-    <td>$table-header-text</td>
-    <td></td>
+<td>
+
+
+`$table-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of group rows in table.</div></div>
@@ -2293,8 +4093,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-group-row-border</td>
     <td></td>
-    <td>$table-header-border</td>
-    <td></td>
+<td>
+
+
+`$table-header-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of group rows in table.</div></div>
@@ -2303,8 +4112,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-alt-row-bg</td>
     <td></td>
-    <td>$grid-alt-bg</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`$grid-alt-bg`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in table.</div></div>
@@ -2313,8 +4131,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-alt-row-text</td>
     <td></td>
-    <td>$grid-alt-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in table.</div></div>
@@ -2323,8 +4150,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-alt-row-border</td>
     <td></td>
-    <td>$grid-alt-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in table.</div></div>
@@ -2333,8 +4169,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-hover-bg</td>
     <td></td>
-    <td>$grid-hovered-bg</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .08 )</td>
+<td>
+
+
+`$grid-hovered-bg`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in table.</div></div>
@@ -2343,8 +4188,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-hover-text</td>
     <td></td>
-    <td>$grid-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in table.</div></div>
@@ -2353,8 +4207,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-hover-border</td>
     <td></td>
-    <td>$grid-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in table.</div></div>
@@ -2363,8 +4226,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-focus-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused rows in table.</div></div>
@@ -2373,8 +4245,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-focus-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused rows in table.</div></div>
@@ -2383,8 +4264,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused rows in table.</div></div>
@@ -2393,8 +4283,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-focus-shadow</td>
     <td></td>
-    <td>$grid-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$grid-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused rows in table.</div></div>
@@ -2403,8 +4302,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-selected-bg</td>
     <td></td>
-    <td>$grid-selected-bg</td>
-    <td>rgba( $selected-bg, .25 )</td>
+<td>
+
+
+`$grid-selected-bg`
+
+</td>
+<td>
+
+`rgba( $selected-bg, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in table.</div></div>
@@ -2413,8 +4321,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-selected-text</td>
     <td></td>
-    <td>$grid-selected-text</td>
-    <td></td>
+<td>
+
+
+`$grid-selected-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in table.</div></div>
@@ -2423,8 +4340,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$table-selected-border</td>
     <td></td>
-    <td>$grid-selected-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$grid-selected-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in table.</div></div>
@@ -2454,8 +4380,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$tabstrip-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip component</div></div>
@@ -2464,8 +4399,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip component</div></div>
@@ -2474,8 +4418,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip component</div></div>
@@ -2484,8 +4437,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-padding-x</td>
     <td></td>
-    <td>$nav-item-padding-x</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-x`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabs</div></div>
@@ -2494,8 +4456,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-padding-y</td>
     <td></td>
-    <td>$nav-item-padding-y</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-y`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabs</div></div>
@@ -2504,8 +4475,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabs</div></div>
@@ -2514,8 +4494,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-border-radius</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of tabs</div></div>
@@ -2524,8 +4513,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-gap</td>
     <td></td>
-    <td>$nav-item-margin</td>
-    <td></td>
+<td>
+
+
+`$nav-item-margin`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between tabs</div></div>
@@ -2534,8 +4532,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabs</div></div>
@@ -2544,8 +4551,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-text</td>
     <td></td>
-    <td>$link-text</td>
-    <td></td>
+<td>
+
+
+`$link-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabs</div></div>
@@ -2554,8 +4570,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabs</div></div>
@@ -2564,8 +4589,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of tabs</div></div>
@@ -2574,8 +4608,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered tabs</div></div>
@@ -2584,8 +4627,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-hovered-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered tabs</div></div>
@@ -2594,8 +4646,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-hovered-border</td>
     <td></td>
-    <td>$gray-200</td>
-    <td></td>
+<td>
+
+
+`$gray-200`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered tabs</div></div>
@@ -2604,8 +4665,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered tabs</div></div>
@@ -2614,8 +4684,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-selected-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected tabs</div></div>
@@ -2624,8 +4703,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-selected-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected tabs</div></div>
@@ -2634,8 +4722,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-selected-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected tabs</div></div>
@@ -2644,8 +4741,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected tabs</div></div>
@@ -2654,8 +4760,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-content-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabstrip content</div></div>
@@ -2664,8 +4779,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-content-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabstrip content</div></div>
@@ -2674,8 +4798,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-content-border-width</td>
     <td></td>
-    <td>$tabstrip-border-width</td>
-    <td></td>
+<td>
+
+
+`$tabstrip-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabstrip content</div></div>
@@ -2684,8 +4817,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-content-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip content</div></div>
@@ -2694,8 +4836,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-content-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip content</div></div>
@@ -2704,8 +4855,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-content-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>contrast-wcag( $component-bg, $gray-300, $gray-700 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip content</div></div>
@@ -2714,8 +4874,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$tabstrip-content-border-focused</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip focused content</div></div>
@@ -2745,8 +4914,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$toolbar-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the container.</div></div>
@@ -2755,8 +4933,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$toolbar-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the container.</div></div>
@@ -2786,8 +4973,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$treeview-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>$font-family-sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`$font-family-sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the treeview component.</div></div>
@@ -2796,8 +4992,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the treeview component.</div></div>
@@ -2806,8 +5011,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the treeview component.</div></div>
@@ -2816,8 +5030,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-indent</td>
     <td></td>
-    <td>16px</td>
-    <td>16px</td>
+<td>
+
+
+`16px`
+
+</td>
+<td>
+
+`16px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Indentation of child groups in treeview component.</div></div>
@@ -2826,8 +5049,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 3 )</td>
-    <td>map-get( $spacing, 3 )</td>
+<td>
+
+
+`map-get( $spacing, 3 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of treeview items.</div></div>
@@ -2836,8 +5068,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of treeview items.</div></div>
@@ -2846,8 +5087,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of treeview items.</div></div>
@@ -2856,8 +5106,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-border-radius</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of treeview items.</div></div>
@@ -2866,8 +5125,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the treeview component.</div></div>
@@ -2876,8 +5144,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the treeview component.</div></div>
@@ -2886,8 +5163,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the treeview component.</div></div>
@@ -2896,8 +5182,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>$gray-200</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`$gray-200`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered treeview items.</div></div>
@@ -2906,8 +5201,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered treeview items.</div></div>
@@ -2916,8 +5220,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-hovered-border</td>
     <td></td>
-    <td>$treeview-item-hovered-bg</td>
-    <td>$gray-200</td>
+<td>
+
+
+`$treeview-item-hovered-bg`
+
+</td>
+<td>
+
+`$gray-200`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered treeview items.</div></div>
@@ -2926,8 +5239,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered treeview items.</div></div>
@@ -2936,8 +5258,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected treeview items.</div></div>
@@ -2946,8 +5277,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected treeview items.</div></div>
@@ -2956,8 +5296,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-selected-border</td>
     <td></td>
-    <td>$treeview-item-selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$treeview-item-selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected treeview items.</div></div>
@@ -2966,8 +5315,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected treeview items.</div></div>
@@ -2976,8 +5334,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-item-focused-shadow</td>
     <td></td>
-    <td>inset 0 0 0 2px rgba( $treeview-text, .15 )</td>
-    <td>inset 0 0 0 2px rgba( $treeview-text, .15 )</td>
+<td>
+
+
+`inset 0 0 0 2px rgba( $treeview-text, .15 )`
+
+</td>
+<td>
+
+`inset 0 0 0 2px rgba( $treeview-text, .15 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused treeview items.</div></div>
@@ -2986,8 +5353,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-loadmore-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of load more.</div></div>
@@ -2996,8 +5372,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-loadmore-text</td>
     <td></td>
-    <td>$link-text</td>
-    <td></td>
+<td>
+
+
+`$link-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of load more.</div></div>
@@ -3006,8 +5391,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-loadmore-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of load more.</div></div>
@@ -3016,8 +5410,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-loadmore-hover-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a hovered load more.</div></div>
@@ -3026,8 +5429,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-loadmore-hover-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a hovered load more.</div></div>
@@ -3036,8 +5448,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-loadmore-hover-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a hovered load more.</div></div>
@@ -3046,8 +5467,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-loadmore-focus-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a focused load more.</div></div>
@@ -3056,8 +5486,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-loadmore-focus-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a focused load more.</div></div>
@@ -3066,8 +5505,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-loadmore-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a focused load more.</div></div>
@@ -3076,8 +5524,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$treeview-loadmore-focus-shadow</td>
     <td></td>
-    <td>$treeview-item-focused-shadow</td>
-    <td>inset 0 0 0 2px rgba( $treeview-text, .15 )</td>
+<td>
+
+
+`$treeview-item-focused-shadow`
+
+</td>
+<td>
+
+`inset 0 0 0 2px rgba( $treeview-text, .15 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of a focused load more.</div></div>
@@ -3107,8 +5564,17 @@ The following table lists the available variables for customizing the Bootstrap 
         <tr>
     <td>$enable-typography</td>
     <td></td>
-    <td>false</td>
-    <td>false</td>
+<td>
+
+
+`false`
+
+</td>
+<td>
+
+`false`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Global typography styles for the Kendo Bootstrap theme.</div></div>
@@ -3117,8 +5583,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$font-size</td>
     <td></td>
-    <td>$font-size-base</td>
-    <td></td>
+<td>
+
+
+`$font-size-base`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Base font size across all components.</div></div>
@@ -3127,8 +5602,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$font-family</td>
     <td></td>
-    <td>$font-family-sans-serif</td>
-    <td></td>
+<td>
+
+
+`$font-family-sans-serif`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family across all components.</div></div>
@@ -3137,8 +5621,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$font-family-monospace</td>
     <td></td>
-    <td>$font-family-monospace</td>
-    <td>$font-family-monospace</td>
+<td>
+
+
+`$font-family-monospace`
+
+</td>
+<td>
+
+`$font-family-monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family for monospaced text. Used for styling the code.</div></div>
@@ -3147,8 +5640,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$line-height</td>
     <td></td>
-    <td>$line-height-base</td>
-    <td></td>
+<td>
+
+
+`$line-height-base`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>

--- a/packages/classic/docs/customization-avatar.md
+++ b/packages/classic/docs/customization-avatar.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$avatar-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of the avatar.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the avatar.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the avatar.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the avatar.</div></div>
@@ -68,16 +104,25 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-sizes</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sizes of the avatar.</div></div>
@@ -86,8 +131,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-theme-colors</td>
     <td></td>
-    <td>$theme-colors</td>
-    <td></td>
+<td>
+
+
+`$theme-colors`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Theme colors map of the avatar.</div></div>

--- a/packages/classic/docs/customization-button.md
+++ b/packages/classic/docs/customization-button.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$button-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of the border around the button.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of the button.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of the button.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of the button.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the button.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the button.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated height of the button.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-inner-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated inner height of the button. Without the border width.</div></div>
@@ -118,7 +199,10 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-theme-colors</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -129,8 +213,12 @@ The following table lists the available variables for customization.
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -141,7 +229,9 @@ The following table lists the available variables for customization.
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Theme colors map for the button.</div></div>
@@ -150,8 +240,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-bg</td>
     <td></td>
-    <td>$base-bg</td>
-    <td><span class="color-preview" style="background-color: #f0f0f0"></span>#f0f0f0</td>
+<td>
+
+
+`$base-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the buttons.</div></div>
@@ -160,8 +259,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td>$body-text</td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+`$body-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the buttons.</div></div>
@@ -170,8 +278,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-border</td>
     <td></td>
-    <td>try-shade( $button-bg, 2 )</td>
-    <td>try-shade( $button-bg, 2 )</td>
+<td>
+
+
+`try-shade( $button-bg, 2 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the buttons.</div></div>
@@ -180,8 +297,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of the buttons.</div></div>
@@ -190,8 +316,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, 1 )</td>
-    <td>try-shade( $button-bg, 1 )</td>
+<td>
+
+
+`try-shade( $button-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered buttons.</div></div>
@@ -200,8 +335,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered buttons.</div></div>
@@ -210,8 +354,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-border</td>
     <td></td>
-    <td>try-shade( $button-bg, 3 )</td>
-    <td>try-shade( $button-bg, 3 )</td>
+<td>
+
+
+`try-shade( $button-bg, 3 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered buttons.</div></div>
@@ -220,8 +373,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of hovered buttons.</div></div>
@@ -230,8 +392,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, 2 )</td>
-    <td>try-shade( $button-bg, 2 )</td>
+<td>
+
+
+`try-shade( $button-bg, 2 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of active buttons.</div></div>
@@ -240,8 +411,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of active buttons.</div></div>
@@ -250,8 +430,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-border</td>
     <td></td>
-    <td>try-shade( $button-bg, 4 )</td>
-    <td>try-shade( $button-bg, 4 )</td>
+<td>
+
+
+`try-shade( $button-bg, 4 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of active buttons.</div></div>
@@ -260,8 +449,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of active buttons.</div></div>
@@ -270,8 +468,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-bg</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>try-shade( $button-bg, 2 )</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of selected buttons.</div></div>
@@ -280,8 +487,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-text</td>
     <td></td>
-    <td>$button-active-text</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected buttons.</div></div>
@@ -290,8 +506,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-border</td>
     <td></td>
-    <td>$button-active-border</td>
-    <td>try-shade( $button-bg, 4 )</td>
+<td>
+
+
+`$button-active-border`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected buttons.</div></div>
@@ -300,8 +525,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of selected buttons.</div></div>
@@ -310,8 +544,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-focused-shadow</td>
     <td></td>
-    <td>0 0 4px 0 rgba( $button-border, .75 )</td>
-    <td>0 0 4px 0 rgba( $button-border, .75 )</td>
+<td>
+
+
+`0 0 4px 0 rgba( $button-border, .75 )`
+
+</td>
+<td>
+
+`0 0 4px 0 rgba( $button-border, .75 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The shadow of focused buttons.</div></div>

--- a/packages/classic/docs/customization-charts.md
+++ b/packages/classic/docs/customization-charts.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$series-a</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The first base series color and its light and dark shades.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-b</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ffd246"></span>#ffd246</td>
-    <td><span class="color-preview" style="background-color: #ffd246"></span>#ffd246</td>
+<td>
+<span class="color-preview" style="background-color: #ffd246"></span>
+
+`#ffd246`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffd246"></span>
+
+`#ffd246`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The second base series color and its light and dark shades.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-c</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #78d237"></span>#78d237</td>
-    <td><span class="color-preview" style="background-color: #78d237"></span>#78d237</td>
+<td>
+<span class="color-preview" style="background-color: #78d237"></span>
+
+`#78d237`
+
+</td>
+<td><span class="color-preview" style="background-color: #78d237"></span>
+
+`#78d237`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The third base series color and its light and dark shades.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-d</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #28b4c8"></span>#28b4c8</td>
-    <td><span class="color-preview" style="background-color: #28b4c8"></span>#28b4c8</td>
+<td>
+<span class="color-preview" style="background-color: #28b4c8"></span>
+
+`#28b4c8`
+
+</td>
+<td><span class="color-preview" style="background-color: #28b4c8"></span>
+
+`#28b4c8`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fourth base series color and its light and dark shades.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-e</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #2d73f5"></span>#2d73f5</td>
-    <td><span class="color-preview" style="background-color: #2d73f5"></span>#2d73f5</td>
+<td>
+<span class="color-preview" style="background-color: #2d73f5"></span>
+
+`#2d73f5`
+
+</td>
+<td><span class="color-preview" style="background-color: #2d73f5"></span>
+
+`#2d73f5`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fifth base series color and its light and dark shades.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-f</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #aa46be"></span>#aa46be</td>
-    <td><span class="color-preview" style="background-color: #aa46be"></span>#aa46be</td>
+<td>
+<span class="color-preview" style="background-color: #aa46be"></span>
+
+`#aa46be`
+
+</td>
+<td><span class="color-preview" style="background-color: #aa46be"></span>
+
+`#aa46be`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sixth base series color and its light and dark shades.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-1</td>
     <td></td>
-    <td>$series-a</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$series-a`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The series colors in order:<br />base, light, dark, lighter, darker</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$chart-major-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (major).</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$chart-minor-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (minor).</div></div>

--- a/packages/classic/docs/customization-checkbox.md
+++ b/packages/classic/docs/customization-checkbox.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$checkbox-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of checkbox.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checkbox.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>$base-border</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`$base-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checkbox.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered checkbox.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered checkbox.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered checkbox.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked checkbox.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-text</td>
     <td></td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked checkbox.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked checkbox.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of indeterminate checkbox.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-text</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of indeterminate checkbox.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>$base-border</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`$base-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of indeterminate checkbox.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused checkbox.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-shadow</td>
     <td></td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
+<td>
+
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
+<td>
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused checkbox.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked checkbox.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-checked-shadow</td>
     <td></td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
+<td>
+
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
+<td>
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked checkbox.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled checkbox.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled checkbox.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled checkbox.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked checkbox.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked checkbox.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked checkbox.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid checkbox.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-text</td>
     <td></td>
-    <td>$invalid-text</td>
-    <td></td>
+<td>
+
+
+`$invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid checkbox.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-border</td>
     <td></td>
-    <td>$invalid-border</td>
-    <td></td>
+<td>
+
+
+`$invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid checkbox.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of checkbox indicator.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-glyph-font-family</td>
     <td></td>
-    <td>"WebComponentsIcons", monospace</td>
-    <td>"WebComponentsIcons", monospace</td>
+<td>
+
+
+`"WebComponentsIcons", monospace`
+
+</td>
+<td>
+
+`"WebComponentsIcons", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph font family of checkbox indicator.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-glyph</td>
     <td></td>
-    <td>"\e118"</td>
-    <td>"\e118"</td>
+<td>
+
+
+`"\e118"`
+
+</td>
+<td>
+
+`"\e118"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of checkbox indicator.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-glyph</td>
     <td></td>
-    <td>"\e121"</td>
-    <td>"\e121"</td>
+<td>
+
+
+`"\e121"`
+
+</td>
+<td>
+
+`"\e121"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of indeterminate checkbox indicator.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -338,8 +617,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image image of checked checkbox indicator.</div></div>
@@ -348,8 +636,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal checkbox list.</div></div>
@@ -358,8 +655,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of checkbox list items.</div></div>
@@ -368,8 +674,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of checkbox list items.</div></div>
@@ -378,8 +693,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-ripple-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox ripple.</div></div>
@@ -388,8 +712,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of checkbox ripple.</div></div>

--- a/packages/classic/docs/customization-color-system.md
+++ b/packages/classic/docs/customization-color-system.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$primary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+<span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.<br />Used for primary buttons and for elements of primary importance across the theme.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$primary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $primary )</td>
-    <td>contrast-wcag( $primary )</td>
+<td>
+
+
+`contrast-wcag( $primary )`
+
+</td>
+<td>
+
+`contrast-wcag( $primary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the primary color denoted by $primary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$secondary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #e9e9e9"></span>#e9e9e9</td>
-    <td><span class="color-preview" style="background-color: #e9e9e9"></span>#e9e9e9</td>
+<td>
+<span class="color-preview" style="background-color: #e9e9e9"></span>
+
+`#e9e9e9`
+
+</td>
+<td><span class="color-preview" style="background-color: #e9e9e9"></span>
+
+`#e9e9e9`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The secondary color of the theme.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$secondary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $secondary )</td>
-    <td>contrast-wcag( $secondary )</td>
+<td>
+
+
+`contrast-wcag( $secondary )`
+
+</td>
+<td>
+
+`contrast-wcag( $secondary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the secondary color denoted by $secondary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tertiary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
+<td>
+<span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
+<td><span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tertiary color of the theme.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tertiary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $tertiary )</td>
-    <td>contrast-wcag( $tertiary )</td>
+<td>
+
+
+`contrast-wcag( $tertiary )`
+
+</td>
+<td>
+
+`contrast-wcag( $tertiary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the tertiary color denoted by $tertiary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$info</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #2498bc"></span>#2498bc</td>
-    <td><span class="color-preview" style="background-color: #2498bc"></span>#2498bc</td>
+<td>
+<span class="color-preview" style="background-color: #2498bc"></span>
+
+`#2498bc`
+
+</td>
+<td><span class="color-preview" style="background-color: #2498bc"></span>
+
+`#2498bc`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for informational messages and states.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$success</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #3ea44e"></span>#3ea44e</td>
-    <td><span class="color-preview" style="background-color: #3ea44e"></span>#3ea44e</td>
+<td>
+<span class="color-preview" style="background-color: #3ea44e"></span>
+
+`#3ea44e`
+
+</td>
+<td><span class="color-preview" style="background-color: #3ea44e"></span>
+
+`#3ea44e`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for success messages and states.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$warning</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ff9800"></span>#ff9800</td>
-    <td><span class="color-preview" style="background-color: #ff9800"></span>#ff9800</td>
+<td>
+<span class="color-preview" style="background-color: #ff9800"></span>
+
+`#ff9800`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff9800"></span>
+
+`#ff9800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for warning messages and states.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$error</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #d92800"></span>#d92800</td>
-    <td><span class="color-preview" style="background-color: #d92800"></span>#d92800</td>
+<td>
+<span class="color-preview" style="background-color: #d92800"></span>
+
+`#d92800`
+
+</td>
+<td><span class="color-preview" style="background-color: #d92800"></span>
+
+`#d92800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for error messages and states.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dark</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #404040"></span>#404040</td>
-    <td><span class="color-preview" style="background-color: #404040"></span>#404040</td>
+<td>
+<span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
+
+</td>
+<td><span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The dark color of the theme.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$light</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
+<td>
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
+<td><span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The light color of the theme.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$inverse</td>
     <td></td>
-    <td>if( $dark-theme, $light, $dark )</td>
-    <td>if( $dark-theme, $light, $dark )</td>
+<td>
+
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
+<td>
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Inverse color of the theme. Depending on the theme luminance dark or light, it will be light or dark</div></div>

--- a/packages/classic/docs/customization-common.md
+++ b/packages/classic/docs/customization-common.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$border-radius</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius for all components.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-bg</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #f0f0f0"></span>#f0f0f0</td>
-    <td><span class="color-preview" style="background-color: #f0f0f0"></span>#f0f0f0</td>
+<td>
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
+
+</td>
+<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the components' chrome area.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the components' chrome area.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-border</td>
     <td></td>
-    <td>try-shade( $base-bg, 2 )</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`try-shade( $base-bg, 2 )`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the components' chrome area.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-gradient</td>
     <td></td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
+<td>
+
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
+<td>
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of the components' chrome area.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-bg</td>
     <td></td>
-    <td>try-shade( $base-bg, 1 )</td>
-    <td>try-shade( $base-bg, 1 )</td>
+<td>
+
+
+`try-shade( $base-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered items.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td></td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered items.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-border</td>
     <td></td>
-    <td>try-shade( $hovered-bg, 2 )</td>
-    <td>try-shade( $hovered-bg, 2 )</td>
+<td>
+
+
+`try-shade( $hovered-bg, 2 )`
+
+</td>
+<td>
+
+`try-shade( $hovered-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered items.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of hovered items.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of selected items.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-text</td>
     <td></td>
-    <td>contrast-wcag( $selected-bg )</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`contrast-wcag( $selected-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected items.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-border</td>
     <td></td>
-    <td>try-shade( $selected-bg, 2 )</td>
-    <td>try-shade( $selected-bg, 2 )</td>
+<td>
+
+
+`try-shade( $selected-bg, 2 )`
+
+</td>
+<td>
+
+`try-shade( $selected-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of selected items.</div></div>

--- a/packages/classic/docs/customization-component.md
+++ b/packages/classic/docs/customization-component.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$component-bg</td>
     <td></td>
-    <td>$body-bg</td>
-    <td></td>
+<td>
+
+
+`$body-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-bg` e.g. `$grid-bg: $component-bg !defualt;`.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$component-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-text` e.g. `$grid-text: component-text !default;`.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$component-border</td>
     <td></td>
-    <td>$base-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$base-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-border` e.g. `$grid-border: component-border !default;`.</div></div>

--- a/packages/classic/docs/customization-grid.md
+++ b/packages/classic/docs/customization-grid.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$grid-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the grid component</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the grid component</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the grid component</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-bg</td>
     <td></td>
-    <td>$header-bg</td>
-    <td></td>
+<td>
+
+
+`$header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid header</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-text</td>
     <td></td>
-    <td>$header-text</td>
-    <td></td>
+<td>
+
+
+`$header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid header</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid header</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-gradient</td>
     <td></td>
-    <td>$header-gradient</td>
-    <td></td>
+<td>
+
+
+`$header-gradient`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of grid header</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid footer</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid footer</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid footer</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-bg</td>
     <td></td>
-    <td>try-shade( $grid-bg, .5 )</td>
-    <td>try-shade( $grid-bg, .5 )</td>
+<td>
+
+
+`try-shade( $grid-bg, .5 )`
+
+</td>
+<td>
+
+`try-shade( $grid-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in grid</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in grid</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in grid</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-bg</td>
     <td></td>
-    <td>try-shade( $grid-bg, 1 )</td>
-    <td>try-shade( $grid-bg, 1 )</td>
+<td>
+
+
+`try-shade( $grid-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $grid-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in grid</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in grid</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in grid</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-bg</td>
     <td></td>
-    <td>rgba( $selected-bg, .25 )</td>
-    <td>rgba( $selected-bg, .25 )</td>
+<td>
+
+
+`rgba( $selected-bg, .25 )`
+
+</td>
+<td>
+
+`rgba( $selected-bg, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in grid</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in grid</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in grid</div></div>

--- a/packages/classic/docs/customization-icons.md
+++ b/packages/classic/docs/customization-icons.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$icon-font-url</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The URL to the icon font that will be used by the theme<br />The default value of `null` embeds the package font with a `data:` URL</div></div>

--- a/packages/classic/docs/customization-list.md
+++ b/packages/classic/docs/customization-list.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$list-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the list component.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the list component.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of list items.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of list items.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the list component.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the list component.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the list component.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list header.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list header.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-border</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of list header.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of list header.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list items.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>try-shade( $base-bg, 1 )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered list items.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered list items.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused list items.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused list items.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-shadow</td>
     <td></td>
-    <td>inset 0 0 0 2px rgba(0, 0, 0, .12)</td>
-    <td>inset 0 0 0 2px rgba(0, 0, 0, .12)</td>
+<td>
+
+
+`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+
+</td>
+<td>
+
+`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused list items.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected list items.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected list items.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-no-data-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the 'No Data' text.</div></div>

--- a/packages/classic/docs/customization-radio.md
+++ b/packages/classic/docs/customization-radio.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$radio-radius</td>
     <td></td>
-    <td>50%</td>
-    <td>50%</td>
+<td>
+
+
+`50%`
+
+</td>
+<td>
+
+`50%`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of radio button.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of radio button.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-text</td>
     <td></td>
-    <td>$checkbox-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of radio button.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>$base-border</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`$base-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of radio button.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-bg</td>
     <td></td>
-    <td>$checkbox-hovered-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered radio button.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-text</td>
     <td></td>
-    <td>$checkbox-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered radio button.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered radio button.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked radio button.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-text</td>
     <td></td>
-    <td>$checkbox-checked-text</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`$checkbox-checked-text`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked radio button.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked radio button.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused radio button.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-shadow</td>
     <td></td>
-    <td>$checkbox-focused-shadow</td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
+<td>
+
+
+`$checkbox-focused-shadow`
+
+</td>
+<td>
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused radio button.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked radio button.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-checked-shadow</td>
     <td></td>
-    <td>$checkbox-focused-checked-shadow</td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
+<td>
+
+
+`$checkbox-focused-checked-shadow`
+
+</td>
+<td>
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked radio button.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-bg</td>
     <td></td>
-    <td>$checkbox-disabled-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled radio button.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-text</td>
     <td></td>
-    <td>$checkbox-disabled-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled radio button.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-border</td>
     <td></td>
-    <td>$checkbox-disabled-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled radio button.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-bg</td>
     <td></td>
-    <td>$checkbox-disabled-checked-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked radio button.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-text</td>
     <td></td>
-    <td>$checkbox-disabled-checked-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked radio button.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-border</td>
     <td></td>
-    <td>$checkbox-disabled-checked-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked radio button.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-bg</td>
     <td></td>
-    <td>$checkbox-invalid-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-invalid-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid radio button.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-text</td>
     <td></td>
-    <td>$checkbox-invalid-text</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid radio button.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-border</td>
     <td></td>
-    <td>$checkbox-invalid-border</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid radio button.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of radio button indicator.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-glyph</td>
     <td></td>
-    <td>"\e308"</td>
-    <td>"\e308"</td>
+<td>
+
+
+`"\e308"`
+
+</td>
+<td>
+
+`"\e308"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of radio button indicator.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked radio button indicator.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-image</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of disabled and checked radio button indicator.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal radio button list.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of radio button list items.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of radio button list items.</div></div>
@@ -338,8 +617,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-ripple-bg</td>
     <td></td>
-    <td>$radio-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$radio-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button ripple.</div></div>
@@ -348,8 +636,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of radio button ripple.</div></div>

--- a/packages/classic/docs/customization-table.md
+++ b/packages/classic/docs/customization-table.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$table-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of the table border.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-vertical-border-width</td>
     <td></td>
-    <td>$grid-cell-vertical-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-vertical-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of vertical border of table cells.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-horizontal-border-width</td>
     <td></td>
-    <td>$grid-cell-horizontal-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-horizontal-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of horizontal border of table cells.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font size of the table if no size is specified.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the cells in the table if no size is specified.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the cells in the table if no size is specified.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-bg</td>
     <td></td>
-    <td>$grid-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tables.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-text</td>
     <td></td>
-    <td>$grid-text</td>
-    <td></td>
+<td>
+
+
+`$grid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tables.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tables.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table headers.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table headers.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table headers.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-bg</td>
     <td></td>
-    <td>$grid-footer-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table footers.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-text</td>
     <td></td>
-    <td>$grid-footer-text</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table footers.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-border</td>
     <td></td>
-    <td>$grid-footer-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$grid-footer-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table footers.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-bg</td>
     <td></td>
-    <td>$table-header-bg</td>
-    <td></td>
+<td>
+
+
+`$table-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of group rows in table.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-text</td>
     <td></td>
-    <td>$table-header-text</td>
-    <td></td>
+<td>
+
+
+`$table-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of group rows in table.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-border</td>
     <td></td>
-    <td>$table-header-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$table-header-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of group rows in table.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-bg</td>
     <td></td>
-    <td>$grid-alt-bg</td>
-    <td>try-shade( $grid-bg, .5 )</td>
+<td>
+
+
+`$grid-alt-bg`
+
+</td>
+<td>
+
+`try-shade( $grid-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in table.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-text</td>
     <td></td>
-    <td>$grid-alt-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in table.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-border</td>
     <td></td>
-    <td>$grid-alt-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in table.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-bg</td>
     <td></td>
-    <td>$grid-hovered-bg</td>
-    <td>try-shade( $grid-bg, 1 )</td>
+<td>
+
+
+`$grid-hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $grid-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in table.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-text</td>
     <td></td>
-    <td>$grid-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in table.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-border</td>
     <td></td>
-    <td>$grid-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in table.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused rows in table.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused rows in table.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused rows in table.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-shadow</td>
     <td></td>
-    <td>$grid-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$grid-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused rows in table.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-bg</td>
     <td></td>
-    <td>$grid-selected-bg</td>
-    <td>rgba( $selected-bg, .25 )</td>
+<td>
+
+
+`$grid-selected-bg`
+
+</td>
+<td>
+
+`rgba( $selected-bg, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in table.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-text</td>
     <td></td>
-    <td>$grid-selected-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-selected-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in table.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-border</td>
     <td></td>
-    <td>$grid-selected-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-selected-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in table.</div></div>

--- a/packages/classic/docs/customization-tabstrip.md
+++ b/packages/classic/docs/customization-tabstrip.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$tabstrip-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip component</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip component</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip component</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-padding-x</td>
     <td></td>
-    <td>$nav-item-padding-x</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-x`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabs</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-padding-y</td>
     <td></td>
-    <td>$nav-item-padding-y</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-y`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabs</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabs</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of tabs</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-gap</td>
     <td></td>
-    <td>$nav-item-margin</td>
-    <td></td>
+<td>
+
+
+`$nav-item-margin`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between tabs</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-bg</td>
     <td></td>
-    <td>$base-bg</td>
-    <td><span class="color-preview" style="background-color: #f0f0f0"></span>#f0f0f0</td>
+<td>
+
+
+`$base-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabs</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td>$body-text</td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+`$body-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabs</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border</td>
     <td></td>
-    <td>$base-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$base-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabs</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of tabs</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>try-shade( $base-bg, 1 )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered tabs</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered tabs</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-border</td>
     <td></td>
-    <td>$hovered-border</td>
-    <td>try-shade( $hovered-bg, 2 )</td>
+<td>
+
+
+`$hovered-border`
+
+</td>
+<td>
+
+`try-shade( $hovered-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered tabs</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered tabs</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected tabs</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected tabs</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected tabs</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
     <td></td>
-    <td>false</td>
-    <td>false</td>
+<td>
+
+
+`false`
+
+</td>
+<td>
+
+`false`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected tabs</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabstrip content</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabstrip content</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabstrip content</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip content</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip content</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip content</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border-focused</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip focused content</div></div>

--- a/packages/classic/docs/customization-toolbar.md
+++ b/packages/classic/docs/customization-toolbar.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$toolbar-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the container.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$toolbar-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the container.</div></div>

--- a/packages/classic/docs/customization-treeview.md
+++ b/packages/classic/docs/customization-treeview.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$treeview-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the treeview component.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the treeview component.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the treeview component.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-indent</td>
     <td></td>
-    <td>16px</td>
-    <td>16px</td>
+<td>
+
+
+`16px`
+
+</td>
+<td>
+
+`16px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Indentation of child groups in treeview component.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of treeview items.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of treeview items.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of treeview items.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of treeview items.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the treeview component.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the treeview component.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the treeview component.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>try-shade( $base-bg, 1 )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered treeview items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered treeview items.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-border</td>
     <td></td>
-    <td>$hovered-border</td>
-    <td>try-shade( $hovered-bg, 2 )</td>
+<td>
+
+
+`$hovered-border`
+
+</td>
+<td>
+
+`try-shade( $hovered-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered treeview items.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-gradient</td>
     <td></td>
-    <td>$hovered-gradient</td>
-    <td>$base-gradient</td>
+<td>
+
+
+`$hovered-gradient`
+
+</td>
+<td>
+
+`$base-gradient`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered treeview items.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected treeview items.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected treeview items.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-border</td>
     <td></td>
-    <td>$selected-border</td>
-    <td>try-shade( $selected-bg, 2 )</td>
+<td>
+
+
+`$selected-border`
+
+</td>
+<td>
+
+`try-shade( $selected-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected treeview items.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-gradient</td>
     <td></td>
-    <td>$selected-gradient</td>
-    <td>$base-gradient</td>
+<td>
+
+
+`$selected-gradient`
+
+</td>
+<td>
+
+`$base-gradient`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected treeview items.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-focused-shadow</td>
     <td></td>
-    <td>$focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused treeview items.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of load more.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-text</td>
     <td></td>
-    <td>$link-text</td>
-    <td></td>
+<td>
+
+
+`$link-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of load more.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of load more.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a hovered load more.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a hovered load more.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a hovered load more.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a focused load more.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a focused load more.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a focused load more.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-shadow</td>
     <td></td>
-    <td>$treeview-item-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$treeview-item-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of a focused load more.</div></div>

--- a/packages/classic/docs/customization-typography.md
+++ b/packages/classic/docs/customization-typography.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$enable-typography</td>
     <td></td>
-    <td>false</td>
-    <td>false</td>
+<td>
+
+
+`false`
+
+</td>
+<td>
+
+`false`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Global typography styles for the Kendo Classic theme.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-size</td>
     <td></td>
-    <td>14px</td>
-    <td>14px</td>
+<td>
+
+
+`14px`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Base font size across all components.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-family</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family across all components.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-family-monospace</td>
     <td></td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
+<td>
+
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
+<td>
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family for monospaced text. Used for styling the code.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$line-height</td>
     <td></td>
-    <td>(20 / 14)</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`(20 / 14)`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>

--- a/packages/classic/docs/customization.md
+++ b/packages/classic/docs/customization.md
@@ -32,8 +32,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$border-radius</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius for all components.</div></div>
@@ -42,8 +51,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$base-bg</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #f0f0f0"></span>#f0f0f0</td>
-    <td><span class="color-preview" style="background-color: #f0f0f0"></span>#f0f0f0</td>
+<td>
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
+
+</td>
+<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the components' chrome area.</div></div>
@@ -52,8 +70,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$base-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the components' chrome area.</div></div>
@@ -62,8 +89,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$base-border</td>
     <td></td>
-    <td>try-shade( $base-bg, 2 )</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`try-shade( $base-bg, 2 )`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the components' chrome area.</div></div>
@@ -72,8 +108,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$base-gradient</td>
     <td></td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
+<td>
+
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
+<td>
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of the components' chrome area.</div></div>
@@ -82,8 +127,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$hovered-bg</td>
     <td></td>
-    <td>try-shade( $base-bg, 1 )</td>
-    <td>try-shade( $base-bg, 1 )</td>
+<td>
+
+
+`try-shade( $base-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered items.</div></div>
@@ -92,8 +146,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$hovered-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td></td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered items.</div></div>
@@ -102,8 +165,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$hovered-border</td>
     <td></td>
-    <td>try-shade( $hovered-bg, 2 )</td>
-    <td>try-shade( $hovered-bg, 2 )</td>
+<td>
+
+
+`try-shade( $hovered-bg, 2 )`
+
+</td>
+<td>
+
+`try-shade( $hovered-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered items.</div></div>
@@ -112,8 +184,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$hovered-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of hovered items.</div></div>
@@ -122,8 +203,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$selected-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of selected items.</div></div>
@@ -132,8 +222,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$selected-text</td>
     <td></td>
-    <td>contrast-wcag( $selected-bg )</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`contrast-wcag( $selected-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected items.</div></div>
@@ -142,8 +241,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$selected-border</td>
     <td></td>
-    <td>try-shade( $selected-bg, 2 )</td>
-    <td>try-shade( $selected-bg, 2 )</td>
+<td>
+
+
+`try-shade( $selected-bg, 2 )`
+
+</td>
+<td>
+
+`try-shade( $selected-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected items.</div></div>
@@ -152,8 +260,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$selected-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of selected items.</div></div>
@@ -183,8 +300,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$avatar-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of the avatar.</div></div>
@@ -193,8 +319,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$avatar-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the avatar.</div></div>
@@ -203,8 +338,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$avatar-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the avatar.</div></div>
@@ -213,8 +357,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$avatar-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the avatar.</div></div>
@@ -223,16 +376,25 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$avatar-sizes</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sizes of the avatar.</div></div>
@@ -241,8 +403,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$avatar-theme-colors</td>
     <td></td>
-    <td>$theme-colors</td>
-    <td></td>
+<td>
+
+
+`$theme-colors`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Theme colors map of the avatar.</div></div>
@@ -272,8 +443,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$button-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of the border around the button.</div></div>
@@ -282,8 +462,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of the button.</div></div>
@@ -292,8 +481,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of the button.</div></div>
@@ -302,8 +500,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of the button.</div></div>
@@ -312,8 +519,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the button.</div></div>
@@ -322,8 +538,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the button.</div></div>
@@ -332,8 +557,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>
@@ -342,8 +576,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated height of the button.</div></div>
@@ -352,8 +595,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-inner-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated inner height of the button. Without the border width.</div></div>
@@ -362,7 +614,10 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-theme-colors</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -373,8 +628,12 @@ The following table lists the available variables for customizing the Classic th
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -385,7 +644,9 @@ The following table lists the available variables for customizing the Classic th
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Theme colors map for the button.</div></div>
@@ -394,8 +655,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-bg</td>
     <td></td>
-    <td>$base-bg</td>
-    <td><span class="color-preview" style="background-color: #f0f0f0"></span>#f0f0f0</td>
+<td>
+
+
+`$base-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the buttons.</div></div>
@@ -404,8 +674,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td>$body-text</td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+`$body-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the buttons.</div></div>
@@ -414,8 +693,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-border</td>
     <td></td>
-    <td>try-shade( $button-bg, 2 )</td>
-    <td>try-shade( $button-bg, 2 )</td>
+<td>
+
+
+`try-shade( $button-bg, 2 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the buttons.</div></div>
@@ -424,8 +712,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of the buttons.</div></div>
@@ -434,8 +731,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-hovered-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, 1 )</td>
-    <td>try-shade( $button-bg, 1 )</td>
+<td>
+
+
+`try-shade( $button-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered buttons.</div></div>
@@ -444,8 +750,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered buttons.</div></div>
@@ -454,8 +769,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-hovered-border</td>
     <td></td>
-    <td>try-shade( $button-bg, 3 )</td>
-    <td>try-shade( $button-bg, 3 )</td>
+<td>
+
+
+`try-shade( $button-bg, 3 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered buttons.</div></div>
@@ -464,8 +788,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of hovered buttons.</div></div>
@@ -474,8 +807,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-active-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, 2 )</td>
-    <td>try-shade( $button-bg, 2 )</td>
+<td>
+
+
+`try-shade( $button-bg, 2 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of active buttons.</div></div>
@@ -484,8 +826,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-active-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of active buttons.</div></div>
@@ -494,8 +845,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-active-border</td>
     <td></td>
-    <td>try-shade( $button-bg, 4 )</td>
-    <td>try-shade( $button-bg, 4 )</td>
+<td>
+
+
+`try-shade( $button-bg, 4 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of active buttons.</div></div>
@@ -504,8 +864,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-active-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of active buttons.</div></div>
@@ -514,8 +883,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-selected-bg</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>try-shade( $button-bg, 2 )</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of selected buttons.</div></div>
@@ -524,8 +902,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-selected-text</td>
     <td></td>
-    <td>$button-active-text</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected buttons.</div></div>
@@ -534,8 +921,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-selected-border</td>
     <td></td>
-    <td>$button-active-border</td>
-    <td>try-shade( $button-bg, 4 )</td>
+<td>
+
+
+`$button-active-border`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected buttons.</div></div>
@@ -544,8 +940,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of selected buttons.</div></div>
@@ -554,8 +959,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$button-focused-shadow</td>
     <td></td>
-    <td>0 0 4px 0 rgba( $button-border, .75 )</td>
-    <td>0 0 4px 0 rgba( $button-border, .75 )</td>
+<td>
+
+
+`0 0 4px 0 rgba( $button-border, .75 )`
+
+</td>
+<td>
+
+`0 0 4px 0 rgba( $button-border, .75 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The shadow of focused buttons.</div></div>
@@ -585,8 +999,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$series-a</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The first base series color and its light and dark shades.</div></div>
@@ -595,8 +1018,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$series-b</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ffd246"></span>#ffd246</td>
-    <td><span class="color-preview" style="background-color: #ffd246"></span>#ffd246</td>
+<td>
+<span class="color-preview" style="background-color: #ffd246"></span>
+
+`#ffd246`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffd246"></span>
+
+`#ffd246`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The second base series color and its light and dark shades.</div></div>
@@ -605,8 +1037,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$series-c</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #78d237"></span>#78d237</td>
-    <td><span class="color-preview" style="background-color: #78d237"></span>#78d237</td>
+<td>
+<span class="color-preview" style="background-color: #78d237"></span>
+
+`#78d237`
+
+</td>
+<td><span class="color-preview" style="background-color: #78d237"></span>
+
+`#78d237`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The third base series color and its light and dark shades.</div></div>
@@ -615,8 +1056,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$series-d</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #28b4c8"></span>#28b4c8</td>
-    <td><span class="color-preview" style="background-color: #28b4c8"></span>#28b4c8</td>
+<td>
+<span class="color-preview" style="background-color: #28b4c8"></span>
+
+`#28b4c8`
+
+</td>
+<td><span class="color-preview" style="background-color: #28b4c8"></span>
+
+`#28b4c8`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fourth base series color and its light and dark shades.</div></div>
@@ -625,8 +1075,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$series-e</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #2d73f5"></span>#2d73f5</td>
-    <td><span class="color-preview" style="background-color: #2d73f5"></span>#2d73f5</td>
+<td>
+<span class="color-preview" style="background-color: #2d73f5"></span>
+
+`#2d73f5`
+
+</td>
+<td><span class="color-preview" style="background-color: #2d73f5"></span>
+
+`#2d73f5`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fifth base series color and its light and dark shades.</div></div>
@@ -635,8 +1094,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$series-f</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #aa46be"></span>#aa46be</td>
-    <td><span class="color-preview" style="background-color: #aa46be"></span>#aa46be</td>
+<td>
+<span class="color-preview" style="background-color: #aa46be"></span>
+
+`#aa46be`
+
+</td>
+<td><span class="color-preview" style="background-color: #aa46be"></span>
+
+`#aa46be`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sixth base series color and its light and dark shades.</div></div>
@@ -645,8 +1113,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$series-1</td>
     <td></td>
-    <td>$series-a</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$series-a`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The series colors in order:<br />base, light, dark, lighter, darker</div></div>
@@ -655,8 +1132,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$chart-major-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (major).</div></div>
@@ -665,8 +1151,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$chart-minor-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (minor).</div></div>
@@ -696,8 +1191,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$checkbox-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of checkbox.</div></div>
@@ -706,8 +1210,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox.</div></div>
@@ -716,8 +1229,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checkbox.</div></div>
@@ -726,8 +1248,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>$base-border</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`$base-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checkbox.</div></div>
@@ -736,8 +1267,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered checkbox.</div></div>
@@ -746,8 +1286,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered checkbox.</div></div>
@@ -756,8 +1305,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered checkbox.</div></div>
@@ -766,8 +1324,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-checked-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked checkbox.</div></div>
@@ -776,8 +1343,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-checked-text</td>
     <td></td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked checkbox.</div></div>
@@ -786,8 +1362,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked checkbox.</div></div>
@@ -796,8 +1381,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-indeterminate-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of indeterminate checkbox.</div></div>
@@ -806,8 +1400,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-indeterminate-text</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of indeterminate checkbox.</div></div>
@@ -816,8 +1419,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-indeterminate-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>$base-border</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`$base-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of indeterminate checkbox.</div></div>
@@ -826,8 +1438,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-focused-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused checkbox.</div></div>
@@ -836,8 +1457,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-focused-shadow</td>
     <td></td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
+<td>
+
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
+<td>
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused checkbox.</div></div>
@@ -846,8 +1476,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-focused-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked checkbox.</div></div>
@@ -856,8 +1495,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-focused-checked-shadow</td>
     <td></td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
+<td>
+
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
+<td>
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked checkbox.</div></div>
@@ -866,8 +1514,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-disabled-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled checkbox.</div></div>
@@ -876,8 +1533,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-disabled-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled checkbox.</div></div>
@@ -886,8 +1552,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-disabled-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled checkbox.</div></div>
@@ -896,8 +1571,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-disabled-checked-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked checkbox.</div></div>
@@ -906,8 +1590,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-disabled-checked-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked checkbox.</div></div>
@@ -916,8 +1609,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-disabled-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked checkbox.</div></div>
@@ -926,8 +1628,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-invalid-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid checkbox.</div></div>
@@ -936,8 +1647,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-invalid-text</td>
     <td></td>
-    <td>$invalid-text</td>
-    <td></td>
+<td>
+
+
+`$invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid checkbox.</div></div>
@@ -946,8 +1666,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-invalid-border</td>
     <td></td>
-    <td>$invalid-border</td>
-    <td></td>
+<td>
+
+
+`$invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid checkbox.</div></div>
@@ -956,8 +1685,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of checkbox indicator.</div></div>
@@ -966,8 +1704,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-glyph-font-family</td>
     <td></td>
-    <td>"WebComponentsIcons", monospace</td>
-    <td>"WebComponentsIcons", monospace</td>
+<td>
+
+
+`"WebComponentsIcons", monospace`
+
+</td>
+<td>
+
+`"WebComponentsIcons", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph font family of checkbox indicator.</div></div>
@@ -976,8 +1723,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-checked-glyph</td>
     <td></td>
-    <td>"\e118"</td>
-    <td>"\e118"</td>
+<td>
+
+
+`"\e118"`
+
+</td>
+<td>
+
+`"\e118"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of checkbox indicator.</div></div>
@@ -986,8 +1742,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-indeterminate-glyph</td>
     <td></td>
-    <td>"\e121"</td>
-    <td>"\e121"</td>
+<td>
+
+
+`"\e121"`
+
+</td>
+<td>
+
+`"\e121"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of indeterminate checkbox indicator.</div></div>
@@ -996,8 +1761,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -1006,8 +1780,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-indeterminate-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image image of checked checkbox indicator.</div></div>
@@ -1016,8 +1799,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal checkbox list.</div></div>
@@ -1026,8 +1818,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of checkbox list items.</div></div>
@@ -1036,8 +1837,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of checkbox list items.</div></div>
@@ -1046,8 +1856,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-ripple-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox ripple.</div></div>
@@ -1056,8 +1875,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$checkbox-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of checkbox ripple.</div></div>
@@ -1087,8 +1915,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$primary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+<span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.<br />Used for primary buttons and for elements of primary importance across the theme.</div></div>
@@ -1097,8 +1934,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$primary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $primary )</td>
-    <td>contrast-wcag( $primary )</td>
+<td>
+
+
+`contrast-wcag( $primary )`
+
+</td>
+<td>
+
+`contrast-wcag( $primary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the primary color denoted by $primary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1107,8 +1953,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$secondary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #e9e9e9"></span>#e9e9e9</td>
-    <td><span class="color-preview" style="background-color: #e9e9e9"></span>#e9e9e9</td>
+<td>
+<span class="color-preview" style="background-color: #e9e9e9"></span>
+
+`#e9e9e9`
+
+</td>
+<td><span class="color-preview" style="background-color: #e9e9e9"></span>
+
+`#e9e9e9`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The secondary color of the theme.</div></div>
@@ -1117,8 +1972,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$secondary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $secondary )</td>
-    <td>contrast-wcag( $secondary )</td>
+<td>
+
+
+`contrast-wcag( $secondary )`
+
+</td>
+<td>
+
+`contrast-wcag( $secondary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the secondary color denoted by $secondary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1127,8 +1991,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tertiary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
+<td>
+<span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
+<td><span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tertiary color of the theme.</div></div>
@@ -1137,8 +2010,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tertiary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $tertiary )</td>
-    <td>contrast-wcag( $tertiary )</td>
+<td>
+
+
+`contrast-wcag( $tertiary )`
+
+</td>
+<td>
+
+`contrast-wcag( $tertiary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the tertiary color denoted by $tertiary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1147,8 +2029,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$info</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #2498bc"></span>#2498bc</td>
-    <td><span class="color-preview" style="background-color: #2498bc"></span>#2498bc</td>
+<td>
+<span class="color-preview" style="background-color: #2498bc"></span>
+
+`#2498bc`
+
+</td>
+<td><span class="color-preview" style="background-color: #2498bc"></span>
+
+`#2498bc`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for informational messages and states.</div></div>
@@ -1157,8 +2048,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$success</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #3ea44e"></span>#3ea44e</td>
-    <td><span class="color-preview" style="background-color: #3ea44e"></span>#3ea44e</td>
+<td>
+<span class="color-preview" style="background-color: #3ea44e"></span>
+
+`#3ea44e`
+
+</td>
+<td><span class="color-preview" style="background-color: #3ea44e"></span>
+
+`#3ea44e`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for success messages and states.</div></div>
@@ -1167,8 +2067,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$warning</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ff9800"></span>#ff9800</td>
-    <td><span class="color-preview" style="background-color: #ff9800"></span>#ff9800</td>
+<td>
+<span class="color-preview" style="background-color: #ff9800"></span>
+
+`#ff9800`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff9800"></span>
+
+`#ff9800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for warning messages and states.</div></div>
@@ -1177,8 +2086,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$error</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #d92800"></span>#d92800</td>
-    <td><span class="color-preview" style="background-color: #d92800"></span>#d92800</td>
+<td>
+<span class="color-preview" style="background-color: #d92800"></span>
+
+`#d92800`
+
+</td>
+<td><span class="color-preview" style="background-color: #d92800"></span>
+
+`#d92800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for error messages and states.</div></div>
@@ -1187,8 +2105,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$dark</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #404040"></span>#404040</td>
-    <td><span class="color-preview" style="background-color: #404040"></span>#404040</td>
+<td>
+<span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
+
+</td>
+<td><span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The dark color of the theme.</div></div>
@@ -1197,8 +2124,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$light</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
+<td>
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
+<td><span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The light color of the theme.</div></div>
@@ -1207,8 +2143,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$inverse</td>
     <td></td>
-    <td>if( $dark-theme, $light, $dark )</td>
-    <td>if( $dark-theme, $light, $dark )</td>
+<td>
+
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
+<td>
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Inverse color of the theme. Depending on the theme luminance dark or light, it will be light or dark</div></div>
@@ -1238,8 +2183,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$component-bg</td>
     <td></td>
-    <td>$body-bg</td>
-    <td></td>
+<td>
+
+
+`$body-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-bg` e.g. `$grid-bg: $component-bg !defualt;`.</div></div>
@@ -1248,8 +2202,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$component-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-text` e.g. `$grid-text: component-text !default;`.</div></div>
@@ -1258,8 +2221,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$component-border</td>
     <td></td>
-    <td>$base-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$base-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-border` e.g. `$grid-border: component-border !default;`.</div></div>
@@ -1289,8 +2261,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$grid-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the grid component</div></div>
@@ -1299,8 +2280,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the grid component</div></div>
@@ -1309,8 +2299,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the grid component</div></div>
@@ -1319,8 +2318,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-header-bg</td>
     <td></td>
-    <td>$header-bg</td>
-    <td></td>
+<td>
+
+
+`$header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid header</div></div>
@@ -1329,8 +2337,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-header-text</td>
     <td></td>
-    <td>$header-text</td>
-    <td></td>
+<td>
+
+
+`$header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid header</div></div>
@@ -1339,8 +2356,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-header-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid header</div></div>
@@ -1349,8 +2375,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-header-gradient</td>
     <td></td>
-    <td>$header-gradient</td>
-    <td></td>
+<td>
+
+
+`$header-gradient`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of grid header</div></div>
@@ -1359,8 +2394,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-footer-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid footer</div></div>
@@ -1369,8 +2413,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-footer-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid footer</div></div>
@@ -1379,8 +2432,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-footer-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid footer</div></div>
@@ -1389,8 +2451,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-alt-bg</td>
     <td></td>
-    <td>try-shade( $grid-bg, .5 )</td>
-    <td>try-shade( $grid-bg, .5 )</td>
+<td>
+
+
+`try-shade( $grid-bg, .5 )`
+
+</td>
+<td>
+
+`try-shade( $grid-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in grid</div></div>
@@ -1399,8 +2470,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-alt-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in grid</div></div>
@@ -1409,8 +2489,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-alt-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in grid</div></div>
@@ -1419,8 +2508,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-hovered-bg</td>
     <td></td>
-    <td>try-shade( $grid-bg, 1 )</td>
-    <td>try-shade( $grid-bg, 1 )</td>
+<td>
+
+
+`try-shade( $grid-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $grid-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in grid</div></div>
@@ -1429,8 +2527,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in grid</div></div>
@@ -1439,8 +2546,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in grid</div></div>
@@ -1449,8 +2565,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-selected-bg</td>
     <td></td>
-    <td>rgba( $selected-bg, .25 )</td>
-    <td>rgba( $selected-bg, .25 )</td>
+<td>
+
+
+`rgba( $selected-bg, .25 )`
+
+</td>
+<td>
+
+`rgba( $selected-bg, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in grid</div></div>
@@ -1459,8 +2584,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-selected-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in grid</div></div>
@@ -1469,8 +2603,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$grid-selected-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in grid</div></div>
@@ -1500,8 +2643,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$icon-font-url</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The URL to the icon font that will be used by the theme<br />The default value of `null` embeds the package font with a `data:` URL</div></div>
@@ -1531,8 +2683,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$list-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the list component.</div></div>
@@ -1541,8 +2702,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the list component.</div></div>
@@ -1551,8 +2721,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of list items.</div></div>
@@ -1561,8 +2740,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of list items.</div></div>
@@ -1571,8 +2759,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the list component.</div></div>
@@ -1581,8 +2778,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the list component.</div></div>
@@ -1591,8 +2797,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the list component.</div></div>
@@ -1601,8 +2816,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-header-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list header.</div></div>
@@ -1611,8 +2835,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-header-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list header.</div></div>
@@ -1621,8 +2854,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-header-border</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of list header.</div></div>
@@ -1631,8 +2873,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-header-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of list header.</div></div>
@@ -1641,8 +2892,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list items.</div></div>
@@ -1651,8 +2911,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-item-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list items.</div></div>
@@ -1661,8 +2930,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>try-shade( $base-bg, 1 )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered list items.</div></div>
@@ -1671,8 +2949,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered list items.</div></div>
@@ -1681,8 +2968,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-item-focused-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused list items.</div></div>
@@ -1691,8 +2987,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-item-focused-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused list items.</div></div>
@@ -1701,8 +3006,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-item-focused-shadow</td>
     <td></td>
-    <td>inset 0 0 0 2px rgba(0, 0, 0, .12)</td>
-    <td>inset 0 0 0 2px rgba(0, 0, 0, .12)</td>
+<td>
+
+
+`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+
+</td>
+<td>
+
+`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused list items.</div></div>
@@ -1711,8 +3025,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected list items.</div></div>
@@ -1721,8 +3044,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected list items.</div></div>
@@ -1731,8 +3063,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$list-no-data-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the 'No Data' text.</div></div>
@@ -1762,8 +3103,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$radio-radius</td>
     <td></td>
-    <td>50%</td>
-    <td>50%</td>
+<td>
+
+
+`50%`
+
+</td>
+<td>
+
+`50%`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of radio button.</div></div>
@@ -1772,8 +3122,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of radio button.</div></div>
@@ -1782,8 +3141,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button.</div></div>
@@ -1792,8 +3160,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-text</td>
     <td></td>
-    <td>$checkbox-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of radio button.</div></div>
@@ -1802,8 +3179,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>$base-border</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`$base-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of radio button.</div></div>
@@ -1812,8 +3198,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-hovered-bg</td>
     <td></td>
-    <td>$checkbox-hovered-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered radio button.</div></div>
@@ -1822,8 +3217,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-hovered-text</td>
     <td></td>
-    <td>$checkbox-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered radio button.</div></div>
@@ -1832,8 +3236,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-hovered-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered radio button.</div></div>
@@ -1842,8 +3255,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-checked-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked radio button.</div></div>
@@ -1852,8 +3274,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-checked-text</td>
     <td></td>
-    <td>$checkbox-checked-text</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`$checkbox-checked-text`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked radio button.</div></div>
@@ -1862,8 +3293,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked radio button.</div></div>
@@ -1872,8 +3312,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-focused-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused radio button.</div></div>
@@ -1882,8 +3331,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-focused-shadow</td>
     <td></td>
-    <td>$checkbox-focused-shadow</td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
+<td>
+
+
+`$checkbox-focused-shadow`
+
+</td>
+<td>
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused radio button.</div></div>
@@ -1892,8 +3350,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-focused-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked radio button.</div></div>
@@ -1902,8 +3369,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-focused-checked-shadow</td>
     <td></td>
-    <td>$checkbox-focused-checked-shadow</td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
+<td>
+
+
+`$checkbox-focused-checked-shadow`
+
+</td>
+<td>
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked radio button.</div></div>
@@ -1912,8 +3388,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-disabled-bg</td>
     <td></td>
-    <td>$checkbox-disabled-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled radio button.</div></div>
@@ -1922,8 +3407,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-disabled-text</td>
     <td></td>
-    <td>$checkbox-disabled-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled radio button.</div></div>
@@ -1932,8 +3426,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-disabled-border</td>
     <td></td>
-    <td>$checkbox-disabled-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled radio button.</div></div>
@@ -1942,8 +3445,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-disabled-checked-bg</td>
     <td></td>
-    <td>$checkbox-disabled-checked-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked radio button.</div></div>
@@ -1952,8 +3464,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-disabled-checked-text</td>
     <td></td>
-    <td>$checkbox-disabled-checked-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked radio button.</div></div>
@@ -1962,8 +3483,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-disabled-checked-border</td>
     <td></td>
-    <td>$checkbox-disabled-checked-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked radio button.</div></div>
@@ -1972,8 +3502,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-invalid-bg</td>
     <td></td>
-    <td>$checkbox-invalid-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-invalid-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid radio button.</div></div>
@@ -1982,8 +3521,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-invalid-text</td>
     <td></td>
-    <td>$checkbox-invalid-text</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid radio button.</div></div>
@@ -1992,8 +3540,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-invalid-border</td>
     <td></td>
-    <td>$checkbox-invalid-border</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid radio button.</div></div>
@@ -2002,8 +3559,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of radio button indicator.</div></div>
@@ -2012,8 +3578,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-checked-glyph</td>
     <td></td>
-    <td>"\e308"</td>
-    <td>"\e308"</td>
+<td>
+
+
+`"\e308"`
+
+</td>
+<td>
+
+`"\e308"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of radio button indicator.</div></div>
@@ -2022,8 +3597,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked radio button indicator.</div></div>
@@ -2032,8 +3616,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-disabled-checked-image</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of disabled and checked radio button indicator.</div></div>
@@ -2042,8 +3635,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal radio button list.</div></div>
@@ -2052,8 +3654,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of radio button list items.</div></div>
@@ -2062,8 +3673,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of radio button list items.</div></div>
@@ -2072,8 +3692,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-ripple-bg</td>
     <td></td>
-    <td>$radio-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #f35800"></span>#f35800</td>
+<td>
+
+
+`$radio-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button ripple.</div></div>
@@ -2082,8 +3711,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$radio-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of radio button ripple.</div></div>
@@ -2113,8 +3751,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$table-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of the table border.</div></div>
@@ -2123,8 +3770,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-cell-vertical-border-width</td>
     <td></td>
-    <td>$grid-cell-vertical-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-vertical-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of vertical border of table cells.</div></div>
@@ -2133,8 +3789,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-cell-horizontal-border-width</td>
     <td></td>
-    <td>$grid-cell-horizontal-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-horizontal-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of horizontal border of table cells.</div></div>
@@ -2143,8 +3808,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font size of the table if no size is specified.</div></div>
@@ -2153,8 +3827,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-cell-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the cells in the table if no size is specified.</div></div>
@@ -2163,8 +3846,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-cell-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the cells in the table if no size is specified.</div></div>
@@ -2173,8 +3865,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-bg</td>
     <td></td>
-    <td>$grid-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tables.</div></div>
@@ -2183,8 +3884,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-text</td>
     <td></td>
-    <td>$grid-text</td>
-    <td></td>
+<td>
+
+
+`$grid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tables.</div></div>
@@ -2193,8 +3903,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tables.</div></div>
@@ -2203,8 +3922,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-header-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table headers.</div></div>
@@ -2213,8 +3941,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-header-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table headers.</div></div>
@@ -2223,8 +3960,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-header-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table headers.</div></div>
@@ -2233,8 +3979,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-footer-bg</td>
     <td></td>
-    <td>$grid-footer-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table footers.</div></div>
@@ -2243,8 +3998,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-footer-text</td>
     <td></td>
-    <td>$grid-footer-text</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table footers.</div></div>
@@ -2253,8 +4017,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-footer-border</td>
     <td></td>
-    <td>$grid-footer-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$grid-footer-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table footers.</div></div>
@@ -2263,8 +4036,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-group-row-bg</td>
     <td></td>
-    <td>$table-header-bg</td>
-    <td></td>
+<td>
+
+
+`$table-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of group rows in table.</div></div>
@@ -2273,8 +4055,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-group-row-text</td>
     <td></td>
-    <td>$table-header-text</td>
-    <td></td>
+<td>
+
+
+`$table-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of group rows in table.</div></div>
@@ -2283,8 +4074,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-group-row-border</td>
     <td></td>
-    <td>$table-header-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$table-header-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of group rows in table.</div></div>
@@ -2293,8 +4093,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-alt-row-bg</td>
     <td></td>
-    <td>$grid-alt-bg</td>
-    <td>try-shade( $grid-bg, .5 )</td>
+<td>
+
+
+`$grid-alt-bg`
+
+</td>
+<td>
+
+`try-shade( $grid-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in table.</div></div>
@@ -2303,8 +4112,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-alt-row-text</td>
     <td></td>
-    <td>$grid-alt-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in table.</div></div>
@@ -2313,8 +4131,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-alt-row-border</td>
     <td></td>
-    <td>$grid-alt-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in table.</div></div>
@@ -2323,8 +4150,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-hover-bg</td>
     <td></td>
-    <td>$grid-hovered-bg</td>
-    <td>try-shade( $grid-bg, 1 )</td>
+<td>
+
+
+`$grid-hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $grid-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in table.</div></div>
@@ -2333,8 +4169,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-hover-text</td>
     <td></td>
-    <td>$grid-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in table.</div></div>
@@ -2343,8 +4188,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-hover-border</td>
     <td></td>
-    <td>$grid-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in table.</div></div>
@@ -2353,8 +4207,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-focus-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused rows in table.</div></div>
@@ -2363,8 +4226,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-focus-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused rows in table.</div></div>
@@ -2373,8 +4245,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused rows in table.</div></div>
@@ -2383,8 +4264,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-focus-shadow</td>
     <td></td>
-    <td>$grid-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$grid-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused rows in table.</div></div>
@@ -2393,8 +4283,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-selected-bg</td>
     <td></td>
-    <td>$grid-selected-bg</td>
-    <td>rgba( $selected-bg, .25 )</td>
+<td>
+
+
+`$grid-selected-bg`
+
+</td>
+<td>
+
+`rgba( $selected-bg, .25 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in table.</div></div>
@@ -2403,8 +4302,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-selected-text</td>
     <td></td>
-    <td>$grid-selected-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-selected-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in table.</div></div>
@@ -2413,8 +4321,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$table-selected-border</td>
     <td></td>
-    <td>$grid-selected-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-selected-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in table.</div></div>
@@ -2444,8 +4361,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$tabstrip-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip component</div></div>
@@ -2454,8 +4380,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip component</div></div>
@@ -2464,8 +4399,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip component</div></div>
@@ -2474,8 +4418,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-padding-x</td>
     <td></td>
-    <td>$nav-item-padding-x</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-x`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabs</div></div>
@@ -2484,8 +4437,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-padding-y</td>
     <td></td>
-    <td>$nav-item-padding-y</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-y`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabs</div></div>
@@ -2494,8 +4456,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabs</div></div>
@@ -2504,8 +4475,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of tabs</div></div>
@@ -2514,8 +4494,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-gap</td>
     <td></td>
-    <td>$nav-item-margin</td>
-    <td></td>
+<td>
+
+
+`$nav-item-margin`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between tabs</div></div>
@@ -2524,8 +4513,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-bg</td>
     <td></td>
-    <td>$base-bg</td>
-    <td><span class="color-preview" style="background-color: #f0f0f0"></span>#f0f0f0</td>
+<td>
+
+
+`$base-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabs</div></div>
@@ -2534,8 +4532,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td>$body-text</td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+`$body-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabs</div></div>
@@ -2544,8 +4551,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-border</td>
     <td></td>
-    <td>$base-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$base-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabs</div></div>
@@ -2554,8 +4570,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( white, .1 ), rgba( white, 0 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( white, .1 ), rgba( white, 0 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of tabs</div></div>
@@ -2564,8 +4589,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>try-shade( $base-bg, 1 )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered tabs</div></div>
@@ -2574,8 +4608,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered tabs</div></div>
@@ -2584,8 +4627,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-hovered-border</td>
     <td></td>
-    <td>$hovered-border</td>
-    <td>try-shade( $hovered-bg, 2 )</td>
+<td>
+
+
+`$hovered-border`
+
+</td>
+<td>
+
+`try-shade( $hovered-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered tabs</div></div>
@@ -2594,8 +4646,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered tabs</div></div>
@@ -2604,8 +4665,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-selected-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected tabs</div></div>
@@ -2614,8 +4684,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-selected-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected tabs</div></div>
@@ -2624,8 +4703,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-selected-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected tabs</div></div>
@@ -2634,8 +4722,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
     <td></td>
-    <td>false</td>
-    <td>false</td>
+<td>
+
+
+`false`
+
+</td>
+<td>
+
+`false`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected tabs</div></div>
@@ -2644,8 +4741,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-content-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabstrip content</div></div>
@@ -2654,8 +4760,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-content-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabstrip content</div></div>
@@ -2664,8 +4779,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-content-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabstrip content</div></div>
@@ -2674,8 +4798,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-content-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip content</div></div>
@@ -2684,8 +4817,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-content-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip content</div></div>
@@ -2694,8 +4836,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-content-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>try-shade( $base-bg, 2 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip content</div></div>
@@ -2704,8 +4855,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$tabstrip-content-border-focused</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip focused content</div></div>
@@ -2735,8 +4895,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$toolbar-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the container.</div></div>
@@ -2745,8 +4914,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$toolbar-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the container.</div></div>
@@ -2776,8 +4954,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$treeview-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the treeview component.</div></div>
@@ -2786,8 +4973,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the treeview component.</div></div>
@@ -2796,8 +4992,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the treeview component.</div></div>
@@ -2806,8 +5011,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-indent</td>
     <td></td>
-    <td>16px</td>
-    <td>16px</td>
+<td>
+
+
+`16px`
+
+</td>
+<td>
+
+`16px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Indentation of child groups in treeview component.</div></div>
@@ -2816,8 +5030,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of treeview items.</div></div>
@@ -2826,8 +5049,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of treeview items.</div></div>
@@ -2836,8 +5068,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of treeview items.</div></div>
@@ -2846,8 +5087,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of treeview items.</div></div>
@@ -2856,8 +5106,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the treeview component.</div></div>
@@ -2866,8 +5125,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the treeview component.</div></div>
@@ -2876,8 +5144,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the treeview component.</div></div>
@@ -2886,8 +5163,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>try-shade( $base-bg, 1 )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $base-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered treeview items.</div></div>
@@ -2896,8 +5182,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered treeview items.</div></div>
@@ -2906,8 +5201,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-hovered-border</td>
     <td></td>
-    <td>$hovered-border</td>
-    <td>try-shade( $hovered-bg, 2 )</td>
+<td>
+
+
+`$hovered-border`
+
+</td>
+<td>
+
+`try-shade( $hovered-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered treeview items.</div></div>
@@ -2916,8 +5220,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-hovered-gradient</td>
     <td></td>
-    <td>$hovered-gradient</td>
-    <td>$base-gradient</td>
+<td>
+
+
+`$hovered-gradient`
+
+</td>
+<td>
+
+`$base-gradient`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered treeview items.</div></div>
@@ -2926,8 +5239,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected treeview items.</div></div>
@@ -2936,8 +5258,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected treeview items.</div></div>
@@ -2946,8 +5277,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-selected-border</td>
     <td></td>
-    <td>$selected-border</td>
-    <td>try-shade( $selected-bg, 2 )</td>
+<td>
+
+
+`$selected-border`
+
+</td>
+<td>
+
+`try-shade( $selected-bg, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected treeview items.</div></div>
@@ -2956,8 +5296,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-selected-gradient</td>
     <td></td>
-    <td>$selected-gradient</td>
-    <td>$base-gradient</td>
+<td>
+
+
+`$selected-gradient`
+
+</td>
+<td>
+
+`$base-gradient`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected treeview items.</div></div>
@@ -2966,8 +5315,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-item-focused-shadow</td>
     <td></td>
-    <td>$focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused treeview items.</div></div>
@@ -2976,8 +5334,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-loadmore-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of load more.</div></div>
@@ -2986,8 +5353,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-loadmore-text</td>
     <td></td>
-    <td>$link-text</td>
-    <td></td>
+<td>
+
+
+`$link-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of load more.</div></div>
@@ -2996,8 +5372,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-loadmore-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of load more.</div></div>
@@ -3006,8 +5391,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-loadmore-hover-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a hovered load more.</div></div>
@@ -3016,8 +5410,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-loadmore-hover-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a hovered load more.</div></div>
@@ -3026,8 +5429,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-loadmore-hover-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a hovered load more.</div></div>
@@ -3036,8 +5448,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-loadmore-focus-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a focused load more.</div></div>
@@ -3046,8 +5467,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-loadmore-focus-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a focused load more.</div></div>
@@ -3056,8 +5486,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-loadmore-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a focused load more.</div></div>
@@ -3066,8 +5505,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$treeview-loadmore-focus-shadow</td>
     <td></td>
-    <td>$treeview-item-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$treeview-item-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of a focused load more.</div></div>
@@ -3097,8 +5545,17 @@ The following table lists the available variables for customizing the Classic th
         <tr>
     <td>$enable-typography</td>
     <td></td>
-    <td>false</td>
-    <td>false</td>
+<td>
+
+
+`false`
+
+</td>
+<td>
+
+`false`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Global typography styles for the Kendo Classic theme.</div></div>
@@ -3107,8 +5564,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$font-size</td>
     <td></td>
-    <td>14px</td>
-    <td>14px</td>
+<td>
+
+
+`14px`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Base font size across all components.</div></div>
@@ -3117,8 +5583,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$font-family</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family across all components.</div></div>
@@ -3127,8 +5602,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$font-family-monospace</td>
     <td></td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
+<td>
+
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
+<td>
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family for monospaced text. Used for styling the code.</div></div>
@@ -3137,8 +5621,17 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$line-height</td>
     <td></td>
-    <td>(20 / 14)</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`(20 / 14)`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>

--- a/packages/default/docs/customization-avatar.md
+++ b/packages/default/docs/customization-avatar.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$avatar-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of the avatar.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the avatar.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the avatar.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the avatar.</div></div>
@@ -68,16 +104,25 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-sizes</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sizes of the avatar.</div></div>

--- a/packages/default/docs/customization-button.md
+++ b/packages/default/docs/customization-button.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$button-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of the border around the button.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>2px</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of the button.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of the button.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of the button.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the button.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the button.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated height of the button.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-inner-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated inner height of the button. Without the border width.</div></div>
@@ -118,7 +199,10 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-theme-colors</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -129,8 +213,12 @@ The following table lists the available variables for customization.
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -141,7 +229,9 @@ The following table lists the available variables for customization.
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Theme colors map for the button.</div></div>
@@ -150,8 +240,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-bg</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #f5f5f5"></span>#f5f5f5</td>
-    <td><span class="color-preview" style="background-color: #f5f5f5"></span>#f5f5f5</td>
+<td>
+<span class="color-preview" style="background-color: #f5f5f5"></span>
+
+`#f5f5f5`
+
+</td>
+<td><span class="color-preview" style="background-color: #f5f5f5"></span>
+
+`#f5f5f5`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the buttons.</div></div>
@@ -160,8 +259,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-text</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #424242"></span>#424242</td>
-    <td><span class="color-preview" style="background-color: #424242"></span>#424242</td>
+<td>
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
+
+</td>
+<td><span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the buttons.</div></div>
@@ -170,8 +278,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-border</td>
     <td></td>
-    <td>rgba( black, .08 )</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`rgba( black, .08 )`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the buttons.</div></div>
@@ -180,8 +297,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-gradient</td>
     <td></td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of the buttons.</div></div>
@@ -190,8 +316,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, .5 )</td>
-    <td>try-shade( $button-bg, .5 )</td>
+<td>
+
+
+`try-shade( $button-bg, .5 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered buttons.</div></div>
@@ -200,8 +335,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered buttons.</div></div>
@@ -210,8 +354,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered buttons.</div></div>
@@ -220,8 +373,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of hovered buttons.</div></div>
@@ -230,8 +392,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, 1.5 )</td>
-    <td>try-shade( $button-bg, 1.5 )</td>
+<td>
+
+
+`try-shade( $button-bg, 1.5 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 1.5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of active buttons.</div></div>
@@ -240,8 +411,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of active buttons.</div></div>
@@ -250,8 +430,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of active buttons.</div></div>
@@ -260,8 +449,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of active buttons.</div></div>
@@ -270,8 +468,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-bg</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>try-shade( $button-bg, 1.5 )</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 1.5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of selected buttons.</div></div>
@@ -280,8 +487,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-text</td>
     <td></td>
-    <td>$button-active-text</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected buttons.</div></div>
@@ -290,8 +506,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-border</td>
     <td></td>
-    <td>$button-active-border</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected buttons.</div></div>
@@ -300,8 +525,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of selected buttons.</div></div>
@@ -310,8 +544,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-focused-shadow</td>
     <td></td>
-    <td>0 0 0 2px rgba( $button-border, .08 )</td>
-    <td>0 0 0 2px rgba( $button-border, .08 )</td>
+<td>
+
+
+`0 0 0 2px rgba( $button-border, .08 )`
+
+</td>
+<td>
+
+`0 0 0 2px rgba( $button-border, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The shadow of focused buttons.</div></div>

--- a/packages/default/docs/customization-charts.md
+++ b/packages/default/docs/customization-charts.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$series-a</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The first base series color and its light and dark shades.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-b</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ffd246"></span>#ffd246</td>
-    <td><span class="color-preview" style="background-color: #ffd246"></span>#ffd246</td>
+<td>
+<span class="color-preview" style="background-color: #ffd246"></span>
+
+`#ffd246`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffd246"></span>
+
+`#ffd246`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The second base series color and its light and dark shades.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-c</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #78d237"></span>#78d237</td>
-    <td><span class="color-preview" style="background-color: #78d237"></span>#78d237</td>
+<td>
+<span class="color-preview" style="background-color: #78d237"></span>
+
+`#78d237`
+
+</td>
+<td><span class="color-preview" style="background-color: #78d237"></span>
+
+`#78d237`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The third base series color and its light and dark shades.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-d</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #28b4c8"></span>#28b4c8</td>
-    <td><span class="color-preview" style="background-color: #28b4c8"></span>#28b4c8</td>
+<td>
+<span class="color-preview" style="background-color: #28b4c8"></span>
+
+`#28b4c8`
+
+</td>
+<td><span class="color-preview" style="background-color: #28b4c8"></span>
+
+`#28b4c8`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fourth base series color and its light and dark shades.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-e</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #2d73f5"></span>#2d73f5</td>
-    <td><span class="color-preview" style="background-color: #2d73f5"></span>#2d73f5</td>
+<td>
+<span class="color-preview" style="background-color: #2d73f5"></span>
+
+`#2d73f5`
+
+</td>
+<td><span class="color-preview" style="background-color: #2d73f5"></span>
+
+`#2d73f5`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fifth base series color and its light and dark shades.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-f</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #aa46be"></span>#aa46be</td>
-    <td><span class="color-preview" style="background-color: #aa46be"></span>#aa46be</td>
+<td>
+<span class="color-preview" style="background-color: #aa46be"></span>
+
+`#aa46be`
+
+</td>
+<td><span class="color-preview" style="background-color: #aa46be"></span>
+
+`#aa46be`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sixth base series color and its light and dark shades.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-1</td>
     <td></td>
-    <td>$series-a</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$series-a`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The series colors in order:<br />base, light, dark, lighter, darker</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$chart-major-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (major).</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$chart-minor-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (minor).</div></div>

--- a/packages/default/docs/customization-checkbox.md
+++ b/packages/default/docs/customization-checkbox.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$checkbox-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of checkbox.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checkbox.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checkbox.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered checkbox.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered checkbox.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered checkbox.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked checkbox.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-text</td>
     <td></td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked checkbox.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked checkbox.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of indeterminate checkbox.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-text</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of indeterminate checkbox.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of indeterminate checkbox.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused checkbox.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-shadow</td>
     <td></td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
+<td>
+
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
+<td>
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused checkbox.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked checkbox.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-checked-shadow</td>
     <td></td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
+<td>
+
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
+<td>
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked checkbox.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled checkbox.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled checkbox.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled checkbox.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked checkbox.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked checkbox.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked checkbox.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid checkbox.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-text</td>
     <td></td>
-    <td>$invalid-text</td>
-    <td></td>
+<td>
+
+
+`$invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid checkbox.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-border</td>
     <td></td>
-    <td>$invalid-border</td>
-    <td></td>
+<td>
+
+
+`$invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid checkbox.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of checkbox indicator.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-glyph-font-family</td>
     <td></td>
-    <td>"WebComponentsIcons", monospace</td>
-    <td>"WebComponentsIcons", monospace</td>
+<td>
+
+
+`"WebComponentsIcons", monospace`
+
+</td>
+<td>
+
+`"WebComponentsIcons", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph font family of checkbox indicator.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-glyph</td>
     <td></td>
-    <td>"\e118"</td>
-    <td>"\e118"</td>
+<td>
+
+
+`"\e118"`
+
+</td>
+<td>
+
+`"\e118"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of checkbox indicator.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-glyph</td>
     <td></td>
-    <td>"\e121"</td>
-    <td>"\e121"</td>
+<td>
+
+
+`"\e121"`
+
+</td>
+<td>
+
+`"\e121"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of indeterminate checkbox indicator.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -338,8 +617,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image image of checked checkbox indicator.</div></div>
@@ -348,8 +636,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal checkbox list.</div></div>
@@ -358,8 +655,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of checkbox list items.</div></div>
@@ -368,8 +674,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of checkbox list items.</div></div>
@@ -378,8 +693,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-ripple-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox ripple.</div></div>
@@ -388,8 +712,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of checkbox ripple.</div></div>

--- a/packages/default/docs/customization-color-system.md
+++ b/packages/default/docs/customization-color-system.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$accent</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Deprecated</b><div class="theme-variables-description">Will be removed in v5. Use `$primary` variable instead.</div></div><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$accent-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $accent )</td>
-    <td>contrast-wcag( $accent )</td>
+<td>
+
+
+`contrast-wcag( $accent )`
+
+</td>
+<td>
+
+`contrast-wcag( $accent )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Deprecated</b><div class="theme-variables-description">Will be removed in v5. Use `$primary-contrast` variable instead.</div></div><div><b>Description</b><div class="theme-variables-description">The color used along with the accent color denoted by $primary.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$primary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.<br />Used for primary buttons and for elements of primary importance across the theme.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$primary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $primary )</td>
-    <td>contrast-wcag( $primary )</td>
+<td>
+
+
+`contrast-wcag( $primary )`
+
+</td>
+<td>
+
+`contrast-wcag( $primary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the accent color denoted by $primary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$secondary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #666666"></span>#666666</td>
-    <td><span class="color-preview" style="background-color: #666666"></span>#666666</td>
+<td>
+<span class="color-preview" style="background-color: #666666"></span>
+
+`#666666`
+
+</td>
+<td><span class="color-preview" style="background-color: #666666"></span>
+
+`#666666`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The secondary color of the theme.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$secondary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $secondary )</td>
-    <td>contrast-wcag( $secondary )</td>
+<td>
+
+
+`contrast-wcag( $secondary )`
+
+</td>
+<td>
+
+`contrast-wcag( $secondary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the secondary color denoted by $secondary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tertiary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
+<td>
+<span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
+<td><span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tertiary color of the theme.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tertiary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $tertiary )</td>
-    <td>contrast-wcag( $tertiary )</td>
+<td>
+
+
+`contrast-wcag( $tertiary )`
+
+</td>
+<td>
+
+`contrast-wcag( $tertiary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the tertiary color denoted by $tertiary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$info</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
+<td>
+<span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
+<td><span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for informational messages and states.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$success</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
+<td>
+<span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
+<td><span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for success messages and states.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$warning</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
+<td>
+<span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for warning messages and states.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$error</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
+<td>
+<span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
+<td><span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for error messages and states.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dark</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #424242"></span>#424242</td>
-    <td><span class="color-preview" style="background-color: #424242"></span>#424242</td>
+<td>
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
+
+</td>
+<td><span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The dark color of the theme.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$light</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
+<td>
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
+<td><span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The light color of the theme.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$inverse</td>
     <td></td>
-    <td>if( $dark-theme, $light, $dark )</td>
-    <td>if( $dark-theme, $light, $dark )</td>
+<td>
+
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
+<td>
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Inverse color of the theme. Depending on the theme luminance dark or light, it will be light or dark</div></div>

--- a/packages/default/docs/customization-common.md
+++ b/packages/default/docs/customization-common.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$border-radius</td>
     <td></td>
-    <td>2px</td>
-    <td>2px</td>
+<td>
+
+
+`2px`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius for all components.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-bg</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #fafafa"></span>#fafafa</td>
-    <td><span class="color-preview" style="background-color: #fafafa"></span>#fafafa</td>
+<td>
+<span class="color-preview" style="background-color: #fafafa"></span>
+
+`#fafafa`
+
+</td>
+<td><span class="color-preview" style="background-color: #fafafa"></span>
+
+`#fafafa`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the components' chrome area.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the components' chrome area.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-border</td>
     <td></td>
-    <td>rgba( black, .08 )</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`rgba( black, .08 )`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the components' chrome area.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-gradient</td>
     <td></td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of the components' chrome area.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-bg</td>
     <td></td>
-    <td>try-shade( $base-bg, .5 )</td>
-    <td>try-shade( $base-bg, .5 )</td>
+<td>
+
+
+`try-shade( $base-bg, .5 )`
+
+</td>
+<td>
+
+`try-shade( $base-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered items.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td></td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered items.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-border</td>
     <td></td>
-    <td>$base-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$base-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered items.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of hovered items.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of selected items.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-text</td>
     <td></td>
-    <td>contrast-wcag( $selected-bg )</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`contrast-wcag( $selected-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected items.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-border</td>
     <td></td>
-    <td>$base-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$base-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of selected items.</div></div>

--- a/packages/default/docs/customization-component.md
+++ b/packages/default/docs/customization-component.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$component-bg</td>
     <td></td>
-    <td>$body-bg</td>
-    <td></td>
+<td>
+
+
+`$body-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-bg` e.g. `$grid-bg: $component-bg !defualt;`.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$component-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-text` e.g. `$grid-text: component-text !default;`.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$component-border</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-border` e.g. `$grid-border: component-border !default;`.</div></div>

--- a/packages/default/docs/customization-grid.md
+++ b/packages/default/docs/customization-grid.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$grid-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the grid component</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the grid component</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the grid component</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-bg</td>
     <td></td>
-    <td>$header-bg</td>
-    <td></td>
+<td>
+
+
+`$header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid header</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-text</td>
     <td></td>
-    <td>$header-text</td>
-    <td></td>
+<td>
+
+
+`$header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid header</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid header</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-gradient</td>
     <td></td>
-    <td>$header-gradient</td>
-    <td></td>
+<td>
+
+
+`$header-gradient`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of grid header</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid footer</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid footer</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid footer</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-bg</td>
     <td></td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in grid</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in grid</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in grid</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-bg</td>
     <td></td>
-    <td>darken($grid-bg, 7%)</td>
-    <td>darken($grid-bg, 7%)</td>
+<td>
+
+
+`darken($grid-bg, 7%)`
+
+</td>
+<td>
+
+`darken($grid-bg, 7%)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in grid</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in grid</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in grid</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-bg</td>
     <td></td>
-    <td>rgba($selected-bg, .25)</td>
-    <td>rgba($selected-bg, .25)</td>
+<td>
+
+
+`rgba($selected-bg, .25)`
+
+</td>
+<td>
+
+`rgba($selected-bg, .25)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in grid</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in grid</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in grid</div></div>

--- a/packages/default/docs/customization-icons.md
+++ b/packages/default/docs/customization-icons.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$icon-font-url</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The URL to the icon font that will be used by the theme<br />The default value of `null` embeds the package font with a `data:` URL</div></div>

--- a/packages/default/docs/customization-list.md
+++ b/packages/default/docs/customization-list.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$list-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the list component.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the list component.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of list items.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of list items.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the list component.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the list component.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the list component.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list header.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list header.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-border</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of list header.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-shadow</td>
     <td></td>
-    <td>0 5px 10px 0 rgba(0, 0, 0, .06)</td>
-    <td>0 5px 10px 0 rgba(0, 0, 0, .06)</td>
+<td>
+
+
+`0 5px 10px 0 rgba(0, 0, 0, .06)`
+
+</td>
+<td>
+
+`0 5px 10px 0 rgba(0, 0, 0, .06)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of list header.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list items.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>try-shade( $base-bg, .5 )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $base-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered list items.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered list items.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused list items.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused list items.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-shadow</td>
     <td></td>
-    <td>inset 0 0 0 2px rgba(0, 0, 0, .12)</td>
-    <td>inset 0 0 0 2px rgba(0, 0, 0, .12)</td>
+<td>
+
+
+`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+
+</td>
+<td>
+
+`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused list items.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected list items.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected list items.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-no-data-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the 'No Data' text.</div></div>

--- a/packages/default/docs/customization-radio.md
+++ b/packages/default/docs/customization-radio.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$radio-radius</td>
     <td></td>
-    <td>50%</td>
-    <td>50%</td>
+<td>
+
+
+`50%`
+
+</td>
+<td>
+
+`50%`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of radio button.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of radio button.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-text</td>
     <td></td>
-    <td>$checkbox-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of radio button.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of radio button.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-bg</td>
     <td></td>
-    <td>$checkbox-hovered-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered radio button.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-text</td>
     <td></td>
-    <td>$checkbox-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered radio button.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered radio button.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked radio button.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-text</td>
     <td></td>
-    <td>$checkbox-checked-text</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`$checkbox-checked-text`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked radio button.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked radio button.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused radio button.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-shadow</td>
     <td></td>
-    <td>$checkbox-focused-shadow</td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
+<td>
+
+
+`$checkbox-focused-shadow`
+
+</td>
+<td>
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused radio button.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked radio button.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-checked-shadow</td>
     <td></td>
-    <td>$checkbox-focused-checked-shadow</td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
+<td>
+
+
+`$checkbox-focused-checked-shadow`
+
+</td>
+<td>
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked radio button.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-bg</td>
     <td></td>
-    <td>$checkbox-disabled-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled radio button.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-text</td>
     <td></td>
-    <td>$checkbox-disabled-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled radio button.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-border</td>
     <td></td>
-    <td>$checkbox-disabled-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled radio button.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-bg</td>
     <td></td>
-    <td>$checkbox-disabled-checked-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked radio button.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-text</td>
     <td></td>
-    <td>$checkbox-disabled-checked-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked radio button.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-border</td>
     <td></td>
-    <td>$checkbox-disabled-checked-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked radio button.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-bg</td>
     <td></td>
-    <td>$checkbox-invalid-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-invalid-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid radio button.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-text</td>
     <td></td>
-    <td>$checkbox-invalid-text</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid radio button.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-border</td>
     <td></td>
-    <td>$checkbox-invalid-border</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid radio button.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of radio button indicator.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-glyph-font-family</td>
     <td></td>
-    <td>"WebComponentsIcons", monospace</td>
-    <td>"WebComponentsIcons", monospace</td>
+<td>
+
+
+`"WebComponentsIcons", monospace`
+
+</td>
+<td>
+
+`"WebComponentsIcons", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph font family of radio button indicator.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-glyph</td>
     <td></td>
-    <td>"\e308"</td>
-    <td>"\e308"</td>
+<td>
+
+
+`"\e308"`
+
+</td>
+<td>
+
+`"\e308"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of radio button indicator.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked radio button indicator.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-image</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of disabled and checked radio button indicator.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal radio button list.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of radio button list items.</div></div>
@@ -338,8 +617,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of radio button list items.</div></div>
@@ -348,8 +636,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-ripple-bg</td>
     <td></td>
-    <td>$radio-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$radio-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button ripple.</div></div>
@@ -358,8 +655,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of radio button ripple.</div></div>

--- a/packages/default/docs/customization-table.md
+++ b/packages/default/docs/customization-table.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$table-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of the table border.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-vertical-border-width</td>
     <td></td>
-    <td>$grid-cell-vertical-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-vertical-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of vertical border of table cells.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-horizontal-border-width</td>
     <td></td>
-    <td>$grid-cell-horizontal-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-horizontal-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of horizontal border of table cells.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font size of the table if no size is specified.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the cells in the table if no size is specified.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the cells in the table if no size is specified.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-bg</td>
     <td></td>
-    <td>$grid-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tables.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-text</td>
     <td></td>
-    <td>$grid-text</td>
-    <td></td>
+<td>
+
+
+`$grid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tables.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tables.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table headers.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table headers.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table headers.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-bg</td>
     <td></td>
-    <td>$grid-footer-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table footers.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-text</td>
     <td></td>
-    <td>$grid-footer-text</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table footers.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-border</td>
     <td></td>
-    <td>$grid-footer-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$grid-footer-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table footers.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-bg</td>
     <td></td>
-    <td>$table-header-bg</td>
-    <td></td>
+<td>
+
+
+`$table-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of group rows in table.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-text</td>
     <td></td>
-    <td>$table-header-text</td>
-    <td></td>
+<td>
+
+
+`$table-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of group rows in table.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-border</td>
     <td></td>
-    <td>$table-header-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$table-header-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of group rows in table.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-bg</td>
     <td></td>
-    <td>$grid-alt-bg</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`$grid-alt-bg`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in table.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-text</td>
     <td></td>
-    <td>$grid-alt-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in table.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-border</td>
     <td></td>
-    <td>$grid-alt-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in table.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-bg</td>
     <td></td>
-    <td>$grid-hovered-bg</td>
-    <td>darken($grid-bg, 7%)</td>
+<td>
+
+
+`$grid-hovered-bg`
+
+</td>
+<td>
+
+`darken($grid-bg, 7%)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in table.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-text</td>
     <td></td>
-    <td>$grid-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in table.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-border</td>
     <td></td>
-    <td>$grid-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in table.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused rows in table.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused rows in table.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused rows in table.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-shadow</td>
     <td></td>
-    <td>$grid-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$grid-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused rows in table.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-bg</td>
     <td></td>
-    <td>$grid-selected-bg</td>
-    <td>rgba($selected-bg, .25)</td>
+<td>
+
+
+`$grid-selected-bg`
+
+</td>
+<td>
+
+`rgba($selected-bg, .25)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in table.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-text</td>
     <td></td>
-    <td>$grid-selected-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-selected-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in table.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-border</td>
     <td></td>
-    <td>$grid-selected-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-selected-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in table.</div></div>

--- a/packages/default/docs/customization-tabstrip.md
+++ b/packages/default/docs/customization-tabstrip.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$tabstrip-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip component</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip component</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip component</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-padding-x</td>
     <td></td>
-    <td>$nav-item-padding-x</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-x`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabs</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-padding-y</td>
     <td></td>
-    <td>$nav-item-padding-y</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-y`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabs</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabs</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>2px</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of tabs</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-gap</td>
     <td></td>
-    <td>$nav-item-margin</td>
-    <td></td>
+<td>
+
+
+`$nav-item-margin`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between tabs</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabs</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-text</td>
     <td></td>
-    <td>$link-text</td>
-    <td></td>
+<td>
+
+
+`$link-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabs</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabs</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of tabs</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered tabs</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered tabs</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered tabs</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered tabs</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected tabs</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected tabs</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected tabs</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected tabs</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabstrip content</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabstrip content</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabstrip content</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip content</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip content</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip content</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border-focused</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip focused content</div></div>

--- a/packages/default/docs/customization-toolbar.md
+++ b/packages/default/docs/customization-toolbar.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$toolbar-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the container.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$toolbar-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the container.</div></div>

--- a/packages/default/docs/customization-treeview.md
+++ b/packages/default/docs/customization-treeview.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$treeview-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the treeview component.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the treeview component.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the treeview component.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-indent</td>
     <td></td>
-    <td>16px</td>
-    <td>16px</td>
+<td>
+
+
+`16px`
+
+</td>
+<td>
+
+`16px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Indentation of child groups in treeview component.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of treeview items.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of treeview items.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of treeview items.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-border-radius</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of treeview items.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the treeview component.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the treeview component.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the treeview component.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>try-shade( $base-bg, .5 )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $base-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered treeview items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered treeview items.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered treeview items.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered treeview items.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected treeview items.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected treeview items.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected treeview items.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected treeview items.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-focused-shadow</td>
     <td></td>
-    <td>$focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused treeview items.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of load more.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-text</td>
     <td></td>
-    <td>$link-text</td>
-    <td></td>
+<td>
+
+
+`$link-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of load more.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of load more.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a hovered load more.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a hovered load more.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a hovered load more.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a focused load more.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a focused load more.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a focused load more.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-shadow</td>
     <td></td>
-    <td>$treeview-item-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$treeview-item-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of a focused load more.</div></div>

--- a/packages/default/docs/customization-typography.md
+++ b/packages/default/docs/customization-typography.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$enable-typography</td>
     <td></td>
-    <td>false</td>
-    <td>false</td>
+<td>
+
+
+`false`
+
+</td>
+<td>
+
+`false`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Global typography styles for the Kendo Default theme.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-size</td>
     <td></td>
-    <td>14px</td>
-    <td>14px</td>
+<td>
+
+
+`14px`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Base font size across all components.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-family</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family across all components.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-family-monospace</td>
     <td></td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
+<td>
+
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
+<td>
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family for monospaced text. Used for styling the code.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$line-height</td>
     <td></td>
-    <td>(20 / 14)</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`(20 / 14)`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>

--- a/packages/default/docs/customization.md
+++ b/packages/default/docs/customization.md
@@ -32,8 +32,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$border-radius</td>
     <td></td>
-    <td>2px</td>
-    <td>2px</td>
+<td>
+
+
+`2px`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius for all components.</div></div>
@@ -42,8 +51,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$base-bg</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #fafafa"></span>#fafafa</td>
-    <td><span class="color-preview" style="background-color: #fafafa"></span>#fafafa</td>
+<td>
+<span class="color-preview" style="background-color: #fafafa"></span>
+
+`#fafafa`
+
+</td>
+<td><span class="color-preview" style="background-color: #fafafa"></span>
+
+`#fafafa`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the components' chrome area.</div></div>
@@ -52,8 +70,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$base-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the components' chrome area.</div></div>
@@ -62,8 +89,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$base-border</td>
     <td></td>
-    <td>rgba( black, .08 )</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`rgba( black, .08 )`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the components' chrome area.</div></div>
@@ -72,8 +108,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$base-gradient</td>
     <td></td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of the components' chrome area.</div></div>
@@ -82,8 +127,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$hovered-bg</td>
     <td></td>
-    <td>try-shade( $base-bg, .5 )</td>
-    <td>try-shade( $base-bg, .5 )</td>
+<td>
+
+
+`try-shade( $base-bg, .5 )`
+
+</td>
+<td>
+
+`try-shade( $base-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered items.</div></div>
@@ -92,8 +146,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$hovered-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td></td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered items.</div></div>
@@ -102,8 +165,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$hovered-border</td>
     <td></td>
-    <td>$base-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$base-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered items.</div></div>
@@ -112,8 +184,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$hovered-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of hovered items.</div></div>
@@ -122,8 +203,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$selected-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of selected items.</div></div>
@@ -132,8 +222,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$selected-text</td>
     <td></td>
-    <td>contrast-wcag( $selected-bg )</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`contrast-wcag( $selected-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected items.</div></div>
@@ -142,8 +241,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$selected-border</td>
     <td></td>
-    <td>$base-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$base-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected items.</div></div>
@@ -152,8 +260,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$selected-gradient</td>
     <td></td>
-    <td>$base-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$base-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of selected items.</div></div>
@@ -183,8 +300,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$avatar-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of the avatar.</div></div>
@@ -193,8 +319,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$avatar-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the avatar.</div></div>
@@ -203,8 +338,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$avatar-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the avatar.</div></div>
@@ -213,8 +357,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$avatar-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the avatar.</div></div>
@@ -223,16 +376,25 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$avatar-sizes</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sizes of the avatar.</div></div>
@@ -262,8 +424,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$button-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of the border around the button.</div></div>
@@ -272,8 +443,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>2px</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of the button.</div></div>
@@ -282,8 +462,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of the button.</div></div>
@@ -292,8 +481,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of the button.</div></div>
@@ -302,8 +500,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the button.</div></div>
@@ -312,8 +519,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the button.</div></div>
@@ -322,8 +538,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>
@@ -332,8 +557,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated height of the button.</div></div>
@@ -342,8 +576,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-inner-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated inner height of the button. Without the border width.</div></div>
@@ -352,7 +595,10 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-theme-colors</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -363,8 +609,12 @@ The following table lists the available variables for customizing the Default th
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -375,7 +625,9 @@ The following table lists the available variables for customizing the Default th
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Theme colors map for the button.</div></div>
@@ -384,8 +636,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-bg</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #f5f5f5"></span>#f5f5f5</td>
-    <td><span class="color-preview" style="background-color: #f5f5f5"></span>#f5f5f5</td>
+<td>
+<span class="color-preview" style="background-color: #f5f5f5"></span>
+
+`#f5f5f5`
+
+</td>
+<td><span class="color-preview" style="background-color: #f5f5f5"></span>
+
+`#f5f5f5`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the buttons.</div></div>
@@ -394,8 +655,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-text</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #424242"></span>#424242</td>
-    <td><span class="color-preview" style="background-color: #424242"></span>#424242</td>
+<td>
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
+
+</td>
+<td><span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the buttons.</div></div>
@@ -404,8 +674,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-border</td>
     <td></td>
-    <td>rgba( black, .08 )</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`rgba( black, .08 )`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the buttons.</div></div>
@@ -414,8 +693,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-gradient</td>
     <td></td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of the buttons.</div></div>
@@ -424,8 +712,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-hovered-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, .5 )</td>
-    <td>try-shade( $button-bg, .5 )</td>
+<td>
+
+
+`try-shade( $button-bg, .5 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered buttons.</div></div>
@@ -434,8 +731,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered buttons.</div></div>
@@ -444,8 +750,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered buttons.</div></div>
@@ -454,8 +769,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of hovered buttons.</div></div>
@@ -464,8 +788,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-active-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, 1.5 )</td>
-    <td>try-shade( $button-bg, 1.5 )</td>
+<td>
+
+
+`try-shade( $button-bg, 1.5 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 1.5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of active buttons.</div></div>
@@ -474,8 +807,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-active-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of active buttons.</div></div>
@@ -484,8 +826,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-active-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of active buttons.</div></div>
@@ -494,8 +845,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-active-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of active buttons.</div></div>
@@ -504,8 +864,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-selected-bg</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>try-shade( $button-bg, 1.5 )</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 1.5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of selected buttons.</div></div>
@@ -514,8 +883,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-selected-text</td>
     <td></td>
-    <td>$button-active-text</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected buttons.</div></div>
@@ -524,8 +902,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-selected-border</td>
     <td></td>
-    <td>$button-active-border</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected buttons.</div></div>
@@ -534,8 +921,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of selected buttons.</div></div>
@@ -544,8 +940,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$button-focused-shadow</td>
     <td></td>
-    <td>0 0 0 2px rgba( $button-border, .08 )</td>
-    <td>0 0 0 2px rgba( $button-border, .08 )</td>
+<td>
+
+
+`0 0 0 2px rgba( $button-border, .08 )`
+
+</td>
+<td>
+
+`0 0 0 2px rgba( $button-border, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The shadow of focused buttons.</div></div>
@@ -575,8 +980,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$series-a</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The first base series color and its light and dark shades.</div></div>
@@ -585,8 +999,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$series-b</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ffd246"></span>#ffd246</td>
-    <td><span class="color-preview" style="background-color: #ffd246"></span>#ffd246</td>
+<td>
+<span class="color-preview" style="background-color: #ffd246"></span>
+
+`#ffd246`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffd246"></span>
+
+`#ffd246`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The second base series color and its light and dark shades.</div></div>
@@ -595,8 +1018,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$series-c</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #78d237"></span>#78d237</td>
-    <td><span class="color-preview" style="background-color: #78d237"></span>#78d237</td>
+<td>
+<span class="color-preview" style="background-color: #78d237"></span>
+
+`#78d237`
+
+</td>
+<td><span class="color-preview" style="background-color: #78d237"></span>
+
+`#78d237`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The third base series color and its light and dark shades.</div></div>
@@ -605,8 +1037,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$series-d</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #28b4c8"></span>#28b4c8</td>
-    <td><span class="color-preview" style="background-color: #28b4c8"></span>#28b4c8</td>
+<td>
+<span class="color-preview" style="background-color: #28b4c8"></span>
+
+`#28b4c8`
+
+</td>
+<td><span class="color-preview" style="background-color: #28b4c8"></span>
+
+`#28b4c8`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fourth base series color and its light and dark shades.</div></div>
@@ -615,8 +1056,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$series-e</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #2d73f5"></span>#2d73f5</td>
-    <td><span class="color-preview" style="background-color: #2d73f5"></span>#2d73f5</td>
+<td>
+<span class="color-preview" style="background-color: #2d73f5"></span>
+
+`#2d73f5`
+
+</td>
+<td><span class="color-preview" style="background-color: #2d73f5"></span>
+
+`#2d73f5`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fifth base series color and its light and dark shades.</div></div>
@@ -625,8 +1075,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$series-f</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #aa46be"></span>#aa46be</td>
-    <td><span class="color-preview" style="background-color: #aa46be"></span>#aa46be</td>
+<td>
+<span class="color-preview" style="background-color: #aa46be"></span>
+
+`#aa46be`
+
+</td>
+<td><span class="color-preview" style="background-color: #aa46be"></span>
+
+`#aa46be`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sixth base series color and its light and dark shades.</div></div>
@@ -635,8 +1094,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$series-1</td>
     <td></td>
-    <td>$series-a</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$series-a`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The series colors in order:<br />base, light, dark, lighter, darker</div></div>
@@ -645,8 +1113,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$chart-major-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (major).</div></div>
@@ -655,8 +1132,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$chart-minor-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (minor).</div></div>
@@ -686,8 +1172,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$checkbox-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of checkbox.</div></div>
@@ -696,8 +1191,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox.</div></div>
@@ -706,8 +1210,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checkbox.</div></div>
@@ -716,8 +1229,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checkbox.</div></div>
@@ -726,8 +1248,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered checkbox.</div></div>
@@ -736,8 +1267,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered checkbox.</div></div>
@@ -746,8 +1286,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered checkbox.</div></div>
@@ -756,8 +1305,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-checked-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked checkbox.</div></div>
@@ -766,8 +1324,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-checked-text</td>
     <td></td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked checkbox.</div></div>
@@ -776,8 +1343,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked checkbox.</div></div>
@@ -786,8 +1362,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-indeterminate-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of indeterminate checkbox.</div></div>
@@ -796,8 +1381,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-indeterminate-text</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of indeterminate checkbox.</div></div>
@@ -806,8 +1400,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-indeterminate-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of indeterminate checkbox.</div></div>
@@ -816,8 +1419,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-focused-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused checkbox.</div></div>
@@ -826,8 +1438,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-focused-shadow</td>
     <td></td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
+<td>
+
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
+<td>
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused checkbox.</div></div>
@@ -836,8 +1457,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-focused-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked checkbox.</div></div>
@@ -846,8 +1476,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-focused-checked-shadow</td>
     <td></td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
+<td>
+
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
+<td>
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked checkbox.</div></div>
@@ -856,8 +1495,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-disabled-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled checkbox.</div></div>
@@ -866,8 +1514,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-disabled-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled checkbox.</div></div>
@@ -876,8 +1533,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-disabled-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled checkbox.</div></div>
@@ -886,8 +1552,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-disabled-checked-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked checkbox.</div></div>
@@ -896,8 +1571,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-disabled-checked-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked checkbox.</div></div>
@@ -906,8 +1590,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-disabled-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked checkbox.</div></div>
@@ -916,8 +1609,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-invalid-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid checkbox.</div></div>
@@ -926,8 +1628,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-invalid-text</td>
     <td></td>
-    <td>$invalid-text</td>
-    <td></td>
+<td>
+
+
+`$invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid checkbox.</div></div>
@@ -936,8 +1647,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-invalid-border</td>
     <td></td>
-    <td>$invalid-border</td>
-    <td></td>
+<td>
+
+
+`$invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid checkbox.</div></div>
@@ -946,8 +1666,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of checkbox indicator.</div></div>
@@ -956,8 +1685,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-glyph-font-family</td>
     <td></td>
-    <td>"WebComponentsIcons", monospace</td>
-    <td>"WebComponentsIcons", monospace</td>
+<td>
+
+
+`"WebComponentsIcons", monospace`
+
+</td>
+<td>
+
+`"WebComponentsIcons", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph font family of checkbox indicator.</div></div>
@@ -966,8 +1704,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-checked-glyph</td>
     <td></td>
-    <td>"\e118"</td>
-    <td>"\e118"</td>
+<td>
+
+
+`"\e118"`
+
+</td>
+<td>
+
+`"\e118"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of checkbox indicator.</div></div>
@@ -976,8 +1723,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-indeterminate-glyph</td>
     <td></td>
-    <td>"\e121"</td>
-    <td>"\e121"</td>
+<td>
+
+
+`"\e121"`
+
+</td>
+<td>
+
+`"\e121"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of indeterminate checkbox indicator.</div></div>
@@ -986,8 +1742,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -996,8 +1761,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-indeterminate-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image image of checked checkbox indicator.</div></div>
@@ -1006,8 +1780,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal checkbox list.</div></div>
@@ -1016,8 +1799,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of checkbox list items.</div></div>
@@ -1026,8 +1818,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of checkbox list items.</div></div>
@@ -1036,8 +1837,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-ripple-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox ripple.</div></div>
@@ -1046,8 +1856,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$checkbox-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of checkbox ripple.</div></div>
@@ -1077,8 +1896,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$accent</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Deprecated</b><div class="theme-variables-description">Will be removed in v5. Use `$primary` variable instead.</div></div><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.</div></div>
@@ -1087,8 +1915,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$accent-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $accent )</td>
-    <td>contrast-wcag( $accent )</td>
+<td>
+
+
+`contrast-wcag( $accent )`
+
+</td>
+<td>
+
+`contrast-wcag( $accent )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Deprecated</b><div class="theme-variables-description">Will be removed in v5. Use `$primary-contrast` variable instead.</div></div><div><b>Description</b><div class="theme-variables-description">The color used along with the accent color denoted by $primary.</div></div>
@@ -1097,8 +1934,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$primary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.<br />Used for primary buttons and for elements of primary importance across the theme.</div></div>
@@ -1107,8 +1953,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$primary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $primary )</td>
-    <td>contrast-wcag( $primary )</td>
+<td>
+
+
+`contrast-wcag( $primary )`
+
+</td>
+<td>
+
+`contrast-wcag( $primary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the accent color denoted by $primary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1117,8 +1972,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$secondary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #666666"></span>#666666</td>
-    <td><span class="color-preview" style="background-color: #666666"></span>#666666</td>
+<td>
+<span class="color-preview" style="background-color: #666666"></span>
+
+`#666666`
+
+</td>
+<td><span class="color-preview" style="background-color: #666666"></span>
+
+`#666666`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The secondary color of the theme.</div></div>
@@ -1127,8 +1991,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$secondary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $secondary )</td>
-    <td>contrast-wcag( $secondary )</td>
+<td>
+
+
+`contrast-wcag( $secondary )`
+
+</td>
+<td>
+
+`contrast-wcag( $secondary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the secondary color denoted by $secondary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1137,8 +2010,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tertiary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
+<td>
+<span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
+<td><span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tertiary color of the theme.</div></div>
@@ -1147,8 +2029,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tertiary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $tertiary )</td>
-    <td>contrast-wcag( $tertiary )</td>
+<td>
+
+
+`contrast-wcag( $tertiary )`
+
+</td>
+<td>
+
+`contrast-wcag( $tertiary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the tertiary color denoted by $tertiary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1157,8 +2048,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$info</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
+<td>
+<span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
+<td><span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for informational messages and states.</div></div>
@@ -1167,8 +2067,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$success</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
+<td>
+<span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
+<td><span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for success messages and states.</div></div>
@@ -1177,8 +2086,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$warning</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
+<td>
+<span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for warning messages and states.</div></div>
@@ -1187,8 +2105,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$error</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
+<td>
+<span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
+<td><span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for error messages and states.</div></div>
@@ -1197,8 +2124,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$dark</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #424242"></span>#424242</td>
-    <td><span class="color-preview" style="background-color: #424242"></span>#424242</td>
+<td>
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
+
+</td>
+<td><span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The dark color of the theme.</div></div>
@@ -1207,8 +2143,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$light</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
+<td>
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
+<td><span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The light color of the theme.</div></div>
@@ -1217,8 +2162,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$inverse</td>
     <td></td>
-    <td>if( $dark-theme, $light, $dark )</td>
-    <td>if( $dark-theme, $light, $dark )</td>
+<td>
+
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
+<td>
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Inverse color of the theme. Depending on the theme luminance dark or light, it will be light or dark</div></div>
@@ -1248,8 +2202,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$component-bg</td>
     <td></td>
-    <td>$body-bg</td>
-    <td></td>
+<td>
+
+
+`$body-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-bg` e.g. `$grid-bg: $component-bg !defualt;`.</div></div>
@@ -1258,8 +2221,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$component-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-text` e.g. `$grid-text: component-text !default;`.</div></div>
@@ -1268,8 +2240,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$component-border</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-border` e.g. `$grid-border: component-border !default;`.</div></div>
@@ -1299,8 +2280,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$grid-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the grid component</div></div>
@@ -1309,8 +2299,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the grid component</div></div>
@@ -1319,8 +2318,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the grid component</div></div>
@@ -1329,8 +2337,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-header-bg</td>
     <td></td>
-    <td>$header-bg</td>
-    <td></td>
+<td>
+
+
+`$header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid header</div></div>
@@ -1339,8 +2356,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-header-text</td>
     <td></td>
-    <td>$header-text</td>
-    <td></td>
+<td>
+
+
+`$header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid header</div></div>
@@ -1349,8 +2375,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-header-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid header</div></div>
@@ -1359,8 +2394,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-header-gradient</td>
     <td></td>
-    <td>$header-gradient</td>
-    <td></td>
+<td>
+
+
+`$header-gradient`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of grid header</div></div>
@@ -1369,8 +2413,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-footer-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid footer</div></div>
@@ -1379,8 +2432,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-footer-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid footer</div></div>
@@ -1389,8 +2451,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-footer-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid footer</div></div>
@@ -1399,8 +2470,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-alt-bg</td>
     <td></td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in grid</div></div>
@@ -1409,8 +2489,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-alt-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in grid</div></div>
@@ -1419,8 +2508,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-alt-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in grid</div></div>
@@ -1429,8 +2527,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-hovered-bg</td>
     <td></td>
-    <td>darken($grid-bg, 7%)</td>
-    <td>darken($grid-bg, 7%)</td>
+<td>
+
+
+`darken($grid-bg, 7%)`
+
+</td>
+<td>
+
+`darken($grid-bg, 7%)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in grid</div></div>
@@ -1439,8 +2546,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in grid</div></div>
@@ -1449,8 +2565,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in grid</div></div>
@@ -1459,8 +2584,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-selected-bg</td>
     <td></td>
-    <td>rgba($selected-bg, .25)</td>
-    <td>rgba($selected-bg, .25)</td>
+<td>
+
+
+`rgba($selected-bg, .25)`
+
+</td>
+<td>
+
+`rgba($selected-bg, .25)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in grid</div></div>
@@ -1469,8 +2603,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-selected-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in grid</div></div>
@@ -1479,8 +2622,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$grid-selected-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in grid</div></div>
@@ -1510,8 +2662,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$icon-font-url</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The URL to the icon font that will be used by the theme<br />The default value of `null` embeds the package font with a `data:` URL</div></div>
@@ -1541,8 +2702,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$list-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the list component.</div></div>
@@ -1551,8 +2721,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the list component.</div></div>
@@ -1561,8 +2740,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of list items.</div></div>
@@ -1571,8 +2759,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of list items.</div></div>
@@ -1581,8 +2778,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the list component.</div></div>
@@ -1591,8 +2797,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the list component.</div></div>
@@ -1601,8 +2816,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the list component.</div></div>
@@ -1611,8 +2835,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-header-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list header.</div></div>
@@ -1621,8 +2854,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-header-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list header.</div></div>
@@ -1631,8 +2873,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-header-border</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of list header.</div></div>
@@ -1641,8 +2892,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-header-shadow</td>
     <td></td>
-    <td>0 5px 10px 0 rgba(0, 0, 0, .06)</td>
-    <td>0 5px 10px 0 rgba(0, 0, 0, .06)</td>
+<td>
+
+
+`0 5px 10px 0 rgba(0, 0, 0, .06)`
+
+</td>
+<td>
+
+`0 5px 10px 0 rgba(0, 0, 0, .06)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of list header.</div></div>
@@ -1651,8 +2911,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list items.</div></div>
@@ -1661,8 +2930,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-item-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list items.</div></div>
@@ -1671,8 +2949,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>try-shade( $base-bg, .5 )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $base-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered list items.</div></div>
@@ -1681,8 +2968,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered list items.</div></div>
@@ -1691,8 +2987,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-item-focused-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused list items.</div></div>
@@ -1701,8 +3006,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-item-focused-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused list items.</div></div>
@@ -1711,8 +3025,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-item-focused-shadow</td>
     <td></td>
-    <td>inset 0 0 0 2px rgba(0, 0, 0, .12)</td>
-    <td>inset 0 0 0 2px rgba(0, 0, 0, .12)</td>
+<td>
+
+
+`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+
+</td>
+<td>
+
+`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused list items.</div></div>
@@ -1721,8 +3044,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected list items.</div></div>
@@ -1731,8 +3063,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected list items.</div></div>
@@ -1741,8 +3082,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$list-no-data-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the 'No Data' text.</div></div>
@@ -1772,8 +3122,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$radio-radius</td>
     <td></td>
-    <td>50%</td>
-    <td>50%</td>
+<td>
+
+
+`50%`
+
+</td>
+<td>
+
+`50%`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of radio button.</div></div>
@@ -1782,8 +3141,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of radio button.</div></div>
@@ -1792,8 +3160,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>$body-bg</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`$body-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button.</div></div>
@@ -1802,8 +3179,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-text</td>
     <td></td>
-    <td>$checkbox-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of radio button.</div></div>
@@ -1812,8 +3198,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of radio button.</div></div>
@@ -1822,8 +3217,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-hovered-bg</td>
     <td></td>
-    <td>$checkbox-hovered-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered radio button.</div></div>
@@ -1832,8 +3236,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-hovered-text</td>
     <td></td>
-    <td>$checkbox-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered radio button.</div></div>
@@ -1842,8 +3255,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-hovered-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered radio button.</div></div>
@@ -1852,8 +3274,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-checked-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked radio button.</div></div>
@@ -1862,8 +3293,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-checked-text</td>
     <td></td>
-    <td>$checkbox-checked-text</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`$checkbox-checked-text`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked radio button.</div></div>
@@ -1872,8 +3312,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked radio button.</div></div>
@@ -1882,8 +3331,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-focused-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused radio button.</div></div>
@@ -1892,8 +3350,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-focused-shadow</td>
     <td></td>
-    <td>$checkbox-focused-shadow</td>
-    <td>0 0 0 2px rgba(0, 0, 0, .06)</td>
+<td>
+
+
+`$checkbox-focused-shadow`
+
+</td>
+<td>
+
+`0 0 0 2px rgba(0, 0, 0, .06)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused radio button.</div></div>
@@ -1902,8 +3369,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-focused-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked radio button.</div></div>
@@ -1912,8 +3388,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-focused-checked-shadow</td>
     <td></td>
-    <td>$checkbox-focused-checked-shadow</td>
-    <td>0 0 0 2px rgba( $primary, .3 )</td>
+<td>
+
+
+`$checkbox-focused-checked-shadow`
+
+</td>
+<td>
+
+`0 0 0 2px rgba( $primary, .3 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked radio button.</div></div>
@@ -1922,8 +3407,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-disabled-bg</td>
     <td></td>
-    <td>$checkbox-disabled-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled radio button.</div></div>
@@ -1932,8 +3426,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-disabled-text</td>
     <td></td>
-    <td>$checkbox-disabled-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled radio button.</div></div>
@@ -1942,8 +3445,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-disabled-border</td>
     <td></td>
-    <td>$checkbox-disabled-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled radio button.</div></div>
@@ -1952,8 +3464,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-disabled-checked-bg</td>
     <td></td>
-    <td>$checkbox-disabled-checked-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked radio button.</div></div>
@@ -1962,8 +3483,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-disabled-checked-text</td>
     <td></td>
-    <td>$checkbox-disabled-checked-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked radio button.</div></div>
@@ -1972,8 +3502,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-disabled-checked-border</td>
     <td></td>
-    <td>$checkbox-disabled-checked-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-disabled-checked-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked radio button.</div></div>
@@ -1982,8 +3521,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-invalid-bg</td>
     <td></td>
-    <td>$checkbox-invalid-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-invalid-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid radio button.</div></div>
@@ -1992,8 +3540,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-invalid-text</td>
     <td></td>
-    <td>$checkbox-invalid-text</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid radio button.</div></div>
@@ -2002,8 +3559,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-invalid-border</td>
     <td></td>
-    <td>$checkbox-invalid-border</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid radio button.</div></div>
@@ -2012,8 +3578,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of radio button indicator.</div></div>
@@ -2022,8 +3597,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-glyph-font-family</td>
     <td></td>
-    <td>"WebComponentsIcons", monospace</td>
-    <td>"WebComponentsIcons", monospace</td>
+<td>
+
+
+`"WebComponentsIcons", monospace`
+
+</td>
+<td>
+
+`"WebComponentsIcons", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph font family of radio button indicator.</div></div>
@@ -2032,8 +3616,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-checked-glyph</td>
     <td></td>
-    <td>"\e308"</td>
-    <td>"\e308"</td>
+<td>
+
+
+`"\e308"`
+
+</td>
+<td>
+
+`"\e308"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of radio button indicator.</div></div>
@@ -2042,8 +3635,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked radio button indicator.</div></div>
@@ -2052,8 +3654,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-disabled-checked-image</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of disabled and checked radio button indicator.</div></div>
@@ -2062,8 +3673,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal radio button list.</div></div>
@@ -2072,8 +3692,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of radio button list items.</div></div>
@@ -2082,8 +3711,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of radio button list items.</div></div>
@@ -2092,8 +3730,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-ripple-bg</td>
     <td></td>
-    <td>$radio-checked-bg</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$radio-checked-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button ripple.</div></div>
@@ -2102,8 +3749,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$radio-ripple-opacity</td>
     <td></td>
-    <td>.25</td>
-    <td>.25</td>
+<td>
+
+
+`.25`
+
+</td>
+<td>
+
+`.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of radio button ripple.</div></div>
@@ -2133,8 +3789,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$table-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of the table border.</div></div>
@@ -2143,8 +3808,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-cell-vertical-border-width</td>
     <td></td>
-    <td>$grid-cell-vertical-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-vertical-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of vertical border of table cells.</div></div>
@@ -2153,8 +3827,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-cell-horizontal-border-width</td>
     <td></td>
-    <td>$grid-cell-horizontal-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-horizontal-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of horizontal border of table cells.</div></div>
@@ -2163,8 +3846,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font size of the table if no size is specified.</div></div>
@@ -2173,8 +3865,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-cell-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the cells in the table if no size is specified.</div></div>
@@ -2183,8 +3884,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-cell-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the cells in the table if no size is specified.</div></div>
@@ -2193,8 +3903,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-bg</td>
     <td></td>
-    <td>$grid-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tables.</div></div>
@@ -2203,8 +3922,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-text</td>
     <td></td>
-    <td>$grid-text</td>
-    <td></td>
+<td>
+
+
+`$grid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tables.</div></div>
@@ -2213,8 +3941,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tables.</div></div>
@@ -2223,8 +3960,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-header-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table headers.</div></div>
@@ -2233,8 +3979,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-header-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td></td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table headers.</div></div>
@@ -2243,8 +3998,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-header-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table headers.</div></div>
@@ -2253,8 +4017,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-footer-bg</td>
     <td></td>
-    <td>$grid-footer-bg</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table footers.</div></div>
@@ -2263,8 +4036,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-footer-text</td>
     <td></td>
-    <td>$grid-footer-text</td>
-    <td></td>
+<td>
+
+
+`$grid-footer-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table footers.</div></div>
@@ -2273,8 +4055,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-footer-border</td>
     <td></td>
-    <td>$grid-footer-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$grid-footer-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table footers.</div></div>
@@ -2283,8 +4074,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-group-row-bg</td>
     <td></td>
-    <td>$table-header-bg</td>
-    <td></td>
+<td>
+
+
+`$table-header-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of group rows in table.</div></div>
@@ -2293,8 +4093,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-group-row-text</td>
     <td></td>
-    <td>$table-header-text</td>
-    <td></td>
+<td>
+
+
+`$table-header-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of group rows in table.</div></div>
@@ -2303,8 +4112,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-group-row-border</td>
     <td></td>
-    <td>$table-header-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$table-header-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of group rows in table.</div></div>
@@ -2313,8 +4131,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-alt-row-bg</td>
     <td></td>
-    <td>$grid-alt-bg</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`$grid-alt-bg`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in table.</div></div>
@@ -2323,8 +4150,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-alt-row-text</td>
     <td></td>
-    <td>$grid-alt-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in table.</div></div>
@@ -2333,8 +4169,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-alt-row-border</td>
     <td></td>
-    <td>$grid-alt-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in table.</div></div>
@@ -2343,8 +4188,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-hover-bg</td>
     <td></td>
-    <td>$grid-hovered-bg</td>
-    <td>darken($grid-bg, 7%)</td>
+<td>
+
+
+`$grid-hovered-bg`
+
+</td>
+<td>
+
+`darken($grid-bg, 7%)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in table.</div></div>
@@ -2353,8 +4207,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-hover-text</td>
     <td></td>
-    <td>$grid-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in table.</div></div>
@@ -2363,8 +4226,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-hover-border</td>
     <td></td>
-    <td>$grid-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in table.</div></div>
@@ -2373,8 +4245,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-focus-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused rows in table.</div></div>
@@ -2383,8 +4264,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-focus-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused rows in table.</div></div>
@@ -2393,8 +4283,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused rows in table.</div></div>
@@ -2403,8 +4302,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-focus-shadow</td>
     <td></td>
-    <td>$grid-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$grid-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused rows in table.</div></div>
@@ -2413,8 +4321,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-selected-bg</td>
     <td></td>
-    <td>$grid-selected-bg</td>
-    <td>rgba($selected-bg, .25)</td>
+<td>
+
+
+`$grid-selected-bg`
+
+</td>
+<td>
+
+`rgba($selected-bg, .25)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in table.</div></div>
@@ -2423,8 +4340,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-selected-text</td>
     <td></td>
-    <td>$grid-selected-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-selected-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in table.</div></div>
@@ -2433,8 +4359,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$table-selected-border</td>
     <td></td>
-    <td>$grid-selected-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-selected-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in table.</div></div>
@@ -2464,8 +4399,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$tabstrip-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip component</div></div>
@@ -2474,8 +4418,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip component</div></div>
@@ -2484,8 +4437,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip component</div></div>
@@ -2494,8 +4456,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-padding-x</td>
     <td></td>
-    <td>$nav-item-padding-x</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-x`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabs</div></div>
@@ -2504,8 +4475,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-padding-y</td>
     <td></td>
-    <td>$nav-item-padding-y</td>
-    <td></td>
+<td>
+
+
+`$nav-item-padding-y`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabs</div></div>
@@ -2514,8 +4494,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabs</div></div>
@@ -2524,8 +4513,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-border-radius</td>
     <td></td>
-    <td>$border-radius</td>
-    <td>2px</td>
+<td>
+
+
+`$border-radius`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of tabs</div></div>
@@ -2534,8 +4532,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-gap</td>
     <td></td>
-    <td>$nav-item-margin</td>
-    <td></td>
+<td>
+
+
+`$nav-item-margin`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between tabs</div></div>
@@ -2544,8 +4551,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabs</div></div>
@@ -2554,8 +4570,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-text</td>
     <td></td>
-    <td>$link-text</td>
-    <td></td>
+<td>
+
+
+`$link-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabs</div></div>
@@ -2564,8 +4589,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabs</div></div>
@@ -2574,8 +4608,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of tabs</div></div>
@@ -2584,8 +4627,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered tabs</div></div>
@@ -2594,8 +4646,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-hovered-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered tabs</div></div>
@@ -2604,8 +4665,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered tabs</div></div>
@@ -2614,8 +4684,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered tabs</div></div>
@@ -2624,8 +4703,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-selected-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected tabs</div></div>
@@ -2634,8 +4722,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-selected-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected tabs</div></div>
@@ -2644,8 +4741,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-selected-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected tabs</div></div>
@@ -2654,8 +4760,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected tabs</div></div>
@@ -2664,8 +4779,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-content-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabstrip content</div></div>
@@ -2674,8 +4798,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-content-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabstrip content</div></div>
@@ -2684,8 +4817,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-content-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabstrip content</div></div>
@@ -2694,8 +4836,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-content-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip content</div></div>
@@ -2704,8 +4855,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-content-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip content</div></div>
@@ -2714,8 +4874,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-content-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip content</div></div>
@@ -2724,8 +4893,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$tabstrip-content-border-focused</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip focused content</div></div>
@@ -2755,8 +4933,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$toolbar-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the container.</div></div>
@@ -2765,8 +4952,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$toolbar-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the container.</div></div>
@@ -2796,8 +4992,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$treeview-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>inherit</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the treeview component.</div></div>
@@ -2806,8 +5011,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-font-size</td>
     <td></td>
-    <td>$font-size-md</td>
-    <td></td>
+<td>
+
+
+`$font-size-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the treeview component.</div></div>
@@ -2816,8 +5030,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-line-height</td>
     <td></td>
-    <td>$line-height-md</td>
-    <td></td>
+<td>
+
+
+`$line-height-md`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the treeview component.</div></div>
@@ -2826,8 +5049,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-indent</td>
     <td></td>
-    <td>16px</td>
-    <td>16px</td>
+<td>
+
+
+`16px`
+
+</td>
+<td>
+
+`16px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Indentation of child groups in treeview component.</div></div>
@@ -2836,8 +5068,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of treeview items.</div></div>
@@ -2846,8 +5087,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of treeview items.</div></div>
@@ -2856,8 +5106,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of treeview items.</div></div>
@@ -2866,8 +5125,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-border-radius</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of treeview items.</div></div>
@@ -2876,8 +5144,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the treeview component.</div></div>
@@ -2886,8 +5163,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the treeview component.</div></div>
@@ -2896,8 +5182,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the treeview component.</div></div>
@@ -2906,8 +5201,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>try-shade( $base-bg, .5 )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`try-shade( $base-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered treeview items.</div></div>
@@ -2916,8 +5220,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered treeview items.</div></div>
@@ -2926,8 +5239,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered treeview items.</div></div>
@@ -2936,8 +5258,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered treeview items.</div></div>
@@ -2946,8 +5277,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-selected-bg</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$primary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$primary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected treeview items.</div></div>
@@ -2956,8 +5296,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-selected-text</td>
     <td></td>
-    <td>$selected-text</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`$selected-text`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected treeview items.</div></div>
@@ -2966,8 +5315,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-selected-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected treeview items.</div></div>
@@ -2976,8 +5334,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected treeview items.</div></div>
@@ -2986,8 +5353,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-item-focused-shadow</td>
     <td></td>
-    <td>$focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused treeview items.</div></div>
@@ -2996,8 +5372,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-loadmore-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of load more.</div></div>
@@ -3006,8 +5391,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-loadmore-text</td>
     <td></td>
-    <td>$link-text</td>
-    <td></td>
+<td>
+
+
+`$link-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of load more.</div></div>
@@ -3016,8 +5410,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-loadmore-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of load more.</div></div>
@@ -3026,8 +5429,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-loadmore-hover-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a hovered load more.</div></div>
@@ -3036,8 +5448,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-loadmore-hover-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a hovered load more.</div></div>
@@ -3046,8 +5467,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-loadmore-hover-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a hovered load more.</div></div>
@@ -3056,8 +5486,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-loadmore-focus-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a focused load more.</div></div>
@@ -3066,8 +5505,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-loadmore-focus-text</td>
     <td></td>
-    <td>$link-hover-text</td>
-    <td></td>
+<td>
+
+
+`$link-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a focused load more.</div></div>
@@ -3076,8 +5524,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-loadmore-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a focused load more.</div></div>
@@ -3086,8 +5543,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$treeview-loadmore-focus-shadow</td>
     <td></td>
-    <td>$treeview-item-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$treeview-item-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of a focused load more.</div></div>
@@ -3117,8 +5583,17 @@ The following table lists the available variables for customizing the Default th
         <tr>
     <td>$enable-typography</td>
     <td></td>
-    <td>false</td>
-    <td>false</td>
+<td>
+
+
+`false`
+
+</td>
+<td>
+
+`false`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Global typography styles for the Kendo Default theme.</div></div>
@@ -3127,8 +5602,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$font-size</td>
     <td></td>
-    <td>14px</td>
-    <td>14px</td>
+<td>
+
+
+`14px`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Base font size across all components.</div></div>
@@ -3137,8 +5621,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$font-family</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family across all components.</div></div>
@@ -3147,8 +5640,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$font-family-monospace</td>
     <td></td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
+<td>
+
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
+<td>
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family for monospaced text. Used for styling the code.</div></div>
@@ -3157,8 +5659,17 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$line-height</td>
     <td></td>
-    <td>(20 / 14)</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`(20 / 14)`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>

--- a/packages/material/docs/customization-avatar.md
+++ b/packages/material/docs/customization-avatar.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$avatar-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of the avatar.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>Roboto, "Helvetica Neue", sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`Roboto, "Helvetica Neue", sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the avatar.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the avatar.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>(28 / 14)</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`(28 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the avatar.</div></div>
@@ -68,16 +104,25 @@ The following table lists the available variables for customization.
 <tr>
     <td>$avatar-sizes</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sizes of the avatar.</div></div>

--- a/packages/material/docs/customization-button.md
+++ b/packages/material/docs/customization-button.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$button-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of the border around the button.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-border-radius</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of the button.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of the button.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of the button.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>Roboto, "Helvetica Neue", sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`Roboto, "Helvetica Neue", sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the button.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the button.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-line-height</td>
     <td></td>
-    <td>(20 / 14)</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`(20 / 14)`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated height of the button.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-inner-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated inner height of the button. Without the border width.</div></div>
@@ -118,7 +199,10 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-theme-colors</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -129,8 +213,12 @@ The following table lists the available variables for customization.
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -141,7 +229,9 @@ The following table lists the available variables for customization.
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Theme colors map for the button.</div></div>
@@ -150,8 +240,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-bg</td>
     <td></td>
-    <td>$base-bg</td>
-    <td>map-get( $theme, base-bg )</td>
+<td>
+
+
+`$base-bg`
+
+</td>
+<td>
+
+`map-get( $theme, base-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the buttons.</div></div>
@@ -160,8 +259,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the buttons.</div></div>
@@ -170,8 +278,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-border</td>
     <td></td>
-    <td>$button-bg</td>
-    <td>map-get( $theme, base-bg )</td>
+<td>
+
+
+`$button-bg`
+
+</td>
+<td>
+
+`map-get( $theme, base-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the buttons.</div></div>
@@ -180,8 +297,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of the buttons.</div></div>
@@ -190,8 +316,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered buttons.</div></div>
@@ -200,8 +335,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered buttons.</div></div>
@@ -210,8 +354,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered buttons.</div></div>
@@ -220,8 +373,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of hovered buttons.</div></div>
@@ -230,8 +392,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of active buttons.</div></div>
@@ -240,8 +411,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of active buttons.</div></div>
@@ -250,8 +430,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of active buttons.</div></div>
@@ -260,8 +449,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of active buttons.</div></div>
@@ -270,8 +468,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-bg</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of selected buttons.</div></div>
@@ -280,8 +487,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-text</td>
     <td></td>
-    <td>$button-active-text</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected buttons.</div></div>
@@ -290,8 +506,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-border</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected buttons.</div></div>
@@ -300,8 +525,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of selected buttons.</div></div>
@@ -310,8 +544,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-focused-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The shadow of focused buttons.</div></div>

--- a/packages/material/docs/customization-charts.md
+++ b/packages/material/docs/customization-charts.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$series-a</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #3f51b5"></span>#3f51b5</td>
-    <td><span class="color-preview" style="background-color: #3f51b5"></span>#3f51b5</td>
+<td>
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
+
+</td>
+<td><span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The first base series color and its light and dark shades.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-b</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #2196f3"></span>#2196f3</td>
-    <td><span class="color-preview" style="background-color: #2196f3"></span>#2196f3</td>
+<td>
+<span class="color-preview" style="background-color: #2196f3"></span>
+
+`#2196f3`
+
+</td>
+<td><span class="color-preview" style="background-color: #2196f3"></span>
+
+`#2196f3`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The second base series color and its light and dark shades.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-c</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #43a047"></span>#43a047</td>
-    <td><span class="color-preview" style="background-color: #43a047"></span>#43a047</td>
+<td>
+<span class="color-preview" style="background-color: #43a047"></span>
+
+`#43a047`
+
+</td>
+<td><span class="color-preview" style="background-color: #43a047"></span>
+
+`#43a047`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The third base series color and its light and dark shades.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-d</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ffc107"></span>#ffc107</td>
-    <td><span class="color-preview" style="background-color: #ffc107"></span>#ffc107</td>
+<td>
+<span class="color-preview" style="background-color: #ffc107"></span>
+
+`#ffc107`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffc107"></span>
+
+`#ffc107`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fourth base series color and its light and dark shades.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-e</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ff5722"></span>#ff5722</td>
-    <td><span class="color-preview" style="background-color: #ff5722"></span>#ff5722</td>
+<td>
+<span class="color-preview" style="background-color: #ff5722"></span>
+
+`#ff5722`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff5722"></span>
+
+`#ff5722`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fifth base series color and its light and dark shades.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-f</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #e91e63"></span>#e91e63</td>
-    <td><span class="color-preview" style="background-color: #e91e63"></span>#e91e63</td>
+<td>
+<span class="color-preview" style="background-color: #e91e63"></span>
+
+`#e91e63`
+
+</td>
+<td><span class="color-preview" style="background-color: #e91e63"></span>
+
+`#e91e63`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sixth base series color and its light and dark shades.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$series-1</td>
     <td></td>
-    <td>$series-a</td>
-    <td><span class="color-preview" style="background-color: #3f51b5"></span>#3f51b5</td>
+<td>
+
+
+`$series-a`
+
+</td>
+<td><span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The series colors in order:<br />base, light, dark, lighter, darker</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$chart-major-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (major).</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$chart-minor-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (minor).</div></div>

--- a/packages/material/docs/customization-checkbox.md
+++ b/packages/material/docs/customization-checkbox.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$checkbox-border-width</td>
     <td></td>
-    <td>2px</td>
-    <td>2px</td>
+<td>
+
+
+`2px`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of checkbox.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checkbox.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-border</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .54 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .54 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .54 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .54 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checkbox.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered checkbox.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered checkbox.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered checkbox.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked checkbox.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-text</td>
     <td></td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked checkbox.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked checkbox.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of indeterminate checkbox.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-text</td>
     <td></td>
-    <td>$checkbox-checked-text</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`$checkbox-checked-text`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of indeterminate checkbox.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of indeterminate checkbox.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused checkbox.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused checkbox.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked checkbox.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-focused-checked-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked checkbox.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled checkbox.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled checkbox.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-border</td>
     <td></td>
-    <td>try-shade( $component-bg, 4 )</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`try-shade( $component-bg, 4 )`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled checkbox.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-bg</td>
     <td></td>
-    <td>$checkbox-disabled-border</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`$checkbox-disabled-border`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked checkbox.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-text</td>
     <td></td>
-    <td>contrast-wcag( $checkbox-disabled-checked-bg )</td>
-    <td>contrast-wcag( $checkbox-disabled-checked-bg )</td>
+<td>
+
+
+`contrast-wcag( $checkbox-disabled-checked-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-disabled-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked checkbox.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-disabled-checked-border</td>
     <td></td>
-    <td>$checkbox-disabled-checked-bg</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`$checkbox-disabled-checked-bg`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked checkbox.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid checkbox.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-text</td>
     <td></td>
-    <td>$invalid-text</td>
-    <td></td>
+<td>
+
+
+`$invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid checkbox.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-invalid-border</td>
     <td></td>
-    <td>$invalid-border</td>
-    <td></td>
+<td>
+
+
+`$invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid checkbox.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of checkbox indicator.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-glyph-font-family</td>
     <td></td>
-    <td>"WebComponentsIcons", monospace</td>
-    <td>"WebComponentsIcons", monospace</td>
+<td>
+
+
+`"WebComponentsIcons", monospace`
+
+</td>
+<td>
+
+`"WebComponentsIcons", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph font family of checkbox indicator.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-glyph</td>
     <td></td>
-    <td>"\e118"</td>
-    <td>"\e118"</td>
+<td>
+
+
+`"\e118"`
+
+</td>
+<td>
+
+`"\e118"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of checkbox indicator.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-glyph</td>
     <td></td>
-    <td>"\e121"</td>
-    <td>"\e121"</td>
+<td>
+
+
+`"\e121"`
+
+</td>
+<td>
+
+`"\e121"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of indeterminate checkbox indicator.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -338,8 +617,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-indeterminate-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -348,8 +636,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal checkbox list.</div></div>
@@ -358,8 +655,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of checkbox list items.</div></div>
@@ -368,8 +674,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of checkbox list items.</div></div>
@@ -378,8 +693,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-ripple-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox ripple.</div></div>
@@ -388,8 +712,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$checkbox-ripple-opacity</td>
     <td></td>
-    <td>.2</td>
-    <td>.2</td>
+<td>
+
+
+`.2`
+
+</td>
+<td>
+
+`.2`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of checkbox ripple.</div></div>

--- a/packages/material/docs/customization-color-system.md
+++ b/packages/material/docs/customization-color-system.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$primary</td>
     <td>Color</td>
-    <td>material-color( $primary-palette, main )</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`material-color( $primary-palette, main )`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.<br />Used for primary buttons and for elements of primary importance across the theme.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$primary-contrast</td>
     <td>Color</td>
-    <td>material-color( $primary-palette, main-contrast )</td>
-    <td>material-color( $primary-palette, main-contrast )</td>
+<td>
+
+
+`material-color( $primary-palette, main-contrast )`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main-contrast )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the primary color denoted by $primary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$secondary</td>
     <td>Color</td>
-    <td>material-color( $secondary-palette, main )</td>
-    <td>material-color( $secondary-palette, main )</td>
+<td>
+
+
+`material-color( $secondary-palette, main )`
+
+</td>
+<td>
+
+`material-color( $secondary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The secondary color of the theme.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$secondary-contrast</td>
     <td>Color</td>
-    <td>material-color( $secondary-palette, main-contrast )</td>
-    <td>material-color( $secondary-palette, main-contrast )</td>
+<td>
+
+
+`material-color( $secondary-palette, main-contrast )`
+
+</td>
+<td>
+
+`material-color( $secondary-palette, main-contrast )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the secondary color denoted by $secondary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tertiary</td>
     <td>Color</td>
-    <td>material-color($tertiary-palette, main)</td>
-    <td>material-color($tertiary-palette, main)</td>
+<td>
+
+
+`material-color($tertiary-palette, main)`
+
+</td>
+<td>
+
+`material-color($tertiary-palette, main)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tertiary color of the theme.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tertiary-contrast</td>
     <td>Color</td>
-    <td>material-color($tertiary-palette, main-contrast)</td>
-    <td>material-color($tertiary-palette, main-contrast)</td>
+<td>
+
+
+`material-color($tertiary-palette, main-contrast)`
+
+</td>
+<td>
+
+`material-color($tertiary-palette, main-contrast)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the tertiary color denoted by $tertiary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$info</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
+<td>
+<span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
+<td><span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for informational messages and states.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$success</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
+<td>
+<span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
+<td><span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for success messages and states.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$warning</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
+<td>
+<span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for warning messages and states.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$error</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
+<td>
+<span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
+<td><span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for error messages and states.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dark</td>
     <td>Color</td>
-    <td>get-base-hue( gray, 800 )</td>
-    <td>get-base-hue( gray, 800 )</td>
+<td>
+
+
+`get-base-hue( gray, 800 )`
+
+</td>
+<td>
+
+`get-base-hue( gray, 800 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The dark color of the theme.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$light</td>
     <td>Color</td>
-    <td>get-base-hue( gray, 100 )</td>
-    <td>get-base-hue( gray, 100 )</td>
+<td>
+
+
+`get-base-hue( gray, 100 )`
+
+</td>
+<td>
+
+`get-base-hue( gray, 100 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The light color of the theme.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$inverse</td>
     <td></td>
-    <td>if( $dark-theme, $light, $dark )</td>
-    <td>if( $dark-theme, $light, $dark )</td>
+<td>
+
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
+<td>
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Inverse color of the theme. Depending on the theme luminance dark or lught, it will be light or dark</div></div>

--- a/packages/material/docs/customization-common.md
+++ b/packages/material/docs/customization-common.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$border-radius</td>
     <td></td>
-    <td>2px</td>
-    <td>2px</td>
+<td>
+
+
+`2px`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius for all components.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-bg</td>
     <td></td>
-    <td>map-get( $theme, base-bg )</td>
-    <td>map-get( $theme, base-bg )</td>
+<td>
+
+
+`map-get( $theme, base-bg )`
+
+</td>
+<td>
+
+`map-get( $theme, base-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the components' chrome area.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-text</td>
     <td></td>
-    <td>map-get($theme, component-text)</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`map-get($theme, component-text)`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the components' chrome area.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-border</td>
     <td></td>
-    <td>rgba( if($theme-type == dark, white, black), .08 )</td>
-    <td>rgba( if($theme-type == dark, white, black), .08 )</td>
+<td>
+
+
+`rgba( if($theme-type == dark, white, black), .08 )`
+
+</td>
+<td>
+
+`rgba( if($theme-type == dark, white, black), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border of the components' chrome area.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$base-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of the components' chrome area.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-bg</td>
     <td></td>
-    <td>map-get( $theme, hover-bg )</td>
-    <td>map-get( $theme, hover-bg )</td>
+<td>
+
+
+`map-get( $theme, hover-bg )`
+
+</td>
+<td>
+
+`map-get( $theme, hover-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered items.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered items.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-border</td>
     <td></td>
-    <td>rgba( if($theme-type == dark, white, black), .15 )</td>
-    <td>rgba( if($theme-type == dark, white, black), .15 )</td>
+<td>
+
+
+`rgba( if($theme-type == dark, white, black), .15 )`
+
+</td>
+<td>
+
+`rgba( if($theme-type == dark, white, black), .15 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered items.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of hovered items.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-bg</td>
     <td></td>
-    <td>$secondary</td>
-    <td>material-color( $secondary-palette, main )</td>
+<td>
+
+
+`$secondary`
+
+</td>
+<td>
+
+`material-color( $secondary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of selected items.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-text</td>
     <td></td>
-    <td>$secondary-contrast</td>
-    <td>material-color( $secondary-palette, main-contrast )</td>
+<td>
+
+
+`$secondary-contrast`
+
+</td>
+<td>
+
+`material-color( $secondary-palette, main-contrast )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected items.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-border</td>
     <td></td>
-    <td>rgba( if($theme-type == dark, white, black), .1 )</td>
-    <td>rgba( if($theme-type == dark, white, black), .1 )</td>
+<td>
+
+
+`rgba( if($theme-type == dark, white, black), .1 )`
+
+</td>
+<td>
+
+`rgba( if($theme-type == dark, white, black), .1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of selected items.</div></div>

--- a/packages/material/docs/customization-component.md
+++ b/packages/material/docs/customization-component.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$component-bg</td>
     <td></td>
-    <td>map-get($theme, component-bg)</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`map-get($theme, component-bg)`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-bg` e.g. `$grid-bg: $component-bg !defualt;`.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$component-text</td>
     <td></td>
-    <td>map-get($theme, component-text)</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`map-get($theme, component-text)`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-text` e.g. `$grid-text: component-text !default;`.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$component-border</td>
     <td></td>
-    <td>map-get($theme, component-border)</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`map-get($theme, component-border)`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-border` e.g. `$grid-border: component-border !default;`.</div></div>

--- a/packages/material/docs/customization-grid.md
+++ b/packages/material/docs/customization-grid.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$grid-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the grid component</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the grid component</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the grid component</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-bg</td>
     <td></td>
-    <td>$grid-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$grid-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid header</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-text</td>
     <td></td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
+<td>
+
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
+<td>
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid header</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid header</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-header-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of grid header</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid footer</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid footer</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-footer-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid footer</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in grid</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in grid</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-alt-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in grid</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-bg</td>
     <td></td>
-    <td>rgba( contrast-wcag( $grid-bg ), .07 )</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .07 )</td>
+<td>
+
+
+`rgba( contrast-wcag( $grid-bg ), .07 )`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .07 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in grid</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in grid</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-hovered-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in grid</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-bg</td>
     <td></td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in grid</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in grid</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$grid-selected-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in grid</div></div>

--- a/packages/material/docs/customization-icons.md
+++ b/packages/material/docs/customization-icons.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$icon-font-url</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The URL to the icon font that will be used by the theme<br />The default value of `null` embeds the package font with a `data:` URL</div></div>

--- a/packages/material/docs/customization-list.md
+++ b/packages/material/docs/customization-list.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$list-font-size</td>
     <td></td>
-    <td>$font-size-lg</td>
-    <td></td>
+<td>
+
+
+`$font-size-lg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the list component.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-line-height</td>
     <td></td>
-    <td>1.25</td>
-    <td>1.25</td>
+<td>
+
+
+`1.25`
+
+</td>
+<td>
+
+`1.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the list component.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of list items.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of list items.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the list component.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the list component.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the list component.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list header.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list header.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-border</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of list header.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-header-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of list header.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list items.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>map-get( $theme, hover-bg )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`map-get( $theme, hover-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered list items.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered list items.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused list items.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused list items.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-focused-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused list items.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-selected-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected list items.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-item-selected-text</td>
     <td></td>
-    <td>$secondary</td>
-    <td>material-color( $secondary-palette, main )</td>
+<td>
+
+
+`$secondary`
+
+</td>
+<td>
+
+`material-color( $secondary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected list items.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-no-data-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the 'No Data' text.</div></div>

--- a/packages/material/docs/customization-radio.md
+++ b/packages/material/docs/customization-radio.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$radio-radius</td>
     <td></td>
-    <td>50%</td>
-    <td>50%</td>
+<td>
+
+
+`50%`
+
+</td>
+<td>
+
+`50%`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of radio button.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-border-width</td>
     <td></td>
-    <td>2px</td>
-    <td>2px</td>
+<td>
+
+
+`2px`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of radio button.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-text</td>
     <td></td>
-    <td>$checkbox-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of radio button.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .54 )</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .54 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of radio button.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered radio button.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered radio button.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered radio button.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked radio button.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-text</td>
     <td></td>
-    <td>$primary</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked radio button.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-border</td>
     <td></td>
-    <td>$radio-checked-text</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$radio-checked-text`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked radio button.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused radio button.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-shadow</td>
     <td></td>
-    <td>$checkbox-focused-shadow</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-focused-shadow`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused radio button.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked radio button.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-focused-checked-shadow</td>
     <td></td>
-    <td>$checkbox-focused-checked-shadow</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-focused-checked-shadow`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked radio button.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled radio button.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled radio button.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-border</td>
     <td></td>
-    <td>$checkbox-disabled-border</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`$checkbox-disabled-border`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled radio button.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked radio button.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-text</td>
     <td></td>
-    <td>$radio-disabled-border</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`$radio-disabled-border`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked radio button.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-border</td>
     <td></td>
-    <td>$radio-disabled-border</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`$radio-disabled-border`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked radio button.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-bg</td>
     <td></td>
-    <td>$checkbox-invalid-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-invalid-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid radio button.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-text</td>
     <td></td>
-    <td>$checkbox-invalid-text</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid radio button.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-invalid-border</td>
     <td></td>
-    <td>$checkbox-invalid-border</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid radio button.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of radio button indicator.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-glyph</td>
     <td></td>
-    <td>"\e308"</td>
-    <td>"\e308"</td>
+<td>
+
+
+`"\e308"`
+
+</td>
+<td>
+
+`"\e308"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of radio button indicator.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked radio button indicator.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-disabled-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-disabled-checked-text}'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-disabled-checked-text}'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-disabled-checked-text}'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-disabled-checked-text}'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of disabled and checked radio button indicator.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal radio button list.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of radio button list items.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of radio button list items.</div></div>
@@ -338,8 +617,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-ripple-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button ripple.</div></div>
@@ -348,8 +636,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$radio-ripple-opacity</td>
     <td></td>
-    <td>.2</td>
-    <td>.2</td>
+<td>
+
+
+`.2`
+
+</td>
+<td>
+
+`.2`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of radio button ripple.</div></div>

--- a/packages/material/docs/customization-shadows.md
+++ b/packages/material/docs/customization-shadows.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$elevation</td>
     <td></td>
-    <td>map-get( $theme, elevation )</td>
-    <td>map-get( $theme, elevation )</td>
+<td>
+
+
+`map-get( $theme, elevation )`
+
+</td>
+<td>
+
+`map-get( $theme, elevation )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of shadows</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$box-shadow-depth-1</td>
     <td></td>
-    <td>0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )</td>
-    <td>0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )</td>
+<td>
+
+
+`0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )`
+
+</td>
+<td>
+
+`0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Shadow for switch.<br />Equivalent to material elevation 1.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$box-shadow-depth-2</td>
     <td></td>
-    <td>0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )</td>
-    <td>0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )</td>
+<td>
+
+
+`0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )`
+
+</td>
+<td>
+
+`0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Shadow for resting state of button, card and other widgets.<br />Equivalent to material elevation 2.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$box-shadow-depth-3</td>
     <td></td>
-    <td>0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )</td>
-    <td>0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )</td>
+<td>
+
+
+`0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )`
+
+</td>
+<td>
+
+`0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Shadow for menu, popups and raised state of button and card.<br />Equivalent to material elevation 8.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$box-shadow-depth-4</td>
     <td></td>
-    <td>0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )</td>
-    <td>0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )</td>
+<td>
+
+
+`0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )`
+
+</td>
+<td>
+
+`0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Shadow for drawers and other overlaying elements.<br />Equivalent to material elevation 16.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$box-shadow-depth-5</td>
     <td></td>
-    <td>0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )</td>
-    <td>0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )</td>
+<td>
+
+
+`0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )`
+
+</td>
+<td>
+
+`0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Shadow for window and dialog.<br />Equivalent to material elevation 24.</div></div>

--- a/packages/material/docs/customization-table.md
+++ b/packages/material/docs/customization-table.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$table-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of the table border.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-vertical-border-width</td>
     <td></td>
-    <td>$grid-cell-vertical-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-vertical-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of vertical border of table cells.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-horizontal-border-width</td>
     <td></td>
-    <td>$grid-cell-horizontal-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-horizontal-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of horizontal border of table cells.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font size of the table if no size is specified.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-padding-x</td>
     <td></td>
-    <td>24px</td>
-    <td>24px</td>
+<td>
+
+
+`24px`
+
+</td>
+<td>
+
+`24px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the cells in the table if no size is specified.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-cell-padding-y</td>
     <td></td>
-    <td>10px</td>
-    <td>10px</td>
+<td>
+
+
+`10px`
+
+</td>
+<td>
+
+`10px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the cells in the table if no size is specified.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-bg</td>
     <td></td>
-    <td>$grid-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$grid-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tables.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-text</td>
     <td></td>
-    <td>$grid-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$grid-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tables.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tables.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table headers.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table headers.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-header-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table headers.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-bg</td>
     <td></td>
-    <td>$grid-footer-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$grid-footer-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table footers.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-text</td>
     <td></td>
-    <td>$grid-footer-text</td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
+<td>
+
+
+`$grid-footer-text`
+
+</td>
+<td>
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table footers.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-footer-border</td>
     <td></td>
-    <td>$grid-footer-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-footer-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table footers.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-bg</td>
     <td></td>
-    <td>$table-header-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$table-header-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of group rows in table.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-text</td>
     <td></td>
-    <td>$table-header-text</td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
+<td>
+
+
+`$table-header-text`
+
+</td>
+<td>
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of group rows in table.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-group-row-border</td>
     <td></td>
-    <td>$table-header-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$table-header-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of group rows in table.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-bg</td>
     <td></td>
-    <td>$grid-alt-bg</td>
-    <td>transparent</td>
+<td>
+
+
+`$grid-alt-bg`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in table.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-text</td>
     <td></td>
-    <td>$grid-alt-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in table.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-alt-row-border</td>
     <td></td>
-    <td>$grid-alt-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in table.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-bg</td>
     <td></td>
-    <td>$grid-hovered-bg</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .07 )</td>
+<td>
+
+
+`$grid-hovered-bg`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .07 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in table.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-text</td>
     <td></td>
-    <td>$grid-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in table.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-hover-border</td>
     <td></td>
-    <td>$grid-hovered-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-hovered-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in table.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused rows in table.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused rows in table.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused rows in table.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-focus-shadow</td>
     <td></td>
-    <td>$grid-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$grid-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused rows in table.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-bg</td>
     <td></td>
-    <td>$grid-selected-bg</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`$grid-selected-bg`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in table.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-text</td>
     <td></td>
-    <td>$grid-selected-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-selected-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in table.</div></div>
@@ -328,8 +598,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$table-selected-border</td>
     <td></td>
-    <td>$grid-selected-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-selected-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in table.</div></div>

--- a/packages/material/docs/customization-tabstrip.md
+++ b/packages/material/docs/customization-tabstrip.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$tabstrip-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip component</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip component</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip component</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-padding-x</td>
     <td></td>
-    <td>24px</td>
-    <td>24px</td>
+<td>
+
+
+`24px`
+
+</td>
+<td>
+
+`24px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabs</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-padding-y</td>
     <td></td>
-    <td>14px</td>
-    <td>14px</td>
+<td>
+
+
+`14px`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabs</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around of tabs</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border-radius</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of tabs</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-gap</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between tabs</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabs</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabs</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabs</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of tabs</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>map-get( $theme, hover-bg )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`map-get( $theme, hover-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered tabs</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered tabs</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered tabs</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradent of hovered tabs</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected tabs</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected tabs</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected tabs</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected tabs</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabstrip content</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabstrip content</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabstrip content</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip content</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip content</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip content</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tabstrip-content-border-focused</td>
     <td></td>
-    <td>$component-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip focused content</div></div>

--- a/packages/material/docs/customization-toolbar.md
+++ b/packages/material/docs/customization-toolbar.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$toolbar-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the container.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$toolbar-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the container.</div></div>

--- a/packages/material/docs/customization-treeview.md
+++ b/packages/material/docs/customization-treeview.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$treeview-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>Roboto, "Helvetica Neue", sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`Roboto, "Helvetica Neue", sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the treeview component.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-font-size</td>
     <td></td>
-    <td>16px</td>
-    <td>16px</td>
+<td>
+
+
+`16px`
+
+</td>
+<td>
+
+`16px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the treeview component.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-line-height</td>
     <td></td>
-    <td>1.25</td>
-    <td>1.25</td>
+<td>
+
+
+`1.25`
+
+</td>
+<td>
+
+`1.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the treeview component.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-indent</td>
     <td></td>
-    <td>16px</td>
-    <td>16px</td>
+<td>
+
+
+`16px`
+
+</td>
+<td>
+
+`16px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Indentation of child groups in treeview component.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of treeview items.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of treeview items.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of treeview items.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-border-radius</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of treeview items.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the treeview component.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the treeview component.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the treeview component.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-bg</td>
     <td></td>
-    <td>rgba( $treeview-text, .07 )</td>
-    <td>rgba( $treeview-text, .07 )</td>
+<td>
+
+
+`rgba( $treeview-text, .07 )`
+
+</td>
+<td>
+
+`rgba( $treeview-text, .07 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered treeview items.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered treeview items.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered treeview items.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered treeview items.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected treeview items.</div></div>
@@ -188,8 +332,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-text</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$secondary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$secondary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected treeview items.</div></div>
@@ -198,8 +351,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected treeview items.</div></div>
@@ -208,8 +370,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected treeview items.</div></div>
@@ -218,8 +389,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-item-focused-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused treeview items.</div></div>
@@ -228,8 +408,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of load more.</div></div>
@@ -238,8 +427,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-text</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of load more.</div></div>
@@ -248,8 +446,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of load more.</div></div>
@@ -258,8 +465,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a hovered load more.</div></div>
@@ -268,8 +484,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-text</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a hovered load more.</div></div>
@@ -278,8 +503,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-hover-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a hovered load more.</div></div>
@@ -288,8 +522,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a focused load more.</div></div>
@@ -298,8 +541,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-text</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a focused load more.</div></div>
@@ -308,8 +560,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a focused load more.</div></div>
@@ -318,8 +579,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$treeview-loadmore-focus-shadow</td>
     <td></td>
-    <td>$treeview-item-focused-shadow</td>
-    <td>null</td>
+<td>
+
+
+`$treeview-item-focused-shadow`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of a focused load more.</div></div>

--- a/packages/material/docs/customization-typography.md
+++ b/packages/material/docs/customization-typography.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$enable-typography</td>
     <td></td>
-    <td>false</td>
-    <td>false</td>
+<td>
+
+
+`false`
+
+</td>
+<td>
+
+`false`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Global typography styles for the Kendo Material theme.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-size</td>
     <td></td>
-    <td>14px</td>
-    <td>14px</td>
+<td>
+
+
+`14px`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Base font size across all components.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-family</td>
     <td></td>
-    <td>Roboto, "Helvetica Neue", sans-serif</td>
-    <td>Roboto, "Helvetica Neue", sans-serif</td>
+<td>
+
+
+`Roboto, "Helvetica Neue", sans-serif`
+
+</td>
+<td>
+
+`Roboto, "Helvetica Neue", sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family across all components.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-family-monospace</td>
     <td></td>
-    <td>Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
-    <td>Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
+<td>
+
+
+`Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
+<td>
+
+`Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family for monospaced text. Used for styling the code.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$line-height</td>
     <td></td>
-    <td>(28 / 14)</td>
-    <td>(28 / 14)</td>
+<td>
+
+
+`(28 / 14)`
+
+</td>
+<td>
+
+`(28 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>

--- a/packages/material/docs/customization.md
+++ b/packages/material/docs/customization.md
@@ -32,8 +32,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$border-radius</td>
     <td></td>
-    <td>2px</td>
-    <td>2px</td>
+<td>
+
+
+`2px`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius for all components.</div></div>
@@ -42,8 +51,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$base-bg</td>
     <td></td>
-    <td>map-get( $theme, base-bg )</td>
-    <td>map-get( $theme, base-bg )</td>
+<td>
+
+
+`map-get( $theme, base-bg )`
+
+</td>
+<td>
+
+`map-get( $theme, base-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the components' chrome area.</div></div>
@@ -52,8 +70,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$base-text</td>
     <td></td>
-    <td>map-get($theme, component-text)</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`map-get($theme, component-text)`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the components' chrome area.</div></div>
@@ -62,8 +89,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$base-border</td>
     <td></td>
-    <td>rgba( if($theme-type == dark, white, black), .08 )</td>
-    <td>rgba( if($theme-type == dark, white, black), .08 )</td>
+<td>
+
+
+`rgba( if($theme-type == dark, white, black), .08 )`
+
+</td>
+<td>
+
+`rgba( if($theme-type == dark, white, black), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border of the components' chrome area.</div></div>
@@ -72,8 +108,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$base-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of the components' chrome area.</div></div>
@@ -82,8 +127,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$hovered-bg</td>
     <td></td>
-    <td>map-get( $theme, hover-bg )</td>
-    <td>map-get( $theme, hover-bg )</td>
+<td>
+
+
+`map-get( $theme, hover-bg )`
+
+</td>
+<td>
+
+`map-get( $theme, hover-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered items.</div></div>
@@ -92,8 +146,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$hovered-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered items.</div></div>
@@ -102,8 +165,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$hovered-border</td>
     <td></td>
-    <td>rgba( if($theme-type == dark, white, black), .15 )</td>
-    <td>rgba( if($theme-type == dark, white, black), .15 )</td>
+<td>
+
+
+`rgba( if($theme-type == dark, white, black), .15 )`
+
+</td>
+<td>
+
+`rgba( if($theme-type == dark, white, black), .15 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered items.</div></div>
@@ -112,8 +184,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of hovered items.</div></div>
@@ -122,8 +203,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$selected-bg</td>
     <td></td>
-    <td>$secondary</td>
-    <td>material-color( $secondary-palette, main )</td>
+<td>
+
+
+`$secondary`
+
+</td>
+<td>
+
+`material-color( $secondary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of selected items.</div></div>
@@ -132,8 +222,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$selected-text</td>
     <td></td>
-    <td>$secondary-contrast</td>
-    <td>material-color( $secondary-palette, main-contrast )</td>
+<td>
+
+
+`$secondary-contrast`
+
+</td>
+<td>
+
+`material-color( $secondary-palette, main-contrast )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected items.</div></div>
@@ -142,8 +241,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$selected-border</td>
     <td></td>
-    <td>rgba( if($theme-type == dark, white, black), .1 )</td>
-    <td>rgba( if($theme-type == dark, white, black), .1 )</td>
+<td>
+
+
+`rgba( if($theme-type == dark, white, black), .1 )`
+
+</td>
+<td>
+
+`rgba( if($theme-type == dark, white, black), .1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected items.</div></div>
@@ -152,8 +260,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of selected items.</div></div>
@@ -183,8 +300,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$avatar-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of the avatar.</div></div>
@@ -193,8 +319,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$avatar-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>Roboto, "Helvetica Neue", sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`Roboto, "Helvetica Neue", sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the avatar.</div></div>
@@ -203,8 +338,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$avatar-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the avatar.</div></div>
@@ -213,8 +357,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$avatar-line-height</td>
     <td></td>
-    <td>$line-height</td>
-    <td>(28 / 14)</td>
+<td>
+
+
+`$line-height`
+
+</td>
+<td>
+
+`(28 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the avatar.</div></div>
@@ -223,16 +376,25 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$avatar-sizes</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     sm: map-get( $spacing, 4 ),
     md: map-get( $spacing, 8 ),
     lg: map-get( $spacing, 16 )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sizes of the avatar.</div></div>
@@ -262,8 +424,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$button-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of the border around the button.</div></div>
@@ -272,8 +443,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-border-radius</td>
     <td></td>
-    <td>map-get( $spacing, 1 )</td>
-    <td>map-get( $spacing, 1 )</td>
+<td>
+
+
+`map-get( $spacing, 1 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of the button.</div></div>
@@ -282,8 +462,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of the button.</div></div>
@@ -292,8 +481,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of the button.</div></div>
@@ -302,8 +500,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>Roboto, "Helvetica Neue", sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`Roboto, "Helvetica Neue", sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the button.</div></div>
@@ -312,8 +519,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the button.</div></div>
@@ -322,8 +538,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-line-height</td>
     <td></td>
-    <td>(20 / 14)</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`(20 / 14)`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>
@@ -332,8 +557,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated height of the button.</div></div>
@@ -342,8 +576,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-inner-calc-size</td>
     <td></td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
-    <td>calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )</td>
+<td>
+
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
+<td>
+
+`calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Calculated inner height of the button. Without the border width.</div></div>
@@ -352,7 +595,10 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-theme-colors</td>
     <td></td>
-    <td>(
+<td>
+
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -363,8 +609,12 @@ The following table lists the available variables for customizing the Material t
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
-    <td>(
+)`
+
+</td>
+<td>
+
+`(
     "primary": map-get( $theme-colors, primary ),
     "secondary": map-get( $theme-colors, secondary ),
     "tertiary": map-get( $theme-colors, tertiary ),
@@ -375,7 +625,9 @@ The following table lists the available variables for customizing the Material t
     "dark": map-get( $theme-colors, dark ),
     "light": map-get( $theme-colors, light ),
     "inverse": map-get( $theme-colors, inverse )
-)</td>
+)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Theme colors map for the button.</div></div>
@@ -384,8 +636,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-bg</td>
     <td></td>
-    <td>$base-bg</td>
-    <td>map-get( $theme, base-bg )</td>
+<td>
+
+
+`$base-bg`
+
+</td>
+<td>
+
+`map-get( $theme, base-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the buttons.</div></div>
@@ -394,8 +655,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-text</td>
     <td></td>
-    <td>$base-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$base-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the buttons.</div></div>
@@ -404,8 +674,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-border</td>
     <td></td>
-    <td>$button-bg</td>
-    <td>map-get( $theme, base-bg )</td>
+<td>
+
+
+`$button-bg`
+
+</td>
+<td>
+
+`map-get( $theme, base-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the buttons.</div></div>
@@ -414,8 +693,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of the buttons.</div></div>
@@ -424,8 +712,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered buttons.</div></div>
@@ -434,8 +731,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered buttons.</div></div>
@@ -444,8 +750,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered buttons.</div></div>
@@ -454,8 +769,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of hovered buttons.</div></div>
@@ -464,8 +788,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-active-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of active buttons.</div></div>
@@ -474,8 +807,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-active-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of active buttons.</div></div>
@@ -484,8 +826,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-active-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of active buttons.</div></div>
@@ -494,8 +845,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-active-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of active buttons.</div></div>
@@ -504,8 +864,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-selected-bg</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of selected buttons.</div></div>
@@ -514,8 +883,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-selected-text</td>
     <td></td>
-    <td>$button-active-text</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected buttons.</div></div>
@@ -524,8 +902,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-selected-border</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>null</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected buttons.</div></div>
@@ -534,8 +921,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of selected buttons.</div></div>
@@ -544,8 +940,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$button-focused-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The shadow of focused buttons.</div></div>
@@ -575,8 +980,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$series-a</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #3f51b5"></span>#3f51b5</td>
-    <td><span class="color-preview" style="background-color: #3f51b5"></span>#3f51b5</td>
+<td>
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
+
+</td>
+<td><span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The first base series color and its light and dark shades.</div></div>
@@ -585,8 +999,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$series-b</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #2196f3"></span>#2196f3</td>
-    <td><span class="color-preview" style="background-color: #2196f3"></span>#2196f3</td>
+<td>
+<span class="color-preview" style="background-color: #2196f3"></span>
+
+`#2196f3`
+
+</td>
+<td><span class="color-preview" style="background-color: #2196f3"></span>
+
+`#2196f3`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The second base series color and its light and dark shades.</div></div>
@@ -595,8 +1018,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$series-c</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #43a047"></span>#43a047</td>
-    <td><span class="color-preview" style="background-color: #43a047"></span>#43a047</td>
+<td>
+<span class="color-preview" style="background-color: #43a047"></span>
+
+`#43a047`
+
+</td>
+<td><span class="color-preview" style="background-color: #43a047"></span>
+
+`#43a047`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The third base series color and its light and dark shades.</div></div>
@@ -605,8 +1037,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$series-d</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ffc107"></span>#ffc107</td>
-    <td><span class="color-preview" style="background-color: #ffc107"></span>#ffc107</td>
+<td>
+<span class="color-preview" style="background-color: #ffc107"></span>
+
+`#ffc107`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffc107"></span>
+
+`#ffc107`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fourth base series color and its light and dark shades.</div></div>
@@ -615,8 +1056,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$series-e</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #ff5722"></span>#ff5722</td>
-    <td><span class="color-preview" style="background-color: #ff5722"></span>#ff5722</td>
+<td>
+<span class="color-preview" style="background-color: #ff5722"></span>
+
+`#ff5722`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff5722"></span>
+
+`#ff5722`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The fifth base series color and its light and dark shades.</div></div>
@@ -625,8 +1075,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$series-f</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #e91e63"></span>#e91e63</td>
-    <td><span class="color-preview" style="background-color: #e91e63"></span>#e91e63</td>
+<td>
+<span class="color-preview" style="background-color: #e91e63"></span>
+
+`#e91e63`
+
+</td>
+<td><span class="color-preview" style="background-color: #e91e63"></span>
+
+`#e91e63`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sixth base series color and its light and dark shades.</div></div>
@@ -635,8 +1094,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$series-1</td>
     <td></td>
-    <td>$series-a</td>
-    <td><span class="color-preview" style="background-color: #3f51b5"></span>#3f51b5</td>
+<td>
+
+
+`$series-a`
+
+</td>
+<td><span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The series colors in order:<br />base, light, dark, lighter, darker</div></div>
@@ -645,8 +1113,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$chart-major-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .08 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (major).</div></div>
@@ -655,8 +1132,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$chart-minor-lines</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .04 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color of the Chart grid lines (minor).</div></div>
@@ -686,8 +1172,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$checkbox-border-width</td>
     <td></td>
-    <td>2px</td>
-    <td>2px</td>
+<td>
+
+
+`2px`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of checkbox.</div></div>
@@ -696,8 +1191,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox.</div></div>
@@ -706,8 +1210,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checkbox.</div></div>
@@ -716,8 +1229,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-border</td>
     <td></td>
-    <td>rgba( if( $dark-theme, $white, $black ), .54 )</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .54 )</td>
+<td>
+
+
+`rgba( if( $dark-theme, $white, $black ), .54 )`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .54 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checkbox.</div></div>
@@ -726,8 +1248,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered checkbox.</div></div>
@@ -736,8 +1267,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered checkbox.</div></div>
@@ -746,8 +1286,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered checkbox.</div></div>
@@ -756,8 +1305,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-checked-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked checkbox.</div></div>
@@ -766,8 +1324,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-checked-text</td>
     <td></td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked checkbox.</div></div>
@@ -776,8 +1343,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked checkbox.</div></div>
@@ -786,8 +1362,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-indeterminate-bg</td>
     <td></td>
-    <td>$checkbox-checked-bg</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$checkbox-checked-bg`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of indeterminate checkbox.</div></div>
@@ -796,8 +1381,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-indeterminate-text</td>
     <td></td>
-    <td>$checkbox-checked-text</td>
-    <td>contrast-wcag( $checkbox-checked-bg )</td>
+<td>
+
+
+`$checkbox-checked-text`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of indeterminate checkbox.</div></div>
@@ -806,8 +1400,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-indeterminate-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of indeterminate checkbox.</div></div>
@@ -816,8 +1419,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-focused-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused checkbox.</div></div>
@@ -826,8 +1438,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-focused-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused checkbox.</div></div>
@@ -836,8 +1457,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-focused-checked-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked checkbox.</div></div>
@@ -846,8 +1476,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-focused-checked-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked checkbox.</div></div>
@@ -856,8 +1495,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-disabled-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled checkbox.</div></div>
@@ -866,8 +1514,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-disabled-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled checkbox.</div></div>
@@ -876,8 +1533,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-disabled-border</td>
     <td></td>
-    <td>try-shade( $component-bg, 4 )</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`try-shade( $component-bg, 4 )`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled checkbox.</div></div>
@@ -886,8 +1552,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-disabled-checked-bg</td>
     <td></td>
-    <td>$checkbox-disabled-border</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`$checkbox-disabled-border`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked checkbox.</div></div>
@@ -896,8 +1571,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-disabled-checked-text</td>
     <td></td>
-    <td>contrast-wcag( $checkbox-disabled-checked-bg )</td>
-    <td>contrast-wcag( $checkbox-disabled-checked-bg )</td>
+<td>
+
+
+`contrast-wcag( $checkbox-disabled-checked-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $checkbox-disabled-checked-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked checkbox.</div></div>
@@ -906,8 +1590,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-disabled-checked-border</td>
     <td></td>
-    <td>$checkbox-disabled-checked-bg</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`$checkbox-disabled-checked-bg`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked checkbox.</div></div>
@@ -916,8 +1609,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-invalid-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid checkbox.</div></div>
@@ -926,8 +1628,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-invalid-text</td>
     <td></td>
-    <td>$invalid-text</td>
-    <td></td>
+<td>
+
+
+`$invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid checkbox.</div></div>
@@ -936,8 +1647,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-invalid-border</td>
     <td></td>
-    <td>$invalid-border</td>
-    <td></td>
+<td>
+
+
+`$invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid checkbox.</div></div>
@@ -946,8 +1666,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of checkbox indicator.</div></div>
@@ -956,8 +1685,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-glyph-font-family</td>
     <td></td>
-    <td>"WebComponentsIcons", monospace</td>
-    <td>"WebComponentsIcons", monospace</td>
+<td>
+
+
+`"WebComponentsIcons", monospace`
+
+</td>
+<td>
+
+`"WebComponentsIcons", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph font family of checkbox indicator.</div></div>
@@ -966,8 +1704,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-checked-glyph</td>
     <td></td>
-    <td>"\e118"</td>
-    <td>"\e118"</td>
+<td>
+
+
+`"\e118"`
+
+</td>
+<td>
+
+`"\e118"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of checkbox indicator.</div></div>
@@ -976,8 +1723,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-indeterminate-glyph</td>
     <td></td>
-    <td>"\e121"</td>
-    <td>"\e121"</td>
+<td>
+
+
+`"\e121"`
+
+</td>
+<td>
+
+`"\e121"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of indeterminate checkbox indicator.</div></div>
@@ -986,8 +1742,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -996,8 +1761,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-indeterminate-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked checkbox indicator.</div></div>
@@ -1006,8 +1780,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal checkbox list.</div></div>
@@ -1016,8 +1799,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of checkbox list items.</div></div>
@@ -1026,8 +1818,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of checkbox list items.</div></div>
@@ -1036,8 +1837,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-ripple-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checkbox ripple.</div></div>
@@ -1046,8 +1856,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$checkbox-ripple-opacity</td>
     <td></td>
-    <td>.2</td>
-    <td>.2</td>
+<td>
+
+
+`.2`
+
+</td>
+<td>
+
+`.2`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of checkbox ripple.</div></div>
@@ -1077,8 +1896,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$primary</td>
     <td>Color</td>
-    <td>material-color( $primary-palette, main )</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`material-color( $primary-palette, main )`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.<br />Used for primary buttons and for elements of primary importance across the theme.</div></div>
@@ -1087,8 +1915,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$primary-contrast</td>
     <td>Color</td>
-    <td>material-color( $primary-palette, main-contrast )</td>
-    <td>material-color( $primary-palette, main-contrast )</td>
+<td>
+
+
+`material-color( $primary-palette, main-contrast )`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main-contrast )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the primary color denoted by $primary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1097,8 +1934,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$secondary</td>
     <td>Color</td>
-    <td>material-color( $secondary-palette, main )</td>
-    <td>material-color( $secondary-palette, main )</td>
+<td>
+
+
+`material-color( $secondary-palette, main )`
+
+</td>
+<td>
+
+`material-color( $secondary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The secondary color of the theme.</div></div>
@@ -1107,8 +1953,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$secondary-contrast</td>
     <td>Color</td>
-    <td>material-color( $secondary-palette, main-contrast )</td>
-    <td>material-color( $secondary-palette, main-contrast )</td>
+<td>
+
+
+`material-color( $secondary-palette, main-contrast )`
+
+</td>
+<td>
+
+`material-color( $secondary-palette, main-contrast )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the secondary color denoted by $secondary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1117,8 +1972,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tertiary</td>
     <td>Color</td>
-    <td>material-color($tertiary-palette, main)</td>
-    <td>material-color($tertiary-palette, main)</td>
+<td>
+
+
+`material-color($tertiary-palette, main)`
+
+</td>
+<td>
+
+`material-color($tertiary-palette, main)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tertiary color of the theme.</div></div>
@@ -1127,8 +1991,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tertiary-contrast</td>
     <td>Color</td>
-    <td>material-color($tertiary-palette, main-contrast)</td>
-    <td>material-color($tertiary-palette, main-contrast)</td>
+<td>
+
+
+`material-color($tertiary-palette, main-contrast)`
+
+</td>
+<td>
+
+`material-color($tertiary-palette, main-contrast)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the tertiary color denoted by $tertiary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -1137,8 +2010,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$info</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
+<td>
+<span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
+<td><span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for informational messages and states.</div></div>
@@ -1147,8 +2029,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$success</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
+<td>
+<span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
+<td><span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for success messages and states.</div></div>
@@ -1157,8 +2048,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$warning</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
+<td>
+<span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for warning messages and states.</div></div>
@@ -1167,8 +2067,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$error</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
+<td>
+<span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
+<td><span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for error messages and states.</div></div>
@@ -1177,8 +2086,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$dark</td>
     <td>Color</td>
-    <td>get-base-hue( gray, 800 )</td>
-    <td>get-base-hue( gray, 800 )</td>
+<td>
+
+
+`get-base-hue( gray, 800 )`
+
+</td>
+<td>
+
+`get-base-hue( gray, 800 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The dark color of the theme.</div></div>
@@ -1187,8 +2105,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$light</td>
     <td>Color</td>
-    <td>get-base-hue( gray, 100 )</td>
-    <td>get-base-hue( gray, 100 )</td>
+<td>
+
+
+`get-base-hue( gray, 100 )`
+
+</td>
+<td>
+
+`get-base-hue( gray, 100 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The light color of the theme.</div></div>
@@ -1197,8 +2124,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$inverse</td>
     <td></td>
-    <td>if( $dark-theme, $light, $dark )</td>
-    <td>if( $dark-theme, $light, $dark )</td>
+<td>
+
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
+<td>
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Inverse color of the theme. Depending on the theme luminance dark or lught, it will be light or dark</div></div>
@@ -1228,8 +2164,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$component-bg</td>
     <td></td>
-    <td>map-get($theme, component-bg)</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`map-get($theme, component-bg)`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-bg` e.g. `$grid-bg: $component-bg !defualt;`.</div></div>
@@ -1238,8 +2183,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$component-text</td>
     <td></td>
-    <td>map-get($theme, component-text)</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`map-get($theme, component-text)`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-text` e.g. `$grid-text: component-text !default;`.</div></div>
@@ -1248,8 +2202,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$component-border</td>
     <td></td>
-    <td>map-get($theme, component-border)</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`map-get($theme, component-border)`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-border` e.g. `$grid-border: component-border !default;`.</div></div>
@@ -1279,8 +2242,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$grid-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the grid component</div></div>
@@ -1289,8 +2261,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the grid component</div></div>
@@ -1299,8 +2280,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the grid component</div></div>
@@ -1309,8 +2299,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-header-bg</td>
     <td></td>
-    <td>$grid-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$grid-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid header</div></div>
@@ -1319,8 +2318,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-header-text</td>
     <td></td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
+<td>
+
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
+<td>
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid header</div></div>
@@ -1329,8 +2337,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-header-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid header</div></div>
@@ -1339,8 +2356,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-header-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of grid header</div></div>
@@ -1349,8 +2375,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-footer-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of grid footer</div></div>
@@ -1359,8 +2394,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-footer-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of grid footer</div></div>
@@ -1369,8 +2413,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-footer-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of grid footer</div></div>
@@ -1379,8 +2432,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-alt-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in grid</div></div>
@@ -1389,8 +2451,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-alt-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in grid</div></div>
@@ -1399,8 +2470,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-alt-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in grid</div></div>
@@ -1409,8 +2489,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-hovered-bg</td>
     <td></td>
-    <td>rgba( contrast-wcag( $grid-bg ), .07 )</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .07 )</td>
+<td>
+
+
+`rgba( contrast-wcag( $grid-bg ), .07 )`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .07 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in grid</div></div>
@@ -1419,8 +2508,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in grid</div></div>
@@ -1429,8 +2527,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-hovered-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in grid</div></div>
@@ -1439,8 +2546,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-selected-bg</td>
     <td></td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in grid</div></div>
@@ -1449,8 +2565,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-selected-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in grid</div></div>
@@ -1459,8 +2584,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$grid-selected-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in grid</div></div>
@@ -1490,8 +2624,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$icon-font-url</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The URL to the icon font that will be used by the theme<br />The default value of `null` embeds the package font with a `data:` URL</div></div>
@@ -1521,8 +2664,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$list-font-size</td>
     <td></td>
-    <td>$font-size-lg</td>
-    <td></td>
+<td>
+
+
+`$font-size-lg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the list component.</div></div>
@@ -1531,8 +2683,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-line-height</td>
     <td></td>
-    <td>1.25</td>
-    <td>1.25</td>
+<td>
+
+
+`1.25`
+
+</td>
+<td>
+
+`1.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the list component.</div></div>
@@ -1541,8 +2702,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of list items.</div></div>
@@ -1551,8 +2721,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of list items.</div></div>
@@ -1561,8 +2740,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the list component.</div></div>
@@ -1571,8 +2759,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the list component.</div></div>
@@ -1581,8 +2778,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the list component.</div></div>
@@ -1591,8 +2797,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-header-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list header.</div></div>
@@ -1601,8 +2816,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-header-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list header.</div></div>
@@ -1611,8 +2835,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-header-border</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of list header.</div></div>
@@ -1621,8 +2854,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-header-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of list header.</div></div>
@@ -1631,8 +2873,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of list items.</div></div>
@@ -1641,8 +2892,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-item-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of list items.</div></div>
@@ -1651,8 +2911,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>map-get( $theme, hover-bg )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`map-get( $theme, hover-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered list items.</div></div>
@@ -1661,8 +2930,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-item-hovered-text</td>
     <td></td>
-    <td>$hovered-text</td>
-    <td>$base-text</td>
+<td>
+
+
+`$hovered-text`
+
+</td>
+<td>
+
+`$base-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered list items.</div></div>
@@ -1671,8 +2949,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-item-focused-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused list items.</div></div>
@@ -1681,8 +2968,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-item-focused-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused list items.</div></div>
@@ -1691,8 +2987,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-item-focused-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused list items.</div></div>
@@ -1701,8 +3006,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-item-selected-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected list items.</div></div>
@@ -1711,8 +3025,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-item-selected-text</td>
     <td></td>
-    <td>$secondary</td>
-    <td>material-color( $secondary-palette, main )</td>
+<td>
+
+
+`$secondary`
+
+</td>
+<td>
+
+`material-color( $secondary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected list items.</div></div>
@@ -1721,8 +3044,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$list-no-data-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the 'No Data' text.</div></div>
@@ -1752,8 +3084,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$radio-radius</td>
     <td></td>
-    <td>50%</td>
-    <td>50%</td>
+<td>
+
+
+`50%`
+
+</td>
+<td>
+
+`50%`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of radio button.</div></div>
@@ -1762,8 +3103,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-border-width</td>
     <td></td>
-    <td>2px</td>
-    <td>2px</td>
+<td>
+
+
+`2px`
+
+</td>
+<td>
+
+`2px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of radio button.</div></div>
@@ -1772,8 +3122,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-bg</td>
     <td></td>
-    <td>$checkbox-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button.</div></div>
@@ -1782,8 +3141,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-text</td>
     <td></td>
-    <td>$checkbox-text</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of radio button.</div></div>
@@ -1792,8 +3160,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-border</td>
     <td></td>
-    <td>$checkbox-border</td>
-    <td>rgba( if( $dark-theme, $white, $black ), .54 )</td>
+<td>
+
+
+`$checkbox-border`
+
+</td>
+<td>
+
+`rgba( if( $dark-theme, $white, $black ), .54 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of radio button.</div></div>
@@ -1802,8 +3179,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-hovered-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered radio button.</div></div>
@@ -1812,8 +3198,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of hovered radio button.</div></div>
@@ -1822,8 +3217,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered radio button.</div></div>
@@ -1832,8 +3236,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-checked-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of checked radio button.</div></div>
@@ -1842,8 +3255,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-checked-text</td>
     <td></td>
-    <td>$primary</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of checked radio button.</div></div>
@@ -1852,8 +3274,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-checked-border</td>
     <td></td>
-    <td>$radio-checked-text</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$radio-checked-text`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of checked radio button.</div></div>
@@ -1862,8 +3293,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-focused-border</td>
     <td></td>
-    <td>$checkbox-hovered-border</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-hovered-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused radio button.</div></div>
@@ -1872,8 +3312,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-focused-shadow</td>
     <td></td>
-    <td>$checkbox-focused-shadow</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-focused-shadow`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused radio button.</div></div>
@@ -1882,8 +3331,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-focused-checked-border</td>
     <td></td>
-    <td>$checkbox-checked-border</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$checkbox-checked-border`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused and checked radio button.</div></div>
@@ -1892,8 +3350,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-focused-checked-shadow</td>
     <td></td>
-    <td>$checkbox-focused-checked-shadow</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-focused-checked-shadow`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused and checked radio button.</div></div>
@@ -1902,8 +3369,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-disabled-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled radio button.</div></div>
@@ -1912,8 +3388,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-disabled-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled radio button.</div></div>
@@ -1922,8 +3407,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-disabled-border</td>
     <td></td>
-    <td>$checkbox-disabled-border</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`$checkbox-disabled-border`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled radio button.</div></div>
@@ -1932,8 +3426,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-disabled-checked-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of disabled and checked radio button.</div></div>
@@ -1942,8 +3445,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-disabled-checked-text</td>
     <td></td>
-    <td>$radio-disabled-border</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`$radio-disabled-border`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of disabled and checked radio button.</div></div>
@@ -1952,8 +3464,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-disabled-checked-border</td>
     <td></td>
-    <td>$radio-disabled-border</td>
-    <td>try-shade( $component-bg, 4 )</td>
+<td>
+
+
+`$radio-disabled-border`
+
+</td>
+<td>
+
+`try-shade( $component-bg, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of disabled and checked radio button.</div></div>
@@ -1962,8 +3483,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-invalid-bg</td>
     <td></td>
-    <td>$checkbox-invalid-bg</td>
-    <td>null</td>
+<td>
+
+
+`$checkbox-invalid-bg`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of invalid radio button.</div></div>
@@ -1972,8 +3502,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-invalid-text</td>
     <td></td>
-    <td>$checkbox-invalid-text</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of invalid radio button.</div></div>
@@ -1982,8 +3521,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-invalid-border</td>
     <td></td>
-    <td>$checkbox-invalid-border</td>
-    <td></td>
+<td>
+
+
+`$checkbox-invalid-border`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of invalid radio button.</div></div>
@@ -1992,8 +3540,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-indicator-type</td>
     <td></td>
-    <td>image</td>
-    <td>image</td>
+<td>
+
+
+`image`
+
+</td>
+<td>
+
+`image`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Type of radio button indicator.</div></div>
@@ -2002,8 +3559,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-checked-glyph</td>
     <td></td>
-    <td>"\e308"</td>
-    <td>"\e308"</td>
+<td>
+
+
+`"\e308"`
+
+</td>
+<td>
+
+`"\e308"`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Glyph of radio button indicator.</div></div>
@@ -2012,8 +3578,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-checked-text}'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of checked radio button indicator.</div></div>
@@ -2022,8 +3597,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-disabled-checked-image</td>
     <td></td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-disabled-checked-text}'/></svg>") )</td>
-    <td>escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-disabled-checked-text}'/></svg>") )</td>
+<td>
+
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-disabled-checked-text}'/></svg>") )`
+
+</td>
+<td>
+
+`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$radio-disabled-checked-text}'/></svg>") )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Image of disabled and checked radio button indicator.</div></div>
@@ -2032,8 +3616,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-list-spacing</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between items of horizontal radio button list.</div></div>
@@ -2042,8 +3635,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-list-item-padding-x</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of radio button list items.</div></div>
@@ -2052,8 +3654,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-list-item-padding-y</td>
     <td></td>
-    <td>$list-item-padding-y</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`$list-item-padding-y`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of radio button list items.</div></div>
@@ -2062,8 +3673,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-ripple-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td>material-color( $primary-palette, main )</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td>
+
+`material-color( $primary-palette, main )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of radio button ripple.</div></div>
@@ -2072,8 +3692,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$radio-ripple-opacity</td>
     <td></td>
-    <td>.2</td>
-    <td>.2</td>
+<td>
+
+
+`.2`
+
+</td>
+<td>
+
+`.2`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Opacity of radio button ripple.</div></div>
@@ -2103,8 +3732,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$elevation</td>
     <td></td>
-    <td>map-get( $theme, elevation )</td>
-    <td>map-get( $theme, elevation )</td>
+<td>
+
+
+`map-get( $theme, elevation )`
+
+</td>
+<td>
+
+`map-get( $theme, elevation )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Color of shadows</div></div>
@@ -2113,8 +3751,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$box-shadow-depth-1</td>
     <td></td>
-    <td>0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )</td>
-    <td>0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )</td>
+<td>
+
+
+`0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )`
+
+</td>
+<td>
+
+`0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Shadow for switch.<br />Equivalent to material elevation 1.</div></div>
@@ -2123,8 +3770,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$box-shadow-depth-2</td>
     <td></td>
-    <td>0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )</td>
-    <td>0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )</td>
+<td>
+
+
+`0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )`
+
+</td>
+<td>
+
+`0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Shadow for resting state of button, card and other widgets.<br />Equivalent to material elevation 2.</div></div>
@@ -2133,8 +3789,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$box-shadow-depth-3</td>
     <td></td>
-    <td>0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )</td>
-    <td>0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )</td>
+<td>
+
+
+`0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )`
+
+</td>
+<td>
+
+`0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Shadow for menu, popups and raised state of button and card.<br />Equivalent to material elevation 8.</div></div>
@@ -2143,8 +3808,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$box-shadow-depth-4</td>
     <td></td>
-    <td>0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )</td>
-    <td>0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )</td>
+<td>
+
+
+`0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )`
+
+</td>
+<td>
+
+`0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Shadow for drawers and other overlaying elements.<br />Equivalent to material elevation 16.</div></div>
@@ -2153,8 +3827,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$box-shadow-depth-5</td>
     <td></td>
-    <td>0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )</td>
-    <td>0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )</td>
+<td>
+
+
+`0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )`
+
+</td>
+<td>
+
+`0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Shadow for window and dialog.<br />Equivalent to material elevation 24.</div></div>
@@ -2184,8 +3867,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$table-border-width</td>
     <td></td>
-    <td>1px</td>
-    <td>1px</td>
+<td>
+
+
+`1px`
+
+</td>
+<td>
+
+`1px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of the table border.</div></div>
@@ -2194,8 +3886,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-cell-vertical-border-width</td>
     <td></td>
-    <td>$grid-cell-vertical-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-vertical-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of vertical border of table cells.</div></div>
@@ -2204,8 +3905,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-cell-horizontal-border-width</td>
     <td></td>
-    <td>$grid-cell-horizontal-border-width</td>
-    <td></td>
+<td>
+
+
+`$grid-cell-horizontal-border-width`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The width of horizontal border of table cells.</div></div>
@@ -2214,8 +3924,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-font-size</td>
     <td></td>
-    <td>$font-size</td>
-    <td>14px</td>
+<td>
+
+
+`$font-size`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font size of the table if no size is specified.</div></div>
@@ -2224,8 +3943,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-cell-padding-x</td>
     <td></td>
-    <td>24px</td>
-    <td>24px</td>
+<td>
+
+
+`24px`
+
+</td>
+<td>
+
+`24px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the cells in the table if no size is specified.</div></div>
@@ -2234,8 +3962,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-cell-padding-y</td>
     <td></td>
-    <td>10px</td>
-    <td>10px</td>
+<td>
+
+
+`10px`
+
+</td>
+<td>
+
+`10px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the cells in the table if no size is specified.</div></div>
@@ -2244,8 +3981,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-bg</td>
     <td></td>
-    <td>$grid-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$grid-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tables.</div></div>
@@ -2254,8 +4000,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-text</td>
     <td></td>
-    <td>$grid-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$grid-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tables.</div></div>
@@ -2264,8 +4019,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-border</td>
     <td></td>
-    <td>$grid-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tables.</div></div>
@@ -2274,8 +4038,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-header-bg</td>
     <td></td>
-    <td>$grid-header-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$grid-header-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table headers.</div></div>
@@ -2284,8 +4057,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-header-text</td>
     <td></td>
-    <td>$grid-header-text</td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
+<td>
+
+
+`$grid-header-text`
+
+</td>
+<td>
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table headers.</div></div>
@@ -2294,8 +4076,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-header-border</td>
     <td></td>
-    <td>$grid-header-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-header-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table headers.</div></div>
@@ -2304,8 +4095,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-footer-bg</td>
     <td></td>
-    <td>$grid-footer-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$grid-footer-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of table footers.</div></div>
@@ -2314,8 +4114,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-footer-text</td>
     <td></td>
-    <td>$grid-footer-text</td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
+<td>
+
+
+`$grid-footer-text`
+
+</td>
+<td>
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of table footers.</div></div>
@@ -2324,8 +4133,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-footer-border</td>
     <td></td>
-    <td>$grid-footer-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-footer-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of table footers.</div></div>
@@ -2334,8 +4152,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-group-row-bg</td>
     <td></td>
-    <td>$table-header-bg</td>
-    <td>map-get($theme, component-bg)</td>
+<td>
+
+
+`$table-header-bg`
+
+</td>
+<td>
+
+`map-get($theme, component-bg)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of group rows in table.</div></div>
@@ -2344,8 +4171,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-group-row-text</td>
     <td></td>
-    <td>$table-header-text</td>
-    <td>if($theme-type == dark, $light-secondary-text, $dark-secondary-text)</td>
+<td>
+
+
+`$table-header-text`
+
+</td>
+<td>
+
+`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of group rows in table.</div></div>
@@ -2354,8 +4190,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-group-row-border</td>
     <td></td>
-    <td>$table-header-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$table-header-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of group rows in table.</div></div>
@@ -2364,8 +4209,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-alt-row-bg</td>
     <td></td>
-    <td>$grid-alt-bg</td>
-    <td>transparent</td>
+<td>
+
+
+`$grid-alt-bg`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of alternating rows in table.</div></div>
@@ -2374,8 +4228,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-alt-row-text</td>
     <td></td>
-    <td>$grid-alt-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of alternating rows in table.</div></div>
@@ -2384,8 +4247,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-alt-row-border</td>
     <td></td>
-    <td>$grid-alt-border</td>
-    <td>null</td>
+<td>
+
+
+`$grid-alt-border`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of alternating rows in table.</div></div>
@@ -2394,8 +4266,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-hover-bg</td>
     <td></td>
-    <td>$grid-hovered-bg</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .07 )</td>
+<td>
+
+
+`$grid-hovered-bg`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .07 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered rows in table.</div></div>
@@ -2404,8 +4285,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-hover-text</td>
     <td></td>
-    <td>$grid-hovered-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-hovered-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered rows in table.</div></div>
@@ -2414,8 +4304,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-hover-border</td>
     <td></td>
-    <td>$grid-hovered-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-hovered-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered rows in table.</div></div>
@@ -2424,8 +4323,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-focus-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of focused rows in table.</div></div>
@@ -2434,8 +4342,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-focus-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of focused rows in table.</div></div>
@@ -2444,8 +4361,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of focused rows in table.</div></div>
@@ -2454,8 +4380,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-focus-shadow</td>
     <td></td>
-    <td>$grid-focused-shadow</td>
-    <td></td>
+<td>
+
+
+`$grid-focused-shadow`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused rows in table.</div></div>
@@ -2464,8 +4399,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-selected-bg</td>
     <td></td>
-    <td>$grid-selected-bg</td>
-    <td>rgba( contrast-wcag( $grid-bg ), .04 )</td>
+<td>
+
+
+`$grid-selected-bg`
+
+</td>
+<td>
+
+`rgba( contrast-wcag( $grid-bg ), .04 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected rows in table.</div></div>
@@ -2474,8 +4418,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-selected-text</td>
     <td></td>
-    <td>$grid-selected-text</td>
-    <td>null</td>
+<td>
+
+
+`$grid-selected-text`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected rows in table.</div></div>
@@ -2484,8 +4437,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$table-selected-border</td>
     <td></td>
-    <td>$grid-selected-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$grid-selected-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected rows in table.</div></div>
@@ -2515,8 +4477,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$tabstrip-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip component</div></div>
@@ -2525,8 +4496,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip component</div></div>
@@ -2535,8 +4515,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>map-get($theme, component-border)</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`map-get($theme, component-border)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip component</div></div>
@@ -2545,8 +4534,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-padding-x</td>
     <td></td>
-    <td>24px</td>
-    <td>24px</td>
+<td>
+
+
+`24px`
+
+</td>
+<td>
+
+`24px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabs</div></div>
@@ -2555,8 +4553,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-padding-y</td>
     <td></td>
-    <td>14px</td>
-    <td>14px</td>
+<td>
+
+
+`14px`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabs</div></div>
@@ -2565,8 +4572,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around of tabs</div></div>
@@ -2575,8 +4591,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-border-radius</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of tabs</div></div>
@@ -2585,8 +4610,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-gap</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Spacing between tabs</div></div>
@@ -2595,8 +4629,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabs</div></div>
@@ -2605,8 +4648,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-text</td>
     <td></td>
-    <td>$subtle-text</td>
-    <td></td>
+<td>
+
+
+`$subtle-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabs</div></div>
@@ -2615,8 +4667,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabs</div></div>
@@ -2625,8 +4686,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of tabs</div></div>
@@ -2635,8 +4705,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
     <td></td>
-    <td>$hovered-bg</td>
-    <td>map-get( $theme, hover-bg )</td>
+<td>
+
+
+`$hovered-bg`
+
+</td>
+<td>
+
+`map-get( $theme, hover-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered tabs</div></div>
@@ -2645,8 +4724,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-hovered-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered tabs</div></div>
@@ -2655,8 +4743,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered tabs</div></div>
@@ -2665,8 +4762,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradent of hovered tabs</div></div>
@@ -2675,8 +4781,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-selected-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected tabs</div></div>
@@ -2685,8 +4800,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-selected-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected tabs</div></div>
@@ -2695,8 +4819,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-selected-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected tabs</div></div>
@@ -2705,8 +4838,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected tabs</div></div>
@@ -2715,8 +4857,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-content-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of tabstrip content</div></div>
@@ -2725,8 +4876,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-content-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of tabstrip content</div></div>
@@ -2735,8 +4895,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-content-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Width of border around tabstrip content</div></div>
@@ -2745,8 +4914,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-content-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of tabstrip content</div></div>
@@ -2755,8 +4933,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-content-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of tabstrip content</div></div>
@@ -2765,8 +4952,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-content-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip content</div></div>
@@ -2775,8 +4971,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$tabstrip-content-border-focused</td>
     <td></td>
-    <td>$component-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of tabstrip focused content</div></div>
@@ -2806,8 +5011,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$toolbar-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the container.</div></div>
@@ -2816,8 +5030,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$toolbar-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the container.</div></div>
@@ -2847,8 +5070,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$treeview-font-family</td>
     <td></td>
-    <td>$font-family</td>
-    <td>Roboto, "Helvetica Neue", sans-serif</td>
+<td>
+
+
+`$font-family`
+
+</td>
+<td>
+
+`Roboto, "Helvetica Neue", sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family of the treeview component.</div></div>
@@ -2857,8 +5089,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-font-size</td>
     <td></td>
-    <td>16px</td>
-    <td>16px</td>
+<td>
+
+
+`16px`
+
+</td>
+<td>
+
+`16px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font size of the treeview component.</div></div>
@@ -2867,8 +5108,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-line-height</td>
     <td></td>
-    <td>1.25</td>
-    <td>1.25</td>
+<td>
+
+
+`1.25`
+
+</td>
+<td>
+
+`1.25`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height of the treeview component.</div></div>
@@ -2877,8 +5127,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-indent</td>
     <td></td>
-    <td>16px</td>
-    <td>16px</td>
+<td>
+
+
+`16px`
+
+</td>
+<td>
+
+`16px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Indentation of child groups in treeview component.</div></div>
@@ -2887,8 +5146,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-padding-x</td>
     <td></td>
-    <td>map-get( $spacing, 4 )</td>
-    <td>map-get( $spacing, 4 )</td>
+<td>
+
+
+`map-get( $spacing, 4 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 4 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Horizontal padding of treeview items.</div></div>
@@ -2897,8 +5165,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-padding-y</td>
     <td></td>
-    <td>map-get( $spacing, 2 )</td>
-    <td>map-get( $spacing, 2 )</td>
+<td>
+
+
+`map-get( $spacing, 2 )`
+
+</td>
+<td>
+
+`map-get( $spacing, 2 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Vertical padding of treeview items.</div></div>
@@ -2907,8 +5184,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-border-width</td>
     <td></td>
-    <td>0px</td>
-    <td>0px</td>
+<td>
+
+
+`0px`
+
+</td>
+<td>
+
+`0px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border width of treeview items.</div></div>
@@ -2917,8 +5203,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-border-radius</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border radius of treeview items.</div></div>
@@ -2927,8 +5222,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of the treeview component.</div></div>
@@ -2937,8 +5241,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td>map-get($theme, component-text)</td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+`map-get($theme, component-text)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of the treeview component.</div></div>
@@ -2947,8 +5260,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of the treeview component.</div></div>
@@ -2957,8 +5279,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-hovered-bg</td>
     <td></td>
-    <td>rgba( $treeview-text, .07 )</td>
-    <td>rgba( $treeview-text, .07 )</td>
+<td>
+
+
+`rgba( $treeview-text, .07 )`
+
+</td>
+<td>
+
+`rgba( $treeview-text, .07 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of hovered treeview items.</div></div>
@@ -2967,8 +5298,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-hovered-text</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of hovered treeview items.</div></div>
@@ -2977,8 +5317,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-hovered-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of hovered treeview items.</div></div>
@@ -2987,8 +5336,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-hovered-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of hovered treeview items.</div></div>
@@ -2997,8 +5355,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-selected-bg</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of selected treeview items.</div></div>
@@ -3007,8 +5374,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-selected-text</td>
     <td></td>
-    <td>$selected-bg</td>
-    <td>$secondary</td>
+<td>
+
+
+`$selected-bg`
+
+</td>
+<td>
+
+`$secondary`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of selected treeview items.</div></div>
@@ -3017,8 +5393,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-selected-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of selected treeview items.</div></div>
@@ -3027,8 +5412,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-selected-gradient</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background gradient of selected treeview items.</div></div>
@@ -3037,8 +5431,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-item-focused-shadow</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of focused treeview items.</div></div>
@@ -3047,8 +5450,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-loadmore-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of load more.</div></div>
@@ -3057,8 +5469,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-loadmore-text</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of load more.</div></div>
@@ -3067,8 +5488,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-loadmore-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of load more.</div></div>
@@ -3077,8 +5507,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-loadmore-hover-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a hovered load more.</div></div>
@@ -3087,8 +5526,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-loadmore-hover-text</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a hovered load more.</div></div>
@@ -3097,8 +5545,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-loadmore-hover-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a hovered load more.</div></div>
@@ -3107,8 +5564,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-loadmore-focus-bg</td>
     <td></td>
-    <td>transparent</td>
-    <td>transparent</td>
+<td>
+
+
+`transparent`
+
+</td>
+<td>
+
+`transparent`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a focused load more.</div></div>
@@ -3117,8 +5583,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-loadmore-focus-text</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a focused load more.</div></div>
@@ -3127,8 +5602,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-loadmore-focus-border</td>
     <td></td>
-    <td>null</td>
-    <td>null</td>
+<td>
+
+
+`null`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a focused load more.</div></div>
@@ -3137,8 +5621,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$treeview-loadmore-focus-shadow</td>
     <td></td>
-    <td>$treeview-item-focused-shadow</td>
-    <td>null</td>
+<td>
+
+
+`$treeview-item-focused-shadow`
+
+</td>
+<td>
+
+`null`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of a focused load more.</div></div>
@@ -3168,8 +5661,17 @@ The following table lists the available variables for customizing the Material t
         <tr>
     <td>$enable-typography</td>
     <td></td>
-    <td>false</td>
-    <td>false</td>
+<td>
+
+
+`false`
+
+</td>
+<td>
+
+`false`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Global typography styles for the Kendo Material theme.</div></div>
@@ -3178,8 +5680,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$font-size</td>
     <td></td>
-    <td>14px</td>
-    <td>14px</td>
+<td>
+
+
+`14px`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Base font size across all components.</div></div>
@@ -3188,8 +5699,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$font-family</td>
     <td></td>
-    <td>Roboto, "Helvetica Neue", sans-serif</td>
-    <td>Roboto, "Helvetica Neue", sans-serif</td>
+<td>
+
+
+`Roboto, "Helvetica Neue", sans-serif`
+
+</td>
+<td>
+
+`Roboto, "Helvetica Neue", sans-serif`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family across all components.</div></div>
@@ -3198,8 +5718,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$font-family-monospace</td>
     <td></td>
-    <td>Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
-    <td>Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
+<td>
+
+
+`Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
+<td>
+
+`Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family for monospaced text. Used for styling the code.</div></div>
@@ -3208,8 +5737,17 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$line-height</td>
     <td></td>
-    <td>(28 / 14)</td>
-    <td>(28 / 14)</td>
+<td>
+
+
+`(28 / 14)`
+
+</td>
+<td>
+
+`(28 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>

--- a/packages/nouvelle/docs/customization-autocomplete.md
+++ b/packages/nouvelle/docs/customization-autocomplete.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$autocomplete-bg</td>
     <td></td>
-    <td>$input-bg</td>
-    <td>$component-bg</td>
+<td>
+
+
+`$input-bg`
+
+</td>
+<td>
+
+`$component-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the autocomplete.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$autocomplete-text</td>
     <td></td>
-    <td>$input-text</td>
-    <td>$component-text</td>
+<td>
+
+
+`$input-text`
+
+</td>
+<td>
+
+`$component-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the autocomplete.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$autocomplete-border</td>
     <td></td>
-    <td>$input-border</td>
-    <td>$component-border</td>
+<td>
+
+
+`$input-border`
+
+</td>
+<td>
+
+`$component-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the autocomplete.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$autocomplete-hover-bg</td>
     <td></td>
-    <td>$input-hover-bg</td>
-    <td>$input-bg</td>
+<td>
+
+
+`$input-hover-bg`
+
+</td>
+<td>
+
+`$input-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered autocomplete.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$autocomplete-hover-text</td>
     <td></td>
-    <td>$input-hover-text</td>
-    <td>$input-text</td>
+<td>
+
+
+`$input-hover-text`
+
+</td>
+<td>
+
+`$input-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered autocomplete.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$autocomplete-hover-border</td>
     <td></td>
-    <td>$input-hover-border</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`$input-hover-border`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered autocomplete.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$autocomplete-focus-text</td>
     <td></td>
-    <td>$input-focus-text</td>
-    <td>$input-hover-text</td>
+<td>
+
+
+`$input-focus-text`
+
+</td>
+<td>
+
+`$input-hover-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus autocomplete.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$autocomplete-focus-bg</td>
     <td></td>
-    <td>$input-focus-bg</td>
-    <td>$input-hover-bg</td>
+<td>
+
+
+`$input-focus-bg`
+
+</td>
+<td>
+
+`$input-hover-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus autocomplete.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$autocomplete-focus-border</td>
     <td></td>
-    <td>$input-focus-border</td>
-    <td>$input-hover-border</td>
+<td>
+
+
+`$input-focus-border`
+
+</td>
+<td>
+
+`$input-hover-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus autocomplete.</div></div>

--- a/packages/nouvelle/docs/customization-button.md
+++ b/packages/nouvelle/docs/customization-button.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$button-bg</td>
     <td></td>
-    <td>$interactive-bg</td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
+<td>
+
+
+`$interactive-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the buttons.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-text</td>
     <td></td>
-    <td>$interactive-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$interactive-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the buttons.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-border</td>
     <td></td>
-    <td>$interactive-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$interactive-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the buttons.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-gradient</td>
     <td></td>
-    <td>$interactive-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$interactive-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of the buttons.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hover-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, .5 )</td>
-    <td>try-shade( $button-bg, .5 )</td>
+<td>
+
+
+`try-shade( $button-bg, .5 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered buttons.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hover-text</td>
     <td></td>
-    <td>$button-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered buttons.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hover-border</td>
     <td></td>
-    <td>$button-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered buttons.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-hover-gradient</td>
     <td></td>
-    <td>$button-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$button-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of hovered buttons.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-focus-bg</td>
     <td></td>
-    <td>$button-hover-bg</td>
-    <td>try-shade( $button-bg, .5 )</td>
+<td>
+
+
+`$button-hover-bg`
+
+</td>
+<td>
+
+`try-shade( $button-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus buttons.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-focus-text</td>
     <td></td>
-    <td>$button-hover-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-hover-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus buttons.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-focus-border</td>
     <td></td>
-    <td>$button-hover-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-hover-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus buttons.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-focus-gradient</td>
     <td></td>
-    <td>$button-hover-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$button-hover-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of focus buttons.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, 1 )</td>
-    <td>try-shade( $button-bg, 1 )</td>
+<td>
+
+
+`try-shade( $button-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of pressed buttons.</div></div>
@@ -158,8 +275,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-text</td>
     <td></td>
-    <td>$button-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of pressed buttons.</div></div>
@@ -168,8 +294,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-border</td>
     <td></td>
-    <td>$button-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of pressed buttons.</div></div>
@@ -178,8 +313,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$button-active-gradient</td>
     <td></td>
-    <td>$button-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$button-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of pressed buttons.</div></div>

--- a/packages/nouvelle/docs/customization-color-system.md
+++ b/packages/nouvelle/docs/customization-color-system.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$primary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.<br />Used for primary buttons and for elements of primary importance across the theme.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$primary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $primary )</td>
-    <td>contrast-wcag( $primary )</td>
+<td>
+
+
+`contrast-wcag( $primary )`
+
+</td>
+<td>
+
+`contrast-wcag( $primary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the accent color denoted by $primary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$secondary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
+<td>
+<span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
+<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The secondary color of the theme.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$secondary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $secondary )</td>
-    <td>contrast-wcag( $secondary )</td>
+<td>
+
+
+`contrast-wcag( $secondary )`
+
+</td>
+<td>
+
+`contrast-wcag( $secondary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the secondary color denoted by $secondary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tertiary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
+<td>
+<span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
+<td><span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tertiary color of the theme.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$tertiary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $tertiary )</td>
-    <td>contrast-wcag( $tertiary )</td>
+<td>
+
+
+`contrast-wcag( $tertiary )`
+
+</td>
+<td>
+
+`contrast-wcag( $tertiary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the tertiary color denoted by $tertiary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$info</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
+<td>
+<span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
+<td><span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for informational messages and states.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$success</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
+<td>
+<span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
+<td><span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for success messages and states.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$warning</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
+<td>
+<span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for warning messages and states.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$error</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
+<td>
+<span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
+<td><span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for error messages and states.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dark</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #404040"></span>#404040</td>
-    <td><span class="color-preview" style="background-color: #404040"></span>#404040</td>
+<td>
+<span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
+
+</td>
+<td><span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The dark color of the theme.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$light</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
+<td>
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
+<td><span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The light color of the theme.</div></div>
@@ -148,8 +256,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$inverse</td>
     <td></td>
-    <td>if( $dark-theme, $light, $dark )</td>
-    <td>if( $dark-theme, $light, $dark )</td>
+<td>
+
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
+<td>
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Inverse color of the theme. Depending on the theme luminance dark or lught, it will be light or dark</div></div>

--- a/packages/nouvelle/docs/customization-combobox.md
+++ b/packages/nouvelle/docs/customization-combobox.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$combobox-bg</td>
     <td></td>
-    <td>$input-bg</td>
-    <td>$component-bg</td>
+<td>
+
+
+`$input-bg`
+
+</td>
+<td>
+
+`$component-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the combobox.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$combobox-text</td>
     <td></td>
-    <td>$input-text</td>
-    <td>$component-text</td>
+<td>
+
+
+`$input-text`
+
+</td>
+<td>
+
+`$component-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the combobox.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$combobox-border</td>
     <td></td>
-    <td>$input-border</td>
-    <td>$component-border</td>
+<td>
+
+
+`$input-border`
+
+</td>
+<td>
+
+`$component-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the combobox.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$combobox-hover-bg</td>
     <td></td>
-    <td>$input-hover-bg</td>
-    <td>$input-bg</td>
+<td>
+
+
+`$input-hover-bg`
+
+</td>
+<td>
+
+`$input-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered combobox.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$combobox-hover-text</td>
     <td></td>
-    <td>$input-hover-text</td>
-    <td>$input-text</td>
+<td>
+
+
+`$input-hover-text`
+
+</td>
+<td>
+
+`$input-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered combobox.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$combobox-hover-border</td>
     <td></td>
-    <td>$input-hover-border</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`$input-hover-border`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered combobox.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$combobox-focus-text</td>
     <td></td>
-    <td>$input-focus-text</td>
-    <td>$input-hover-text</td>
+<td>
+
+
+`$input-focus-text`
+
+</td>
+<td>
+
+`$input-hover-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus combobox.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$combobox-focus-bg</td>
     <td></td>
-    <td>$input-focus-bg</td>
-    <td>$input-hover-bg</td>
+<td>
+
+
+`$input-focus-bg`
+
+</td>
+<td>
+
+`$input-hover-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus combobox.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$combobox-focus-border</td>
     <td></td>
-    <td>$input-focus-border</td>
-    <td>$input-hover-border</td>
+<td>
+
+
+`$input-focus-border`
+
+</td>
+<td>
+
+`$input-hover-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus combobox.</div></div>

--- a/packages/nouvelle/docs/customization-common.md
+++ b/packages/nouvelle/docs/customization-common.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$interactive-bg</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
+<td>
+<span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
+<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the components' chrome area.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$interactive-text</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the components' chrome area.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$interactive-border</td>
     <td></td>
-    <td>rgba( black, .08 )</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`rgba( black, .08 )`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the components' chrome area.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$interactive-gradient</td>
     <td></td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of the components' chrome area.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hover-bg</td>
     <td></td>
-    <td>shade( $interactive-bg, .5 )</td>
-    <td>shade( $interactive-bg, .5 )</td>
+<td>
+
+
+`shade( $interactive-bg, .5 )`
+
+</td>
+<td>
+
+`shade( $interactive-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered items.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hover-text</td>
     <td></td>
-    <td>$interactive-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$interactive-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hover items.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hover-border</td>
     <td></td>
-    <td>rgba( black, .15 )</td>
-    <td>rgba( black, .15 )</td>
+<td>
+
+
+`rgba( black, .15 )`
+
+</td>
+<td>
+
+`rgba( black, .15 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hover items.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$hover-gradient</td>
     <td></td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of hover items.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of selected items.</div></div>
@@ -118,8 +199,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-text</td>
     <td></td>
-    <td>contrast-wcag( $selected-bg )</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`contrast-wcag( $selected-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected items.</div></div>
@@ -128,8 +218,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-border</td>
     <td></td>
-    <td>rgba( black, .1 )</td>
-    <td>rgba( black, .1 )</td>
+<td>
+
+
+`rgba( black, .1 )`
+
+</td>
+<td>
+
+`rgba( black, .1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected items.</div></div>
@@ -138,8 +237,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$selected-gradient</td>
     <td></td>
-    <td>none</td>
-    <td>none</td>
+<td>
+
+
+`none`
+
+</td>
+<td>
+
+`none`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of selected items.</div></div>

--- a/packages/nouvelle/docs/customization-component.md
+++ b/packages/nouvelle/docs/customization-component.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$component-bg</td>
     <td></td>
-    <td>$body-bg</td>
-    <td></td>
+<td>
+
+
+`$body-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-bg` e.g. `$grid-bg: $component-bg !defualt;`.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$component-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-text` e.g. `$grid-text: component-text !default;`.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$component-border</td>
     <td></td>
-    <td>rgba( black, .08 )</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`rgba( black, .08 )`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-border` e.g. `$grid-border: component-border !default;`.</div></div>

--- a/packages/nouvelle/docs/customization-dropdownlist.md
+++ b/packages/nouvelle/docs/customization-dropdownlist.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$dropdownlist-bg</td>
     <td></td>
-    <td>$button-bg</td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
+<td>
+
+
+`$button-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the dropdownlist.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dropdownlist-text</td>
     <td></td>
-    <td>$button-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the dropdownlist.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dropdownlist-border</td>
     <td></td>
-    <td>$button-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the dropdownlist.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dropdownlist-hover-bg</td>
     <td></td>
-    <td>$button-hover-bg</td>
-    <td>try-shade( $button-bg, .5 )</td>
+<td>
+
+
+`$button-hover-bg`
+
+</td>
+<td>
+
+`try-shade( $button-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered dropdownlist.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dropdownlist-hover-text</td>
     <td></td>
-    <td>$button-hover-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-hover-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered dropdownlist.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dropdownlist-hover-border</td>
     <td></td>
-    <td>$button-hover-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-hover-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered dropdownlist.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dropdownlist-focus-text</td>
     <td></td>
-    <td>$button-active-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-active-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus dropdownlist.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dropdownlist-focus-bg</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>try-shade( $button-bg, 1 )</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus dropdownlist.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$dropdownlist-focus-border</td>
     <td></td>
-    <td>$button-active-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-active-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus dropdownlist.</div></div>

--- a/packages/nouvelle/docs/customization-input.md
+++ b/packages/nouvelle/docs/customization-input.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$input-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the input.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$input-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the input.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$input-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the input.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$input-hover-bg</td>
     <td></td>
-    <td>$input-bg</td>
-    <td></td>
+<td>
+
+
+`$input-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered input.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$input-hover-text</td>
     <td></td>
-    <td>$input-text</td>
-    <td></td>
+<td>
+
+
+`$input-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered input.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$input-hover-border</td>
     <td></td>
-    <td>try-shade( $input-border, 1 )</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`try-shade( $input-border, 1 )`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered input.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$input-focus-bg</td>
     <td></td>
-    <td>$input-hover-bg</td>
-    <td></td>
+<td>
+
+
+`$input-hover-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus input.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$input-focus-text</td>
     <td></td>
-    <td>$input-hover-text</td>
-    <td></td>
+<td>
+
+
+`$input-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus input.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$input-focus-border</td>
     <td></td>
-    <td>$input-hover-border</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`$input-hover-border`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus input.</div></div>

--- a/packages/nouvelle/docs/customization-list.md
+++ b/packages/nouvelle/docs/customization-list.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$list-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the list.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the list.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$list-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the list.</div></div>

--- a/packages/nouvelle/docs/customization-popup.md
+++ b/packages/nouvelle/docs/customization-popup.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$popup-bg</td>
     <td></td>
-    <td>mix( black, $component-bg, 2% )</td>
-    <td>mix( black, $component-bg, 2% )</td>
+<td>
+
+
+`mix( black, $component-bg, 2% )`
+
+</td>
+<td>
+
+`mix( black, $component-bg, 2% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the popup.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$popup-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the popup.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$popup-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the popup.</div></div>

--- a/packages/nouvelle/docs/customization-textbox.md
+++ b/packages/nouvelle/docs/customization-textbox.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$kendo-textbox-bg</td>
     <td></td>
-    <td>$input-bg</td>
-    <td></td>
+<td>
+
+
+`$input-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the textbox.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-textbox-text</td>
     <td></td>
-    <td>$input-text</td>
-    <td></td>
+<td>
+
+
+`$input-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the textbox.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-textbox-border</td>
     <td></td>
-    <td>$input-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$input-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the textbox.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-textbox-hover-bg</td>
     <td></td>
-    <td>$input-hover-bg</td>
-    <td></td>
+<td>
+
+
+`$input-hover-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered textbox.</div></div>
@@ -68,8 +104,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-textbox-hover-text</td>
     <td></td>
-    <td>$input-hover-text</td>
-    <td></td>
+<td>
+
+
+`$input-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered textbox.</div></div>
@@ -78,8 +123,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-textbox-hover-border</td>
     <td></td>
-    <td>$input-hover-border</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`$input-hover-border`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered textbox.</div></div>
@@ -88,8 +142,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-textbox-focus-text</td>
     <td></td>
-    <td>$input-focus-text</td>
-    <td></td>
+<td>
+
+
+`$input-focus-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus textbox.</div></div>
@@ -98,8 +161,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-textbox-focus-bg</td>
     <td></td>
-    <td>$input-focus-bg</td>
-    <td></td>
+<td>
+
+
+`$input-focus-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus textbox.</div></div>
@@ -108,8 +180,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-textbox-focus-border</td>
     <td></td>
-    <td>$input-focus-border</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`$input-focus-border`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus textbox.</div></div>

--- a/packages/nouvelle/docs/customization-typography.md
+++ b/packages/nouvelle/docs/customization-typography.md
@@ -28,8 +28,17 @@ The following table lists the available variables for customization.
         <tr>
     <td>$font-size</td>
     <td></td>
-    <td>14px</td>
-    <td>14px</td>
+<td>
+
+
+`14px`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Base font size across all components.</div></div>
@@ -38,8 +47,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-family</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family across all components.</div></div>
@@ -48,8 +66,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$font-family-monospace</td>
     <td></td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
+<td>
+
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
+<td>
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family for monospaced text. Used for styling the code.</div></div>
@@ -58,8 +85,17 @@ The following table lists the available variables for customization.
 <tr>
     <td>$line-height</td>
     <td></td>
-    <td>(20 / 14)</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`(20 / 14)`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>

--- a/packages/nouvelle/docs/customization.md
+++ b/packages/nouvelle/docs/customization.md
@@ -32,8 +32,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$interactive-bg</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
+<td>
+<span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
+<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the components' chrome area.</div></div>
@@ -42,8 +51,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$interactive-text</td>
     <td></td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the components' chrome area.</div></div>
@@ -52,8 +70,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$interactive-border</td>
     <td></td>
-    <td>rgba( black, .08 )</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`rgba( black, .08 )`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the components' chrome area.</div></div>
@@ -62,8 +89,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$interactive-gradient</td>
     <td></td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of the components' chrome area.</div></div>
@@ -72,8 +108,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$hover-bg</td>
     <td></td>
-    <td>shade( $interactive-bg, .5 )</td>
-    <td>shade( $interactive-bg, .5 )</td>
+<td>
+
+
+`shade( $interactive-bg, .5 )`
+
+</td>
+<td>
+
+`shade( $interactive-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered items.</div></div>
@@ -82,8 +127,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$hover-text</td>
     <td></td>
-    <td>$interactive-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$interactive-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hover items.</div></div>
@@ -92,8 +146,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$hover-border</td>
     <td></td>
-    <td>rgba( black, .15 )</td>
-    <td>rgba( black, .15 )</td>
+<td>
+
+
+`rgba( black, .15 )`
+
+</td>
+<td>
+
+`rgba( black, .15 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hover items.</div></div>
@@ -102,8 +165,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$hover-gradient</td>
     <td></td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of hover items.</div></div>
@@ -112,8 +184,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$selected-bg</td>
     <td></td>
-    <td>$primary</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+
+
+`$primary`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of selected items.</div></div>
@@ -122,8 +203,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$selected-text</td>
     <td></td>
-    <td>contrast-wcag( $selected-bg )</td>
-    <td>contrast-wcag( $selected-bg )</td>
+<td>
+
+
+`contrast-wcag( $selected-bg )`
+
+</td>
+<td>
+
+`contrast-wcag( $selected-bg )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of selected items.</div></div>
@@ -132,8 +222,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$selected-border</td>
     <td></td>
-    <td>rgba( black, .1 )</td>
-    <td>rgba( black, .1 )</td>
+<td>
+
+
+`rgba( black, .1 )`
+
+</td>
+<td>
+
+`rgba( black, .1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of selected items.</div></div>
@@ -142,8 +241,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$selected-gradient</td>
     <td></td>
-    <td>none</td>
-    <td>none</td>
+<td>
+
+
+`none`
+
+</td>
+<td>
+
+`none`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The gradient background of selected items.</div></div>
@@ -173,8 +281,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$autocomplete-bg</td>
     <td></td>
-    <td>$input-bg</td>
-    <td>$component-bg</td>
+<td>
+
+
+`$input-bg`
+
+</td>
+<td>
+
+`$component-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the autocomplete.</div></div>
@@ -183,8 +300,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$autocomplete-text</td>
     <td></td>
-    <td>$input-text</td>
-    <td>$component-text</td>
+<td>
+
+
+`$input-text`
+
+</td>
+<td>
+
+`$component-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the autocomplete.</div></div>
@@ -193,8 +319,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$autocomplete-border</td>
     <td></td>
-    <td>$input-border</td>
-    <td>$component-border</td>
+<td>
+
+
+`$input-border`
+
+</td>
+<td>
+
+`$component-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the autocomplete.</div></div>
@@ -203,8 +338,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$autocomplete-hover-bg</td>
     <td></td>
-    <td>$input-hover-bg</td>
-    <td>$input-bg</td>
+<td>
+
+
+`$input-hover-bg`
+
+</td>
+<td>
+
+`$input-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered autocomplete.</div></div>
@@ -213,8 +357,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$autocomplete-hover-text</td>
     <td></td>
-    <td>$input-hover-text</td>
-    <td>$input-text</td>
+<td>
+
+
+`$input-hover-text`
+
+</td>
+<td>
+
+`$input-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered autocomplete.</div></div>
@@ -223,8 +376,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$autocomplete-hover-border</td>
     <td></td>
-    <td>$input-hover-border</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`$input-hover-border`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered autocomplete.</div></div>
@@ -233,8 +395,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$autocomplete-focus-text</td>
     <td></td>
-    <td>$input-focus-text</td>
-    <td>$input-hover-text</td>
+<td>
+
+
+`$input-focus-text`
+
+</td>
+<td>
+
+`$input-hover-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus autocomplete.</div></div>
@@ -243,8 +414,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$autocomplete-focus-bg</td>
     <td></td>
-    <td>$input-focus-bg</td>
-    <td>$input-hover-bg</td>
+<td>
+
+
+`$input-focus-bg`
+
+</td>
+<td>
+
+`$input-hover-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus autocomplete.</div></div>
@@ -253,8 +433,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$autocomplete-focus-border</td>
     <td></td>
-    <td>$input-focus-border</td>
-    <td>$input-hover-border</td>
+<td>
+
+
+`$input-focus-border`
+
+</td>
+<td>
+
+`$input-hover-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus autocomplete.</div></div>
@@ -284,8 +473,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$button-bg</td>
     <td></td>
-    <td>$interactive-bg</td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
+<td>
+
+
+`$interactive-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the buttons.</div></div>
@@ -294,8 +492,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-text</td>
     <td></td>
-    <td>$interactive-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$interactive-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the buttons.</div></div>
@@ -304,8 +511,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-border</td>
     <td></td>
-    <td>$interactive-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$interactive-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the buttons.</div></div>
@@ -314,8 +530,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-gradient</td>
     <td></td>
-    <td>$interactive-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$interactive-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of the buttons.</div></div>
@@ -324,8 +549,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-hover-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, .5 )</td>
-    <td>try-shade( $button-bg, .5 )</td>
+<td>
+
+
+`try-shade( $button-bg, .5 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered buttons.</div></div>
@@ -334,8 +568,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-hover-text</td>
     <td></td>
-    <td>$button-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered buttons.</div></div>
@@ -344,8 +587,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-hover-border</td>
     <td></td>
-    <td>$button-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered buttons.</div></div>
@@ -354,8 +606,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-hover-gradient</td>
     <td></td>
-    <td>$button-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$button-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of hovered buttons.</div></div>
@@ -364,8 +625,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-focus-bg</td>
     <td></td>
-    <td>$button-hover-bg</td>
-    <td>try-shade( $button-bg, .5 )</td>
+<td>
+
+
+`$button-hover-bg`
+
+</td>
+<td>
+
+`try-shade( $button-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus buttons.</div></div>
@@ -374,8 +644,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-focus-text</td>
     <td></td>
-    <td>$button-hover-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-hover-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus buttons.</div></div>
@@ -384,8 +663,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-focus-border</td>
     <td></td>
-    <td>$button-hover-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-hover-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus buttons.</div></div>
@@ -394,8 +682,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-focus-gradient</td>
     <td></td>
-    <td>$button-hover-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$button-hover-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of focus buttons.</div></div>
@@ -404,8 +701,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-active-bg</td>
     <td></td>
-    <td>try-shade( $button-bg, 1 )</td>
-    <td>try-shade( $button-bg, 1 )</td>
+<td>
+
+
+`try-shade( $button-bg, 1 )`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of pressed buttons.</div></div>
@@ -414,8 +720,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-active-text</td>
     <td></td>
-    <td>$button-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of pressed buttons.</div></div>
@@ -424,8 +739,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-active-border</td>
     <td></td>
-    <td>$button-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of pressed buttons.</div></div>
@@ -434,8 +758,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$button-active-gradient</td>
     <td></td>
-    <td>$button-gradient</td>
-    <td>rgba( black, 0 ), rgba( black, .02 )</td>
+<td>
+
+
+`$button-gradient`
+
+</td>
+<td>
+
+`rgba( black, 0 ), rgba( black, .02 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background gradient of pressed buttons.</div></div>
@@ -465,8 +798,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$primary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
-    <td><span class="color-preview" style="background-color: #ff6358"></span>#ff6358</td>
+<td>
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
+<td><span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color that focuses the user attention.<br />Used for primary buttons and for elements of primary importance across the theme.</div></div>
@@ -475,8 +817,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$primary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $primary )</td>
-    <td>contrast-wcag( $primary )</td>
+<td>
+
+
+`contrast-wcag( $primary )`
+
+</td>
+<td>
+
+`contrast-wcag( $primary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the accent color denoted by $primary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -485,8 +836,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$secondary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
+<td>
+<span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
+<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The secondary color of the theme.</div></div>
@@ -495,8 +855,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$secondary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $secondary )</td>
-    <td>contrast-wcag( $secondary )</td>
+<td>
+
+
+`contrast-wcag( $secondary )`
+
+</td>
+<td>
+
+`contrast-wcag( $secondary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the secondary color denoted by $secondary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -505,8 +874,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$tertiary</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
-    <td><span class="color-preview" style="background-color: #03a9f4"></span>#03a9f4</td>
+<td>
+<span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
+<td><span class="color-preview" style="background-color: #03a9f4"></span>
+
+`#03a9f4`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tertiary color of the theme.</div></div>
@@ -515,8 +893,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$tertiary-contrast</td>
     <td>Color</td>
-    <td>contrast-wcag( $tertiary )</td>
-    <td>contrast-wcag( $tertiary )</td>
+<td>
+
+
+`contrast-wcag( $tertiary )`
+
+</td>
+<td>
+
+`contrast-wcag( $tertiary )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color used along with the tertiary color denoted by $tertiary.<br />Used to provide contrast between the background and foreground colors.</div></div>
@@ -525,8 +912,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$info</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
-    <td><span class="color-preview" style="background-color: #0058e9"></span>#0058e9</td>
+<td>
+<span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
+<td><span class="color-preview" style="background-color: #0058e9"></span>
+
+`#0058e9`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for informational messages and states.</div></div>
@@ -535,8 +931,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$success</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
-    <td><span class="color-preview" style="background-color: #37b400"></span>#37b400</td>
+<td>
+<span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
+<td><span class="color-preview" style="background-color: #37b400"></span>
+
+`#37b400`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for success messages and states.</div></div>
@@ -545,8 +950,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$warning</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
-    <td><span class="color-preview" style="background-color: #ffc000"></span>#ffc000</td>
+<td>
+<span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
+<td><span class="color-preview" style="background-color: #ffc000"></span>
+
+`#ffc000`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for warning messages and states.</div></div>
@@ -555,8 +969,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$error</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
-    <td><span class="color-preview" style="background-color: #f31700"></span>#f31700</td>
+<td>
+<span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
+<td><span class="color-preview" style="background-color: #f31700"></span>
+
+`#f31700`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The color for error messages and states.</div></div>
@@ -565,8 +988,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$dark</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #404040"></span>#404040</td>
-    <td><span class="color-preview" style="background-color: #404040"></span>#404040</td>
+<td>
+<span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
+
+</td>
+<td><span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The dark color of the theme.</div></div>
@@ -575,8 +1007,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$light</td>
     <td>Color</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
-    <td><span class="color-preview" style="background-color: #ebebeb"></span>#ebebeb</td>
+<td>
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
+<td><span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The light color of the theme.</div></div>
@@ -585,8 +1026,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$inverse</td>
     <td></td>
-    <td>if( $dark-theme, $light, $dark )</td>
-    <td>if( $dark-theme, $light, $dark )</td>
+<td>
+
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
+<td>
+
+`if( $dark-theme, $light, $dark )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Inverse color of the theme. Depending on the theme luminance dark or lught, it will be light or dark</div></div>
@@ -616,8 +1066,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$combobox-bg</td>
     <td></td>
-    <td>$input-bg</td>
-    <td>$component-bg</td>
+<td>
+
+
+`$input-bg`
+
+</td>
+<td>
+
+`$component-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the combobox.</div></div>
@@ -626,8 +1085,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$combobox-text</td>
     <td></td>
-    <td>$input-text</td>
-    <td>$component-text</td>
+<td>
+
+
+`$input-text`
+
+</td>
+<td>
+
+`$component-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the combobox.</div></div>
@@ -636,8 +1104,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$combobox-border</td>
     <td></td>
-    <td>$input-border</td>
-    <td>$component-border</td>
+<td>
+
+
+`$input-border`
+
+</td>
+<td>
+
+`$component-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the combobox.</div></div>
@@ -646,8 +1123,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$combobox-hover-bg</td>
     <td></td>
-    <td>$input-hover-bg</td>
-    <td>$input-bg</td>
+<td>
+
+
+`$input-hover-bg`
+
+</td>
+<td>
+
+`$input-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered combobox.</div></div>
@@ -656,8 +1142,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$combobox-hover-text</td>
     <td></td>
-    <td>$input-hover-text</td>
-    <td>$input-text</td>
+<td>
+
+
+`$input-hover-text`
+
+</td>
+<td>
+
+`$input-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered combobox.</div></div>
@@ -666,8 +1161,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$combobox-hover-border</td>
     <td></td>
-    <td>$input-hover-border</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`$input-hover-border`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered combobox.</div></div>
@@ -676,8 +1180,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$combobox-focus-text</td>
     <td></td>
-    <td>$input-focus-text</td>
-    <td>$input-hover-text</td>
+<td>
+
+
+`$input-focus-text`
+
+</td>
+<td>
+
+`$input-hover-text`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus combobox.</div></div>
@@ -686,8 +1199,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$combobox-focus-bg</td>
     <td></td>
-    <td>$input-focus-bg</td>
-    <td>$input-hover-bg</td>
+<td>
+
+
+`$input-focus-bg`
+
+</td>
+<td>
+
+`$input-hover-bg`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus combobox.</div></div>
@@ -696,8 +1218,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$combobox-focus-border</td>
     <td></td>
-    <td>$input-focus-border</td>
-    <td>$input-hover-border</td>
+<td>
+
+
+`$input-focus-border`
+
+</td>
+<td>
+
+`$input-hover-border`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus combobox.</div></div>
@@ -727,8 +1258,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$component-bg</td>
     <td></td>
-    <td>$body-bg</td>
-    <td></td>
+<td>
+
+
+`$body-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Background color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-bg` e.g. `$grid-bg: $component-bg !defualt;`.</div></div>
@@ -737,8 +1277,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$component-text</td>
     <td></td>
-    <td>$body-text</td>
-    <td></td>
+<td>
+
+
+`$body-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Text color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-text` e.g. `$grid-text: component-text !default;`.</div></div>
@@ -747,8 +1296,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$component-border</td>
     <td></td>
-    <td>rgba( black, .08 )</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`rgba( black, .08 )`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Border color of a component.<br />Note: do not use this variable directly. Instead derive it as `$component-name-border` e.g. `$grid-border: component-border !default;`.</div></div>
@@ -778,8 +1336,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$dropdownlist-bg</td>
     <td></td>
-    <td>$button-bg</td>
-    <td><span class="color-preview" style="background-color: #f6f6f6"></span>#f6f6f6</td>
+<td>
+
+
+`$button-bg`
+
+</td>
+<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+
+`#f6f6f6`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the dropdownlist.</div></div>
@@ -788,8 +1355,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$dropdownlist-text</td>
     <td></td>
-    <td>$button-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the dropdownlist.</div></div>
@@ -798,8 +1374,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$dropdownlist-border</td>
     <td></td>
-    <td>$button-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the dropdownlist.</div></div>
@@ -808,8 +1393,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$dropdownlist-hover-bg</td>
     <td></td>
-    <td>$button-hover-bg</td>
-    <td>try-shade( $button-bg, .5 )</td>
+<td>
+
+
+`$button-hover-bg`
+
+</td>
+<td>
+
+`try-shade( $button-bg, .5 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered dropdownlist.</div></div>
@@ -818,8 +1412,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$dropdownlist-hover-text</td>
     <td></td>
-    <td>$button-hover-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-hover-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered dropdownlist.</div></div>
@@ -828,8 +1431,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$dropdownlist-hover-border</td>
     <td></td>
-    <td>$button-hover-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-hover-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered dropdownlist.</div></div>
@@ -838,8 +1450,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$dropdownlist-focus-text</td>
     <td></td>
-    <td>$button-active-text</td>
-    <td><span class="color-preview" style="background-color: #656565"></span>#656565</td>
+<td>
+
+
+`$button-active-text`
+
+</td>
+<td><span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus dropdownlist.</div></div>
@@ -848,8 +1469,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$dropdownlist-focus-bg</td>
     <td></td>
-    <td>$button-active-bg</td>
-    <td>try-shade( $button-bg, 1 )</td>
+<td>
+
+
+`$button-active-bg`
+
+</td>
+<td>
+
+`try-shade( $button-bg, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus dropdownlist.</div></div>
@@ -858,8 +1488,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$dropdownlist-focus-border</td>
     <td></td>
-    <td>$button-active-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$button-active-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus dropdownlist.</div></div>
@@ -889,8 +1528,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$input-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the input.</div></div>
@@ -899,8 +1547,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$input-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the input.</div></div>
@@ -909,8 +1566,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$input-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the input.</div></div>
@@ -919,8 +1585,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$input-hover-bg</td>
     <td></td>
-    <td>$input-bg</td>
-    <td></td>
+<td>
+
+
+`$input-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered input.</div></div>
@@ -929,8 +1604,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$input-hover-text</td>
     <td></td>
-    <td>$input-text</td>
-    <td></td>
+<td>
+
+
+`$input-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered input.</div></div>
@@ -939,8 +1623,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$input-hover-border</td>
     <td></td>
-    <td>try-shade( $input-border, 1 )</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`try-shade( $input-border, 1 )`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered input.</div></div>
@@ -949,8 +1642,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$input-focus-bg</td>
     <td></td>
-    <td>$input-hover-bg</td>
-    <td></td>
+<td>
+
+
+`$input-hover-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus input.</div></div>
@@ -959,8 +1661,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$input-focus-text</td>
     <td></td>
-    <td>$input-hover-text</td>
-    <td></td>
+<td>
+
+
+`$input-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus input.</div></div>
@@ -969,8 +1680,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$input-focus-border</td>
     <td></td>
-    <td>$input-hover-border</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`$input-hover-border`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus input.</div></div>
@@ -1000,8 +1720,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$list-bg</td>
     <td></td>
-    <td>$component-bg</td>
-    <td></td>
+<td>
+
+
+`$component-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the list.</div></div>
@@ -1010,8 +1739,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$list-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the list.</div></div>
@@ -1020,8 +1758,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$list-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the list.</div></div>
@@ -1051,8 +1798,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$popup-bg</td>
     <td></td>
-    <td>mix( black, $component-bg, 2% )</td>
-    <td>mix( black, $component-bg, 2% )</td>
+<td>
+
+
+`mix( black, $component-bg, 2% )`
+
+</td>
+<td>
+
+`mix( black, $component-bg, 2% )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the popup.</div></div>
@@ -1061,8 +1817,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$popup-text</td>
     <td></td>
-    <td>$component-text</td>
-    <td></td>
+<td>
+
+
+`$component-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the popup.</div></div>
@@ -1071,8 +1836,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$popup-border</td>
     <td></td>
-    <td>$component-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$component-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the popup.</div></div>
@@ -1102,8 +1876,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$kendo-textbox-bg</td>
     <td></td>
-    <td>$input-bg</td>
-    <td></td>
+<td>
+
+
+`$input-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of the textbox.</div></div>
@@ -1112,8 +1895,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$kendo-textbox-text</td>
     <td></td>
-    <td>$input-text</td>
-    <td></td>
+<td>
+
+
+`$input-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the textbox.</div></div>
@@ -1122,8 +1914,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$kendo-textbox-border</td>
     <td></td>
-    <td>$input-border</td>
-    <td>rgba( black, .08 )</td>
+<td>
+
+
+`$input-border`
+
+</td>
+<td>
+
+`rgba( black, .08 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of the textbox.</div></div>
@@ -1132,8 +1933,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$kendo-textbox-hover-bg</td>
     <td></td>
-    <td>$input-hover-bg</td>
-    <td></td>
+<td>
+
+
+`$input-hover-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background of hovered textbox.</div></div>
@@ -1142,8 +1952,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$kendo-textbox-hover-text</td>
     <td></td>
-    <td>$input-hover-text</td>
-    <td></td>
+<td>
+
+
+`$input-hover-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of hovered textbox.</div></div>
@@ -1152,8 +1971,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$kendo-textbox-hover-border</td>
     <td></td>
-    <td>$input-hover-border</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`$input-hover-border`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of hovered textbox.</div></div>
@@ -1162,8 +1990,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$kendo-textbox-focus-text</td>
     <td></td>
-    <td>$input-focus-text</td>
-    <td></td>
+<td>
+
+
+`$input-focus-text`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of focus textbox.</div></div>
@@ -1172,8 +2009,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$kendo-textbox-focus-bg</td>
     <td></td>
-    <td>$input-focus-bg</td>
-    <td></td>
+<td>
+
+
+`$input-focus-bg`
+
+</td>
+<td>
+
+
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of focus textbox.</div></div>
@@ -1182,8 +2028,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$kendo-textbox-focus-border</td>
     <td></td>
-    <td>$input-focus-border</td>
-    <td>try-shade( $input-border, 1 )</td>
+<td>
+
+
+`$input-focus-border`
+
+</td>
+<td>
+
+`try-shade( $input-border, 1 )`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The border color of focus textbox.</div></div>
@@ -1213,8 +2068,17 @@ The following table lists the available variables for customizing the Nouvelle t
         <tr>
     <td>$font-size</td>
     <td></td>
-    <td>14px</td>
-    <td>14px</td>
+<td>
+
+
+`14px`
+
+</td>
+<td>
+
+`14px`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Base font size across all components.</div></div>
@@ -1223,8 +2087,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$font-family</td>
     <td></td>
-    <td>inherit</td>
-    <td>inherit</td>
+<td>
+
+
+`inherit`
+
+</td>
+<td>
+
+`inherit`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family across all components.</div></div>
@@ -1233,8 +2106,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$font-family-monospace</td>
     <td></td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
-    <td>SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace</td>
+<td>
+
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
+<td>
+
+`SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Font family for monospaced text. Used for styling the code.</div></div>
@@ -1243,8 +2125,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tr>
     <td>$line-height</td>
     <td></td>
-    <td>(20 / 14)</td>
-    <td>(20 / 14)</td>
+<td>
+
+
+`(20 / 14)`
+
+</td>
+<td>
+
+`(20 / 14)`
+
+</td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Line height used along with $font-size.</div></div>


### PR DESCRIPTION
The following PR fixes an issue where the generated markdown is not valid due to calculations inside a variable's value, thus the corresponding website documentation build fails.

The exact issue is reproducible with the value of the `$button-calc-size` variable, which is `calc( #{$button-line-height * 1em} + #{$button-padding-y * 2} + #{$button-border-width * 2} )`. Put into an MDX syntax, this string is not valid unless escaped.

The new-lines around the code-snippets are required to trigger markdown parsing.