### PR TITLE
fix(daterangepicker): set default width for dateinputs

### DIFF
--- a/packages/bootstrap/scss/daterangepicker/_variables.scss
+++ b/packages/bootstrap/scss/daterangepicker/_variables.scss
@@ -1,1 +1,2 @@
 // Daterangepicker
+$kendo-daterange-picker-input-width: 10em;

--- a/packages/classic/scss/daterangepicker/_variables.scss
+++ b/packages/classic/scss/daterangepicker/_variables.scss
@@ -1,1 +1,2 @@
 // Daterangepicker
+$kendo-daterange-picker-input-width: 10em;

--- a/packages/default/scss/daterangepicker/_layout.scss
+++ b/packages/default/scss/daterangepicker/_layout.scss
@@ -13,6 +13,10 @@
         *::after {
             box-sizing: border-box;
         }
+
+        .k-dateinput {
+            width: $kendo-daterange-picker-input-width;
+        }
     }
 
 

--- a/packages/default/scss/daterangepicker/_variables.scss
+++ b/packages/default/scss/daterangepicker/_variables.scss
@@ -1,1 +1,2 @@
 // Daterangepicker
+$kendo-daterange-picker-input-width: 10em;

--- a/packages/default/scss/forms/_layout.scss
+++ b/packages/default/scss/forms/_layout.scss
@@ -141,7 +141,8 @@
 
 
         .k-multiselect,
-        .k-floating-label-container {
+        .k-floating-label-container,
+        .k-daterangepicker .k-dateinput {
             display: inline-flex;
             width: 100%;
         }

--- a/packages/material/scss/daterangepicker/_variables.scss
+++ b/packages/material/scss/daterangepicker/_variables.scss
@@ -1,1 +1,2 @@
 // Daterangepicker
+$kendo-daterange-picker-input-width: 10em;


### PR DESCRIPTION
fixes: https://github.com/telerik/kendo-themes/issues/3209