### PR TITLE
fix(grid): remove separate hover styling on detail row container

### DIFF
--- a/packages/bootstrap/scss/grid/_theme.scss
+++ b/packages/bootstrap/scss/grid/_theme.scss
@@ -18,8 +18,8 @@
         }
 
         // Hover state
-        tbody tr:hover,
-        tbody tr.k-state-hover {
+        tbody tr:not(.k-detail-row):hover,
+        tbody tr:not(.k-detail-row).k-state-hover {
             color: $grid-hovered-text;
             background-color: $grid-hovered-bg;
         }

--- a/packages/default/scss/grid/_theme.scss
+++ b/packages/default/scss/grid/_theme.scss
@@ -73,8 +73,8 @@
         }
 
         // Hover state
-        tbody tr:hover,
-        tbody tr.k-state-hover {
+        tbody tr:not(.k-detail-row):hover,
+        tbody tr:not(.k-detail-row).k-state-hover {
             color: $grid-hovered-text;
             background-color: $grid-hovered-bg;
         }

--- a/packages/material/scss/grid/_theme.scss
+++ b/packages/material/scss/grid/_theme.scss
@@ -18,8 +18,8 @@
 
         // Hover, Focused state
         table {
-            tr:hover,
-            tr.k-state-hover,
+            tr:not(.k-detail-row):hover,
+            tr:not(.k-detail-row).k-state-hover,
             td.k-state-focused,
             th.k-state-focused,
             th:focus,


### PR DESCRIPTION
Fixes: https://github.com/telerik/kendo-themes/issues/1572