### PR TITLE
fix(listbox): display bottom border of the list container

### DIFF
--- a/packages/default/scss/listbox/_layout.scss
+++ b/packages/default/scss/listbox/_layout.scss
@@ -83,6 +83,7 @@
 
             .k-list {
                 height: inherit;
+                background: transparent;
             }
         }
 


### PR DESCRIPTION
Fixes: https://github.com/telerik/kendo-themes/issues/3230