### PR TITLE
Resolve sass variables before markdown generation

### DIFF
--- a/docs/sassdoc-theme.js
+++ b/docs/sassdoc-theme.js
@@ -1,17 +1,25 @@
 const fs = require('fs');
 const path = require('path');
-const sassdocExtras = require('sassdoc-extras');
 const nunjucks = require('./nunjucks');
 
 module.exports = function(dest, context) {
     const capitalize = (str) => str[0].toUpperCase() + str.substring(1);
-
-    sassdocExtras( context, 'resolveVariables' );
+    const resolvedVars = JSON.parse( fs.readFileSync(context.json), 'utf-8');
 
     const data = context.data
         .filter((item) => item.access === 'public')
         .reduce((acc, item) => {
             if (item.context.type === 'variable') {
+                let varName = item.context.name;
+
+                // Augment resolved value
+                item.resolvedValue = resolvedVars[varName].value;
+
+                // Augment variable type
+                item.type = item.type !== undefined
+                    ? item.type
+                    : capitalize(resolvedVars[varName].type);
+
                 acc.variableGroups.push(item);
             } else {
                 acc[item.context.type].push(item);

--- a/docs/templates/includes/theme-variables-row.md.njk
+++ b/docs/templates/includes/theme-variables-row.md.njk
@@ -2,14 +2,31 @@
     <td>${{ variable.context.name }}</td>
     <td>{{ variable.type }}</td>
 <td>
-{% if variable.context.value | is_color === true %}<span class="color-preview" style="background-color: {{variable.context.value}}"></span>{% endif %}
 
-{% if variable.context.value %}`{{ variable.context.value }}`{% endif %}
+{%
+    if variable.context.value | is_color === true
+%}<span class="color-preview" style="background-color: {{variable.context.value}}"></span>
+
+{%
+    endif
+%}{%
+    if variable.context.value
+%}`{{ variable.context.value }}`{%
+    endif
+%}
 
 </td>
-<td>{% if variable.resolvedValue | is_color === true %}<span class="color-preview" style="background-color: {{variable.resolvedValue}}"></span>{% endif %}
+<td>
 
-{% if variable.resolvedValue %}`{{ variable.resolvedValue }}`{% endif %}
+{%
+    if variable.type === 'Color'
+%}<span class="color-preview" style="background-color: {{variable.resolvedValue}}"></span>
+
+{%
+    endif
+%}{%
+    if variable.resolvedValue
+%}`{{ variable.resolvedValue }}`{% endif %}
 
 </td>
 </tr>

--- a/lib/variables.scss
+++ b/lib/variables.scss
@@ -1,0 +1,10 @@
+@use "sass:meta";
+@use "all.scss";
+
+$_vars: meta.module-variables("all");
+
+body {
+    @each $key, $val in $_vars {
+        var: k-resolve-var( unquote($key), meta.type-of( $val ), $val );
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17625,23 +17625,6 @@
         }
       }
     },
-    "sassdoc-extras": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sassdoc-extras/-/sassdoc-extras-3.0.0.tgz",
-      "integrity": "sha512-X5yfgjSjSU/7Vkk1JRIduF56MbFJ0aN2CEB1VnYwdOXIRFFTwTw/+2YeeN+Xgnvsju7XnDvgS+q7wFV5y4rTtg==",
-      "dev": true,
-      "requires": {
-        "marked": "^0.8.0"
-      },
-      "dependencies": {
-        "marked": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
-          "dev": true
-        }
-      }
-    },
     "sassdoc-theme-default": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/sassdoc-theme-default/-/sassdoc-theme-default-2.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "sass-lint": "^1.13.1",
     "sass-variable-parser": "^1.2.2",
     "sassdoc": "^2.7.3",
-    "sassdoc-extras": "^3.0.0",
     "semver": "^7.3.5",
     "stylelint": "^14.2.0",
     "stylelint-config-standard": "^24.0.0",

--- a/packages/bootstrap/docs/customization-avatar.md
+++ b/packages/bootstrap/docs/customization-avatar.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-avatar-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
 </td>
 <td>
 
-`$font-family-sans-serif`
+`system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
 </td>
 <td>
 
-`$font-size-base`
+`1rem`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`$line-height-base`
+`1.5`
 
 </td>
 </tr>
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 4 ),
@@ -116,11 +111,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 4 ),
-    md: map-get( $spacing, 8 ),
-    lg: map-get( $spacing, 16 )
-)`
+`(sm: 1rem, md: 2rem, lg: 4rem)`
 
 </td>
 </tr>
@@ -130,16 +121,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #0d6efd, "secondary": #6c757d, "tertiary": #6f42c1, "info": #0dcaf0, "success": #198754, "warning": #ffc107, "error": #dc3545, "dark": #212529, "light": #f8f9fa, "inverse": #212529)`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-button.md
+++ b/packages/bootstrap/docs/customization-button.md
@@ -27,16 +27,15 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-button-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$btn-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-border-radius</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$btn-padding-x`
 
 </td>
 <td>
 
-
+`0.75rem`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$btn-padding-y`
 
 </td>
 <td>
 
-
+`0.375rem`
 
 </td>
 </tr>
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
 </td>
 <td>
 
-`$font-family-sans-serif`
+`system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`
 
 </td>
 </tr>
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$btn-font-size`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -141,16 +135,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$btn-line-height`
 
 </td>
 <td>
 
-
+`1.5`
 
 </td>
 </tr>
@@ -160,16 +153,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
+`calc( 1.5em + 0.75rem + 2px )`
 
 </td>
 </tr>
@@ -179,16 +171,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-inner-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
+`calc( 1.5em + 0.75rem )`
 
 </td>
 </tr>
@@ -198,9 +189,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `map-merge(
     $kendo-theme-colors,
@@ -210,10 +200,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`map-merge(
-    $kendo-theme-colors,
-    ( "base": #e4e7eb )
-)`
+`("primary": #0d6efd, "secondary": #6c757d, "tertiary": #6f42c1, "info": #0dcaf0, "success": #198754, "warning": #ffc107, "error": #dc3545, "dark": #212529, "light": #f8f9fa, "inverse": #212529, "base": #e4e7eb)`
 
 </td>
 </tr>
@@ -223,14 +210,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #e4e7eb"></span>
 
 `#e4e7eb`
 
 </td>
-<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #e4e7eb"></span>
 
 `#e4e7eb`
 
@@ -242,16 +232,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-button-bg, $gray-900 )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-button-bg, $gray-900 )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -261,14 +252,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #e4e7eb"></span>
 
 `#e4e7eb`
 
@@ -280,9 +272,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -299,9 +290,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -318,16 +308,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $kendo-button-bg, 7.5% )`
 
 </td>
 <td>
 
-`try-darken( $kendo-button-bg, 7.5% )`
+<span class="color-preview" style="background-color: #ced3db"></span>
+
+`#ced3db`
 
 </td>
 </tr>
@@ -337,9 +328,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -356,16 +346,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $kendo-button-bg, 10% )`
 
 </td>
 <td>
 
-`try-darken( $kendo-button-bg, 10% )`
+<span class="color-preview" style="background-color: #c7cdd5"></span>
+
+`#c7cdd5`
 
 </td>
 </tr>
@@ -375,9 +366,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -394,9 +384,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -413,16 +402,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $kendo-button-bg, 10% )`
 
 </td>
 <td>
 
-`try-darken( $kendo-button-bg, 10% )`
+<span class="color-preview" style="background-color: #c7cdd5"></span>
+
+`#c7cdd5`
 
 </td>
 </tr>
@@ -432,9 +422,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -451,16 +440,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $kendo-button-bg, 12.5% )`
 
 </td>
 <td>
 
-`try-darken( $kendo-button-bg, 12.5% )`
+<span class="color-preview" style="background-color: #bfc6d0"></span>
+
+`#bfc6d0`
 
 </td>
 </tr>
@@ -470,9 +460,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -489,9 +478,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -508,16 +496,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $primary, 10% )`
 
 </td>
 <td>
 
-`try-darken( $primary, 10% )`
+<span class="color-preview" style="background-color: #0257d5"></span>
+
+`#0257d5`
 
 </td>
 </tr>
@@ -527,16 +516,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-button-selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-button-selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -546,16 +536,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $primary, 12.5% )`
 
 </td>
 <td>
 
-`try-darken( $primary, 12.5% )`
+<span class="color-preview" style="background-color: #0252c9"></span>
+
+`#0252c9`
 
 </td>
 </tr>
@@ -565,9 +556,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-gradient`
 
@@ -584,9 +574,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-shadow`
 
@@ -603,9 +592,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -622,9 +610,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -641,9 +628,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -660,9 +646,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -679,16 +664,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 .25rem rgba( $kendo-button-border, .5 )`
 
 </td>
 <td>
 
-`0 0 0 .25rem rgba( $kendo-button-border, .5 )`
+`0 0 0 0.25rem rgba(228, 231, 235, 0.5)`
 
 </td>
 </tr>
@@ -698,9 +682,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -717,9 +700,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -736,9 +718,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -755,9 +736,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -774,9 +754,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -793,16 +772,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-hover-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.08`
 
 </td>
 <td>
 
-`.08`
+`0.08`
 
 </td>
 </tr>
@@ -812,9 +790,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-focus-opacity</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -831,16 +808,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-active-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.16`
 
 </td>
 <td>
 
-`.16`
+`0.16`
 
 </td>
 </tr>
@@ -850,16 +826,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-selected-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.2`
 
 </td>
 <td>
 
-`.2`
+`0.2`
 
 </td>
 </tr>
@@ -869,16 +844,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-transition</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$transition`
 
 </td>
 <td>
 
-
+`color 0.2s ease-in-out, background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-charts.md
+++ b/packages/bootstrap/docs/customization-charts.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$series-a</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$blue`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0d6efd"></span>
 
+`#0d6efd`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-b</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$purple`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #6f42c1"></span>
 
+`#6f42c1`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-c</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$teal`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #20c997"></span>
 
+`#20c997`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-d</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$green`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #198754"></span>
 
+`#198754`
 
 </td>
 </tr>
@@ -103,16 +107,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-e</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$yellow`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffc107"></span>
 
+`#ffc107`
 
 </td>
 </tr>
@@ -122,16 +127,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-f</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$red`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -141,16 +147,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-1</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$series-a`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0d6efd"></span>
 
+`#0d6efd`
 
 </td>
 </tr>
@@ -160,16 +167,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$chart-major-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .08 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -179,16 +187,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$chart-minor-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .04 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-checkbox.md
+++ b/packages/bootstrap/docs/customization-checkbox.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-checkbox-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -65,9 +65,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -84,16 +83,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-bg, $gray-400, $gray-600 )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-bg, $gray-400, $gray-600 )`
+<span class="color-preview" style="background-color: #ced4da"></span>
+
+`#ced4da`
 
 </td>
 </tr>
@@ -103,9 +103,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -122,9 +121,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +139,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,16 +157,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -179,16 +177,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-checked-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -198,16 +197,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -217,16 +217,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -236,16 +237,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -255,16 +257,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -274,16 +277,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $primary, 50% )`
 
 </td>
 <td>
 
-`try-tint( $primary, 50% )`
+<span class="color-preview" style="background-color: #86b7fe"></span>
+
+`#86b7fe`
 
 </td>
 </tr>
@@ -293,16 +297,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 .25rem rgba( $primary, .25 )`
 
 </td>
 <td>
 
-`0 0 0 .25rem rgba( $primary, .25 )`
+`0 0 0 0.25rem rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -312,16 +315,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -331,16 +335,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-shadow`
 
 </td>
 <td>
 
-`0 0 0 .25rem rgba( $primary, .25 )`
+`0 0 0 0.25rem rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -350,9 +353,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,9 +371,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -388,9 +389,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -407,9 +407,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -426,9 +425,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +443,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,9 +461,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -483,16 +479,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -502,16 +499,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -521,9 +519,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -540,9 +537,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -559,9 +555,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e118"`
 
@@ -578,9 +573,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e121"`
 
@@ -597,16 +591,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -616,16 +609,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -635,16 +627,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -654,16 +645,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -673,9 +663,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -692,16 +681,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`0.25rem`
 
 </td>
 </tr>
@@ -711,16 +699,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -730,16 +719,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-chip.md
+++ b/packages/bootstrap/docs/customization-chip.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-chip-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.25`
 
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -169,26 +162,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        padding-x: $kendo-chip-padding-x-sm,
-        padding-y: $kendo-chip-padding-y-sm,
-        font-size: $kendo-chip-font-size-sm,
-        line-height: $kendo-chip-line-height-sm
-    ),
-    md: (
-        padding-x: $kendo-chip-padding-x-md,
-        padding-y: $kendo-chip-padding-y-md,
-        font-size: $kendo-chip-font-size-md,
-        line-height: $kendo-chip-line-height-md
-    ),
-    lg: (
-        padding-x: $kendo-chip-padding-x-lg,
-        padding-y: $kendo-chip-padding-y-lg,
-        font-size: $kendo-chip-font-size-lg,
-        line-height: $kendo-chip-line-height-lg
-    )
-)`
+`(sm: (padding-x: 0.25rem, padding-y: 0.125rem, font-size: 1rem, line-height: 1.25), md: (padding-x: 0.25rem, padding-y: 0.25rem, font-size: 1rem, line-height: 1.25), lg: (padding-x: 0.25rem, padding-y: 0.375rem, font-size: 1rem, line-height: 1.25))`
 
 </td>
 </tr>
@@ -198,16 +172,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -217,9 +192,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     "base": $kendo-chip-base-bg,
@@ -232,13 +206,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    "base": $kendo-chip-base-bg,
-    "error": map-get( $kendo-theme-colors, "error" ),
-    "info": map-get( $kendo-theme-colors, "info" ),
-    "warning": map-get( $kendo-theme-colors, "warning" ),
-    "success": map-get( $kendo-theme-colors, "success" )
-)`
+`("base": #212529, "error": #dc3545, "info": #0dcaf0, "warning": #ffc107, "success": #198754)`
 
 </td>
 </tr>
@@ -248,16 +216,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #edeeee"></span>
+
+`#edeeee`
 
 </td>
 </tr>
@@ -267,16 +236,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -286,16 +256,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 70% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 70% )`
+<span class="color-preview" style="background-color: #bcbebf"></span>
+
+`#bcbebf`
 
 </td>
 </tr>
@@ -305,16 +276,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(33, 37, 41, 0.16)`
 
 </td>
 </tr>
@@ -324,16 +294,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #edeeee"></span>
+
+`#edeeee`
 
 </td>
 </tr>
@@ -343,9 +314,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -362,16 +332,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 84% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 84% )`
+<span class="color-preview" style="background-color: #dbdcdd"></span>
+
+`#dbdcdd`
 
 </td>
 </tr>
@@ -381,9 +352,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -400,16 +370,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 76% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 76% )`
+<span class="color-preview" style="background-color: #cacbcc"></span>
+
+`#cacbcc`
 
 </td>
 </tr>
@@ -419,9 +390,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -438,16 +408,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -457,16 +428,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -476,16 +448,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -495,16 +468,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(33, 37, 41, 0.16)`
 
 </td>
 </tr>
@@ -514,16 +486,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -533,16 +506,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-chip-base-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -552,16 +526,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -571,16 +546,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -590,9 +566,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-list-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 1 ),
@@ -603,11 +578,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 1 ),
-    md: map-get( $spacing, 1 ),
-    lg: map-get( $spacing, 1 )
-)`
+`(sm: 0.25rem, md: 0.25rem, lg: 0.25rem)`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-color-system.md
+++ b/packages/bootstrap/docs/customization-color-system.md
@@ -30,13 +30,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `$primary`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -49,13 +50,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $accent )`
 
 </td>
 <td>
 
-`contrast-wcag( $accent )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -68,13 +70,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `$primary`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -87,13 +90,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $primary )`
 
 </td>
 <td>
 
-`contrast-wcag( $primary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -106,13 +110,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `$secondary`
 
 </td>
 <td>
 
-`$secondary`
+<span class="color-preview" style="background-color: #6c757d"></span>
+
+`#6c757d`
 
 </td>
 </tr>
@@ -125,13 +130,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $secondary )`
 
 </td>
 <td>
 
-`contrast-wcag( $secondary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -144,13 +150,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `$purple`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #6f42c1"></span>
 
+`#6f42c1`
 
 </td>
 </tr>
@@ -163,13 +170,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $tertiary )`
 
 </td>
 <td>
 
-`contrast-wcag( $tertiary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -182,13 +190,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `$info`
 
 </td>
 <td>
 
-`$info`
+<span class="color-preview" style="background-color: #0dcaf0"></span>
+
+`#0dcaf0`
 
 </td>
 </tr>
@@ -201,13 +210,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `$success`
 
 </td>
 <td>
 
-`$success`
+<span class="color-preview" style="background-color: #198754"></span>
+
+`#198754`
 
 </td>
 </tr>
@@ -220,13 +230,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `$warning`
 
 </td>
 <td>
 
-`$warning`
+<span class="color-preview" style="background-color: #ffc107"></span>
+
+`#ffc107`
 
 </td>
 </tr>
@@ -239,13 +250,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `$danger`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -258,13 +270,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `$dark`
 
 </td>
 <td>
 
-`$dark`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -277,13 +290,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `$light`
 
 </td>
 <td>
 
-`$light`
+<span class="color-preview" style="background-color: #f8f9fa"></span>
+
+`#f8f9fa`
 
 </td>
 </tr>
@@ -293,16 +307,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$inverse</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $light, $dark )`
 
 </td>
 <td>
 
-`if( $dark-theme, $light, $dark )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-common.md
+++ b/packages/bootstrap/docs/customization-common.md
@@ -27,16 +27,15 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
 </td>
 <td>
 
-`$border-radius`
+`0.25rem`
 
 </td>
 </tr>
@@ -46,16 +45,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$gray-100`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -65,16 +65,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -84,16 +85,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $base-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #e4e5e6"></span>
+
+`#e4e5e6`
 
 </td>
 </tr>
@@ -103,9 +105,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -122,16 +123,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$gray-200`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #e9ecef"></span>
 
+`#e9ecef`
 
 </td>
 </tr>
@@ -141,16 +143,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -160,16 +163,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $hovered-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $hovered-bg, 1 )`
+<span class="color-preview" style="background-color: #d6d9dc"></span>
+
+`#d6d9dc`
 
 </td>
 </tr>
@@ -179,9 +183,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,16 +201,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -217,16 +221,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -236,16 +241,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $selected-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $selected-bg, 1 )`
+<span class="color-preview" style="background-color: #0c65e9"></span>
+
+`#0c65e9`
 
 </td>
 </tr>
@@ -255,9 +261,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/bootstrap/docs/customization-component.md
+++ b/packages/bootstrap/docs/customization-component.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$component-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$component-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$component-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $component-bg, $gray-300, $gray-700 )`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-floating-action-button.md
+++ b/packages/bootstrap/docs/customization-floating-action-button.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-fab-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius / 2`
 
 </td>
 <td>
 
-`$border-radius / 2`
+`0.125rem`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
 </td>
 <td>
 
-`$font-family-sans-serif`
+`system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
 </td>
 <td>
 
-`$font-size-base`
+`1rem`
 
 </td>
 </tr>
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`$line-height-base`
+`1.5`
 
 </td>
 </tr>
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$padding-x`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -141,16 +135,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-padding-x`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `24px`
 
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-icon-width`
 
@@ -198,16 +189,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 ) / 2`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 ) / 2`
+`0.125rem`
 
 </td>
 </tr>
@@ -217,9 +207,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -236,16 +225,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -255,16 +243,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -274,16 +261,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-text-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -293,9 +279,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -312,9 +297,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `4px`
 
@@ -331,16 +315,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-xs`
 
 </td>
 <td>
 
-
+`0.75rem`
 
 </td>
 </tr>
@@ -350,9 +333,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -369,16 +351,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`0.5rem`
 
 </td>
 </tr>
@@ -388,16 +369,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`0.5rem`
 
 </td>
 </tr>
@@ -407,9 +387,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0`
 
@@ -426,9 +405,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -445,9 +423,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `24px`
 
@@ -464,9 +441,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-width`
 
@@ -483,16 +459,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #0d6efd, "secondary": #6c757d, "tertiary": #6f42c1, "info": #0dcaf0, "success": #198754, "warning": #ffc107, "error": #dc3545, "dark": #212529, "light": #f8f9fa, "inverse": #212529)`
 
 </td>
 </tr>
@@ -502,16 +477,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12), 0px 3px 5px rgba(0, 0, 0, .2)`
 
 </td>
 <td>
 
-`0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12), 0px 3px 5px rgba(0, 0, 0, .2)`
+`0px 6px 10px rgba(0, 0, 0, 0.14), 0px 1px 18px rgba(0, 0, 0, 0.12), 0px 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -521,16 +495,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0px 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0px 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0px 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
 
 </td>
 <td>
 
-`0px 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0px 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0px 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0px 6px 10px rgba(91, 91, 91, 0.1744), 0px 1px 18px rgba(101, 101, 101, 0.1552), 0px 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -540,9 +513,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -559,16 +531,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -578,16 +551,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -597,16 +571,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -616,16 +591,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-button-bg, $gray-900 )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -635,14 +611,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #e4e7eb"></span>
 
 `#e4e7eb`
 
@@ -654,14 +631,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
-<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #e4e7eb"></span>
 
 `#e4e7eb`
 
@@ -673,16 +651,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-shadow`
 
 </td>
 <td>
 
-`0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12), 0px 3px 5px rgba(0, 0, 0, .2)`
+`0px 6px 10px rgba(0, 0, 0, 0.14), 0px 1px 18px rgba(0, 0, 0, 0.12), 0px 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -692,16 +669,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-disabled-shadow`
 
 </td>
 <td>
 
-`0px 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0px 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0px 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0px 6px 10px rgba(91, 91, 91, 0.1744), 0px 1px 18px rgba(101, 101, 101, 0.1552), 0px 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -711,9 +687,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-fab-active-shadow`
 

--- a/packages/bootstrap/docs/customization-grid.md
+++ b/packages/bootstrap/docs/customization-grid.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$grid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -103,16 +107,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -122,16 +127,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -141,16 +147,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$header-gradient`
 
 </td>
 <td>
 
-
+`null`
 
 </td>
 </tr>
@@ -160,16 +165,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -179,16 +185,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -198,16 +205,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -217,16 +225,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( contrast-wcag( $grid-bg ), .04 )`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -236,9 +245,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,9 +263,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -274,16 +281,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( contrast-wcag( $grid-bg ), .08 )`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -293,9 +301,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -312,9 +319,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,16 +337,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( $selected-bg, .25 )`
 
 </td>
 <td>
 
-`rgba( $selected-bg, .25 )`
+<span class="color-preview" style="background-color: rgba(13, 110, 253, 0.25)"></span>
+
+`rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -350,16 +357,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -369,16 +377,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-icons.md
+++ b/packages/bootstrap/docs/customization-icons.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$icon-font-url</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/bootstrap/docs/customization-list.md
+++ b/packages/bootstrap/docs/customization-list.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-list-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 1px`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-font-weight</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `bold`
 
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,9 +189,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -217,9 +207,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -236,9 +225,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,9 +243,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -274,9 +261,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -293,9 +279,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `1px 0 0`
 
@@ -312,9 +297,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +315,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,9 +333,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-weight</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `bold`
 
@@ -369,16 +351,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -388,16 +371,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -407,16 +391,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -426,9 +411,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +429,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,9 +447,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -483,9 +465,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -502,9 +483,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,9 +501,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -540,16 +519,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`$gray-200`
+<span class="color-preview" style="background-color: #e9ecef"></span>
+
+`#e9ecef`
 
 </td>
 </tr>
@@ -559,16 +539,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -578,9 +559,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -597,9 +577,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -616,16 +595,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `inset 0 0 0 3px rgba( $kendo-list-text, .15 )`
 
 </td>
 <td>
 
-`inset 0 0 0 3px rgba( $kendo-list-text, .15 )`
+`inset 0 0 0 3px rgba(33, 37, 41, 0.15)`
 
 </td>
 </tr>
@@ -635,16 +613,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -654,16 +633,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -673,9 +653,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -692,9 +671,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -711,9 +689,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -730,9 +707,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -749,16 +725,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-no-data-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #6c757d"></span>
 
+`#6c757d`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-menu.md
+++ b/packages/bootstrap/docs/customization-menu.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-menu-popup-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$popup-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.5`
 
 </td>
 </tr>
@@ -122,16 +117,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -141,16 +137,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -160,16 +157,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -179,9 +177,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,16 +195,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -217,16 +213,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -236,16 +231,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-end</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
+`calc( 2rem + 16px )`
 
 </td>
 </tr>
@@ -255,16 +249,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-start-sm</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-menu-popup-item-padding-x-sm`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -274,16 +267,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-end-sm</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
 
 </td>
 <td>
 
-`calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
+`calc(-1 * (calc( 2rem + 16px ) - 0.5rem))`
 
 </td>
 </tr>
@@ -293,9 +285,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -312,9 +303,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +321,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,9 +339,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,9 +357,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -388,16 +375,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-bg`
 
 </td>
 <td>
 
-`$gray-200`
+<span class="color-preview" style="background-color: #e9ecef"></span>
+
+`#e9ecef`
 
 </td>
 </tr>
@@ -407,16 +395,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -426,9 +415,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +433,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,16 +451,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -483,16 +471,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -502,9 +491,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,9 +509,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -540,16 +527,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$menu-item-focus-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 3px rgba(33, 37, 41, 0.15)`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-radio.md
+++ b/packages/bootstrap/docs/customization-radio.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-radio-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -65,16 +63,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -84,9 +83,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-text`
 
@@ -103,16 +101,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-bg, $gray-400, $gray-600 )`
+<span class="color-preview" style="background-color: #ced4da"></span>
+
+`#ced4da`
 
 </td>
 </tr>
@@ -122,9 +121,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-bg`
 
@@ -141,9 +139,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-text`
 
@@ -160,9 +157,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-border`
 
@@ -179,16 +175,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -198,16 +195,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -217,16 +215,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -236,16 +235,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-focus-border`
 
 </td>
 <td>
 
-`try-tint( $primary, 50% )`
+<span class="color-preview" style="background-color: #86b7fe"></span>
+
+`#86b7fe`
 
 </td>
 </tr>
@@ -255,16 +255,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-shadow`
 
 </td>
 <td>
 
-`0 0 0 .25rem rgba( $primary, .25 )`
+`0 0 0 0.25rem rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -274,16 +273,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-border`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -293,16 +293,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-shadow`
 
 </td>
 <td>
 
-`0 0 0 .25rem rgba( $primary, .25 )`
+`0 0 0 0.25rem rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -312,9 +311,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-bg`
 
@@ -331,9 +329,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-text`
 
@@ -350,9 +347,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-border`
 
@@ -369,9 +365,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-bg`
 
@@ -388,9 +383,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-text`
 
@@ -407,9 +401,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-border`
 
@@ -426,9 +419,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-invalid-bg`
 
@@ -445,16 +437,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -464,16 +457,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -483,9 +477,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -502,9 +495,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -521,9 +513,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e308"`
 
@@ -540,16 +531,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$kendo-radio-checked-text}'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$kendo-radio-checked-text}'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='2' fill='white'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -559,9 +549,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-image</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -578,16 +567,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -597,16 +585,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -616,9 +603,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -635,16 +621,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`0.25rem`
 
 </td>
 </tr>
@@ -654,16 +639,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-checked-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -673,16 +659,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-switch.md
+++ b/packages/bootstrap/docs/customization-switch.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-switch-font-family</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-track-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-thumb-border-width</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-label-text-transform</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-label-display</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `none`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: ( font-size: null, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: null ),
@@ -135,11 +129,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: ( font-size: null, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: null ),
-    md: ( font-size: null, track-width: 56px, track-height: 30px, thumb-width: 24px, thumb-height: 24px, thumb-offset: 3px, label-offset: null ),
-    lg: ( font-size: null, track-width: 64px, track-height: 34px, thumb-width: 28px, thumb-height: 28px, thumb-offset: 3px, label-offset: null )
-)`
+`(sm: (font-size: null, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: null), md: (font-size: null, track-width: 56px, track-height: 30px, thumb-width: 24px, thumb-height: 24px, thumb-offset: 3px, label-offset: null), lg: (font-size: null, track-width: 64px, track-height: 34px, thumb-width: 28px, thumb-height: 28px, thumb-offset: 3px, label-offset: null))`
 
 </td>
 </tr>
@@ -149,16 +139,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -168,9 +159,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -187,16 +177,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$gray-500`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #adb5bd"></span>
 
+`#adb5bd`
 
 </td>
 </tr>
@@ -206,9 +197,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -225,9 +215,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -244,9 +233,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -263,9 +251,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -282,9 +269,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -301,9 +287,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -320,9 +305,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -339,16 +323,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `mix( $kendo-switch-off-track-bg, $primary )`
 
 </td>
 <td>
 
-`mix( $kendo-switch-off-track-bg, $primary )`
+<span class="color-preview" style="background-color: #86b7fe"></span>
+
+`#86b7fe`
 
 </td>
 </tr>
@@ -358,9 +343,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -377,16 +361,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `.25rem solid rgba( $primary, .25 )`
 
 </td>
 <td>
 
-`.25rem solid rgba( $primary, .25 )`
+`0.25rem solid rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -396,16 +379,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $gray-800, $gray-200 )`
 
 </td>
 <td>
 
-`if( $dark-theme, $gray-800, $gray-200 )`
+<span class="color-preview" style="background-color: #e9ecef"></span>
+
+`#e9ecef`
 
 </td>
 </tr>
@@ -415,9 +399,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -434,9 +417,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -453,9 +435,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -472,16 +453,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$gray-500`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #adb5bd"></span>
 
+`#adb5bd`
 
 </td>
 </tr>
@@ -491,9 +473,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -510,9 +491,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -529,9 +509,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -548,9 +527,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -567,9 +545,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -586,9 +563,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -605,9 +581,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -624,16 +599,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -643,9 +619,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -662,16 +637,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-switch-on-track-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -681,9 +657,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -700,9 +675,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -719,9 +693,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -738,9 +711,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -757,9 +729,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -776,9 +747,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -795,9 +765,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -814,9 +783,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -833,9 +801,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -852,16 +819,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `.25rem solid rgba( $kendo-switch-on-track-border, .25 )`
 
 </td>
 <td>
 
-`.25rem solid rgba( $kendo-switch-on-track-border, .25 )`
+`0.25rem solid rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -871,16 +837,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-switch-on-track-bg, 50% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-switch-on-track-bg, 50% )`
+<span class="color-preview" style="background-color: #86b7fe"></span>
+
+`#86b7fe`
 
 </td>
 </tr>
@@ -890,9 +857,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -909,9 +875,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -928,9 +893,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -947,16 +911,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-switch-on-track-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-switch-on-track-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -966,9 +931,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -985,9 +949,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1004,9 +967,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1023,9 +985,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1042,9 +1003,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1061,9 +1021,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1080,9 +1039,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/bootstrap/docs/customization-table.md
+++ b/packages/bootstrap/docs/customization-table.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-table-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-vertical-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-vertical-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-horizontal-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-horizontal-border-width`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -188,26 +180,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 1rem, line-height: 1.5, cell-padding-x: 0.5rem, cell-padding-y: 0.375rem), md: (font-size: 1rem, line-height: 1.5, cell-padding-x: 0.5rem, cell-padding-y: 0.5rem), lg: (font-size: 1rem, line-height: 1.5, cell-padding-x: 0.5rem, cell-padding-y: 0.625rem))`
 
 </td>
 </tr>
@@ -217,16 +190,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -236,16 +210,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -255,16 +230,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -274,16 +250,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -293,16 +270,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -312,16 +290,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -331,16 +310,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -350,16 +330,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -369,16 +350,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -388,16 +370,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -407,16 +390,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -426,16 +410,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -445,16 +430,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-alt-bg`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -464,9 +450,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-text`
 
@@ -483,9 +468,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-border`
 
@@ -502,16 +486,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-hovered-bg`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -521,9 +506,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-text`
 
@@ -540,9 +524,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-border`
 
@@ -559,9 +542,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -578,9 +560,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -597,9 +578,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -616,16 +596,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$grid-focused-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -635,16 +614,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-bg`
 
 </td>
 <td>
 
-`rgba( $selected-bg, .25 )`
+<span class="color-preview" style="background-color: rgba(13, 110, 253, 0.25)"></span>
+
+`rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -654,16 +634,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -673,16 +654,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-tabstrip.md
+++ b/packages/bootstrap/docs/customization-tabstrip.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$tabstrip-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,16 +45,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -65,16 +65,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -84,16 +85,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-x`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -103,16 +103,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-y`
 
 </td>
 <td>
 
-
+`0.5rem`
 
 </td>
 </tr>
@@ -122,9 +121,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -141,16 +139,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -160,16 +157,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-gap</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-margin`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -179,9 +175,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,16 +193,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0d6efd"></span>
 
+`#0d6efd`
 
 </td>
 </tr>
@@ -217,9 +213,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -236,9 +231,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,9 +249,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -274,16 +267,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0a58ca"></span>
 
+`#0a58ca`
 
 </td>
 </tr>
@@ -293,16 +287,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$gray-200`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #e9ecef"></span>
 
+`#e9ecef`
 
 </td>
 </tr>
@@ -312,9 +307,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,16 +325,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -350,16 +345,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -369,16 +365,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -388,9 +385,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -407,16 +403,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -426,16 +421,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -445,16 +439,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$tabstrip-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -464,16 +457,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -483,16 +477,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -502,16 +497,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -521,16 +517,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border-focused</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-toolbar.md
+++ b/packages/bootstrap/docs/customization-toolbar.md
@@ -27,16 +27,15 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$toolbar-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`0.5rem`
 
 </td>
 </tr>
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$toolbar-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`0.5rem`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-treeview.md
+++ b/packages/bootstrap/docs/customization-treeview.md
@@ -27,16 +27,15 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-treeview-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
 </td>
 <td>
 
-`$font-family-sans-serif`
+`system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`
 
 </td>
 </tr>
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`$line-height-base`
+`1.5`
 
 </td>
 </tr>
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-indent</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `16px`
 
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 3 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 3 )`
+`0.75rem`
 
 </td>
 </tr>
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -160,16 +153,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -207,26 +198,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 3 ),
-        item-padding-y: map-get( $spacing, 1 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 3 ),
-        item-padding-y: map-get( $spacing, 1 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 3 ),
-        item-padding-y: map-get( $spacing, 1 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 1rem, line-height: 1.5, item-padding-x: 0.75rem, item-padding-y: 0.125rem), md: (font-size: 1rem, line-height: 1.5, item-padding-x: 0.75rem, item-padding-y: 0.25rem), lg: (font-size: 1rem, line-height: 1.5, item-padding-x: 0.75rem, item-padding-y: 0.375rem))`
 
 </td>
 </tr>
@@ -236,9 +208,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,16 +226,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -274,9 +246,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -293,16 +264,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`$gray-200`
+<span class="color-preview" style="background-color: #e9ecef"></span>
+
+`#e9ecef`
 
 </td>
 </tr>
@@ -312,16 +284,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -331,16 +304,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-treeview-item-hover-bg`
 
 </td>
 <td>
 
-`$gray-200`
+<span class="color-preview" style="background-color: #e9ecef"></span>
+
+`#e9ecef`
 
 </td>
 </tr>
@@ -350,9 +324,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,16 +342,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -388,16 +362,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -407,16 +382,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-treeview-item-selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -426,9 +402,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,16 +420,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `inset 0 0 0 2px rgba( $kendo-treeview-text, .15 )`
 
 </td>
 <td>
 
-`inset 0 0 0 2px rgba( $kendo-treeview-text, .15 )`
+`inset 0 0 0 2px rgba(33, 37, 41, 0.15)`
 
 </td>
 </tr>
@@ -464,14 +438,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -483,16 +458,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0d6efd"></span>
 
+`#0d6efd`
 
 </td>
 </tr>
@@ -502,9 +478,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,14 +496,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -540,16 +516,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0a58ca"></span>
 
+`#0a58ca`
 
 </td>
 </tr>
@@ -559,9 +536,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -578,14 +554,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -597,16 +574,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0a58ca"></span>
 
+`#0a58ca`
 
 </td>
 </tr>
@@ -616,9 +594,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -635,16 +612,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-treeview-item-focus-shadow`
 
 </td>
 <td>
 
-`inset 0 0 0 2px rgba( $kendo-treeview-text, .15 )`
+`inset 0 0 0 2px rgba(33, 37, 41, 0.15)`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization-typography.md
+++ b/packages/bootstrap/docs/customization-typography.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$enable-typography</td>
-    <td></td>
+    <td>Bool</td>
 <td>
-
 
 `false`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-base`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family-sans-serif`
 
 </td>
 <td>
 
-
+`system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-family-monospace</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family-monospace`
 
 </td>
 <td>
 
-`$font-family-monospace`
+`SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`
 
 </td>
 </tr>
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-base`
 
 </td>
 <td>
 
-
+`1.5`
 
 </td>
 </tr>

--- a/packages/bootstrap/docs/customization.md
+++ b/packages/bootstrap/docs/customization.md
@@ -31,16 +31,15 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
 </td>
 <td>
 
-`$border-radius`
+`0.25rem`
 
 </td>
 </tr>
@@ -50,16 +49,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$gray-100`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -69,16 +69,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$base-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -88,16 +89,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$base-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $base-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #e4e5e6"></span>
+
+`#e4e5e6`
 
 </td>
 </tr>
@@ -107,9 +109,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$base-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -126,16 +127,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$gray-200`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #e9ecef"></span>
 
+`#e9ecef`
 
 </td>
 </tr>
@@ -145,16 +147,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -164,16 +167,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $hovered-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $hovered-bg, 1 )`
+<span class="color-preview" style="background-color: #d6d9dc"></span>
+
+`#d6d9dc`
 
 </td>
 </tr>
@@ -183,9 +187,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -202,16 +205,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -221,16 +225,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -240,16 +245,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $selected-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $selected-bg, 1 )`
+<span class="color-preview" style="background-color: #0c65e9"></span>
+
+`#0c65e9`
 
 </td>
 </tr>
@@ -259,9 +265,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -299,9 +304,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$kendo-avatar-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -318,16 +322,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-avatar-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
 </td>
 <td>
 
-`$font-family-sans-serif`
+`system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`
 
 </td>
 </tr>
@@ -337,16 +340,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-avatar-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
 </td>
 <td>
 
-`$font-size-base`
+`1rem`
 
 </td>
 </tr>
@@ -356,16 +358,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-avatar-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`$line-height-base`
+`1.5`
 
 </td>
 </tr>
@@ -375,9 +376,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-avatar-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 4 ),
@@ -388,11 +388,7 @@ The following table lists the available variables for customizing the Bootstrap 
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 4 ),
-    md: map-get( $spacing, 8 ),
-    lg: map-get( $spacing, 16 )
-)`
+`(sm: 1rem, md: 2rem, lg: 4rem)`
 
 </td>
 </tr>
@@ -402,16 +398,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-avatar-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #0d6efd, "secondary": #6c757d, "tertiary": #6f42c1, "info": #0dcaf0, "success": #198754, "warning": #ffc107, "error": #dc3545, "dark": #212529, "light": #f8f9fa, "inverse": #212529)`
 
 </td>
 </tr>
@@ -442,16 +437,15 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$kendo-button-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$btn-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -461,9 +455,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-border-radius</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -480,16 +473,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$btn-padding-x`
 
 </td>
 <td>
 
-
+`0.75rem`
 
 </td>
 </tr>
@@ -499,16 +491,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$btn-padding-y`
 
 </td>
 <td>
 
-
+`0.375rem`
 
 </td>
 </tr>
@@ -518,16 +509,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
 </td>
 <td>
 
-`$font-family-sans-serif`
+`system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`
 
 </td>
 </tr>
@@ -537,16 +527,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$btn-font-size`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -556,16 +545,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$btn-line-height`
 
 </td>
 <td>
 
-
+`1.5`
 
 </td>
 </tr>
@@ -575,16 +563,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
+`calc( 1.5em + 0.75rem + 2px )`
 
 </td>
 </tr>
@@ -594,16 +581,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-inner-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
+`calc( 1.5em + 0.75rem )`
 
 </td>
 </tr>
@@ -613,9 +599,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `map-merge(
     $kendo-theme-colors,
@@ -625,10 +610,7 @@ The following table lists the available variables for customizing the Bootstrap 
 </td>
 <td>
 
-`map-merge(
-    $kendo-theme-colors,
-    ( "base": #e4e7eb )
-)`
+`("primary": #0d6efd, "secondary": #6c757d, "tertiary": #6f42c1, "info": #0dcaf0, "success": #198754, "warning": #ffc107, "error": #dc3545, "dark": #212529, "light": #f8f9fa, "inverse": #212529, "base": #e4e7eb)`
 
 </td>
 </tr>
@@ -638,14 +620,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #e4e7eb"></span>
 
 `#e4e7eb`
 
 </td>
-<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #e4e7eb"></span>
 
 `#e4e7eb`
 
@@ -657,16 +642,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-button-bg, $gray-900 )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-button-bg, $gray-900 )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -676,14 +662,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #e4e7eb"></span>
 
 `#e4e7eb`
 
@@ -695,9 +682,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -714,9 +700,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -733,16 +718,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $kendo-button-bg, 7.5% )`
 
 </td>
 <td>
 
-`try-darken( $kendo-button-bg, 7.5% )`
+<span class="color-preview" style="background-color: #ced3db"></span>
+
+`#ced3db`
 
 </td>
 </tr>
@@ -752,9 +738,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -771,16 +756,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $kendo-button-bg, 10% )`
 
 </td>
 <td>
 
-`try-darken( $kendo-button-bg, 10% )`
+<span class="color-preview" style="background-color: #c7cdd5"></span>
+
+`#c7cdd5`
 
 </td>
 </tr>
@@ -790,9 +776,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -809,9 +794,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-hover-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -828,16 +812,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-active-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $kendo-button-bg, 10% )`
 
 </td>
 <td>
 
-`try-darken( $kendo-button-bg, 10% )`
+<span class="color-preview" style="background-color: #c7cdd5"></span>
+
+`#c7cdd5`
 
 </td>
 </tr>
@@ -847,9 +832,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-active-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -866,16 +850,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-active-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $kendo-button-bg, 12.5% )`
 
 </td>
 <td>
 
-`try-darken( $kendo-button-bg, 12.5% )`
+<span class="color-preview" style="background-color: #bfc6d0"></span>
+
+`#bfc6d0`
 
 </td>
 </tr>
@@ -885,9 +870,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-active-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -904,9 +888,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -923,16 +906,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $primary, 10% )`
 
 </td>
 <td>
 
-`try-darken( $primary, 10% )`
+<span class="color-preview" style="background-color: #0257d5"></span>
+
+`#0257d5`
 
 </td>
 </tr>
@@ -942,16 +926,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-button-selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-button-selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -961,16 +946,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-darken( $primary, 12.5% )`
 
 </td>
 <td>
 
-`try-darken( $primary, 12.5% )`
+<span class="color-preview" style="background-color: #0252c9"></span>
+
+`#0252c9`
 
 </td>
 </tr>
@@ -980,9 +966,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-gradient`
 
@@ -999,9 +984,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-selected-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-shadow`
 
@@ -1018,9 +1002,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1037,9 +1020,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1056,9 +1038,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1075,9 +1056,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1094,16 +1074,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 .25rem rgba( $kendo-button-border, .5 )`
 
 </td>
 <td>
 
-`0 0 0 .25rem rgba( $kendo-button-border, .5 )`
+`0 0 0 0.25rem rgba(228, 231, 235, 0.5)`
 
 </td>
 </tr>
@@ -1113,9 +1092,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1132,9 +1110,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1151,9 +1128,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1170,9 +1146,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1189,9 +1164,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-disabled-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1208,16 +1182,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-flat-button-hover-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.08`
 
 </td>
 <td>
 
-`.08`
+`0.08`
 
 </td>
 </tr>
@@ -1227,9 +1200,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-flat-button-focus-opacity</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1246,16 +1218,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-flat-button-active-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.16`
 
 </td>
 <td>
 
-`.16`
+`0.16`
 
 </td>
 </tr>
@@ -1265,16 +1236,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-flat-button-selected-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.2`
 
 </td>
 <td>
 
-`.2`
+`0.2`
 
 </td>
 </tr>
@@ -1284,16 +1254,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-button-transition</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$transition`
 
 </td>
 <td>
 
-
+`color 0.2s ease-in-out, background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out`
 
 </td>
 </tr>
@@ -1324,16 +1293,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$series-a</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$blue`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0d6efd"></span>
 
+`#0d6efd`
 
 </td>
 </tr>
@@ -1343,16 +1313,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$series-b</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$purple`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #6f42c1"></span>
 
+`#6f42c1`
 
 </td>
 </tr>
@@ -1362,16 +1333,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$series-c</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$teal`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #20c997"></span>
 
+`#20c997`
 
 </td>
 </tr>
@@ -1381,16 +1353,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$series-d</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$green`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #198754"></span>
 
+`#198754`
 
 </td>
 </tr>
@@ -1400,16 +1373,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$series-e</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$yellow`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffc107"></span>
 
+`#ffc107`
 
 </td>
 </tr>
@@ -1419,16 +1393,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$series-f</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$red`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -1438,16 +1413,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$series-1</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$series-a`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0d6efd"></span>
 
+`#0d6efd`
 
 </td>
 </tr>
@@ -1457,16 +1433,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$chart-major-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .08 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1476,16 +1453,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$chart-minor-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .04 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -1516,9 +1494,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$kendo-checkbox-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -1535,16 +1512,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -1554,9 +1532,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1573,16 +1550,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-bg, $gray-400, $gray-600 )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-bg, $gray-400, $gray-600 )`
+<span class="color-preview" style="background-color: #ced4da"></span>
+
+`#ced4da`
 
 </td>
 </tr>
@@ -1592,9 +1570,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1611,9 +1588,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1630,9 +1606,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1649,16 +1624,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -1668,16 +1644,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-checked-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -1687,16 +1664,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -1706,16 +1684,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -1725,16 +1704,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -1744,16 +1724,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -1763,16 +1744,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $primary, 50% )`
 
 </td>
 <td>
 
-`try-tint( $primary, 50% )`
+<span class="color-preview" style="background-color: #86b7fe"></span>
+
+`#86b7fe`
 
 </td>
 </tr>
@@ -1782,16 +1764,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 .25rem rgba( $primary, .25 )`
 
 </td>
 <td>
 
-`0 0 0 .25rem rgba( $primary, .25 )`
+`0 0 0 0.25rem rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -1801,16 +1782,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -1820,16 +1802,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-shadow`
 
 </td>
 <td>
 
-`0 0 0 .25rem rgba( $primary, .25 )`
+`0 0 0 0.25rem rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -1839,9 +1820,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1858,9 +1838,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1877,9 +1856,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1896,9 +1874,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1915,9 +1892,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1934,9 +1910,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1953,9 +1928,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1972,16 +1946,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -1991,16 +1966,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -2010,9 +1986,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -2029,9 +2004,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -2048,9 +2022,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e118"`
 
@@ -2067,9 +2040,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e121"`
 
@@ -2086,16 +2058,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -2105,16 +2076,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -2124,16 +2094,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -2143,16 +2112,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -2162,9 +2130,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -2181,16 +2148,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`0.25rem`
 
 </td>
 </tr>
@@ -2200,16 +2166,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -2219,16 +2186,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>
@@ -2259,9 +2225,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$kendo-chip-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -2278,16 +2243,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -2297,16 +2261,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -2316,16 +2279,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -2335,16 +2297,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -2354,9 +2315,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.25`
 
@@ -2373,9 +2333,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -2401,26 +2360,7 @@ The following table lists the available variables for customizing the Bootstrap 
 </td>
 <td>
 
-`(
-    sm: (
-        padding-x: $kendo-chip-padding-x-sm,
-        padding-y: $kendo-chip-padding-y-sm,
-        font-size: $kendo-chip-font-size-sm,
-        line-height: $kendo-chip-line-height-sm
-    ),
-    md: (
-        padding-x: $kendo-chip-padding-x-md,
-        padding-y: $kendo-chip-padding-y-md,
-        font-size: $kendo-chip-font-size-md,
-        line-height: $kendo-chip-line-height-md
-    ),
-    lg: (
-        padding-x: $kendo-chip-padding-x-lg,
-        padding-y: $kendo-chip-padding-y-lg,
-        font-size: $kendo-chip-font-size-lg,
-        line-height: $kendo-chip-line-height-lg
-    )
-)`
+`(sm: (padding-x: 0.25rem, padding-y: 0.125rem, font-size: 1rem, line-height: 1.25), md: (padding-x: 0.25rem, padding-y: 0.25rem, font-size: 1rem, line-height: 1.25), lg: (padding-x: 0.25rem, padding-y: 0.375rem, font-size: 1rem, line-height: 1.25))`
 
 </td>
 </tr>
@@ -2430,16 +2370,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -2449,9 +2390,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     "base": $kendo-chip-base-bg,
@@ -2464,13 +2404,7 @@ The following table lists the available variables for customizing the Bootstrap 
 </td>
 <td>
 
-`(
-    "base": $kendo-chip-base-bg,
-    "error": map-get( $kendo-theme-colors, "error" ),
-    "info": map-get( $kendo-theme-colors, "info" ),
-    "warning": map-get( $kendo-theme-colors, "warning" ),
-    "success": map-get( $kendo-theme-colors, "success" )
-)`
+`("base": #212529, "error": #dc3545, "info": #0dcaf0, "warning": #ffc107, "success": #198754)`
 
 </td>
 </tr>
@@ -2480,16 +2414,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-solid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #edeeee"></span>
+
+`#edeeee`
 
 </td>
 </tr>
@@ -2499,16 +2434,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-solid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -2518,16 +2454,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-solid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 70% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 70% )`
+<span class="color-preview" style="background-color: #bcbebf"></span>
+
+`#bcbebf`
 
 </td>
 </tr>
@@ -2537,16 +2474,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-solid-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(33, 37, 41, 0.16)`
 
 </td>
 </tr>
@@ -2556,16 +2492,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #edeeee"></span>
+
+`#edeeee`
 
 </td>
 </tr>
@@ -2575,9 +2512,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2594,16 +2530,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 84% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 84% )`
+<span class="color-preview" style="background-color: #dbdcdd"></span>
+
+`#dbdcdd`
 
 </td>
 </tr>
@@ -2613,9 +2550,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2632,16 +2568,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 76% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 76% )`
+<span class="color-preview" style="background-color: #cacbcc"></span>
+
+`#cacbcc`
 
 </td>
 </tr>
@@ -2651,9 +2588,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2670,16 +2606,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-outline-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -2689,16 +2626,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-outline-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -2708,16 +2646,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-outline-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -2727,16 +2666,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-outline-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(33, 37, 41, 0.16)`
 
 </td>
 </tr>
@@ -2746,16 +2684,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -2765,16 +2704,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-chip-base-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2784,16 +2724,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -2803,16 +2744,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2822,9 +2764,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-chip-list-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 1 ),
@@ -2835,11 +2776,7 @@ The following table lists the available variables for customizing the Bootstrap 
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 1 ),
-    md: map-get( $spacing, 1 ),
-    lg: map-get( $spacing, 1 )
-)`
+`(sm: 0.25rem, md: 0.25rem, lg: 0.25rem)`
 
 </td>
 </tr>
@@ -2873,13 +2810,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `$primary`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -2892,13 +2830,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $accent )`
 
 </td>
 <td>
 
-`contrast-wcag( $accent )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2911,13 +2850,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `$primary`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -2930,13 +2870,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $primary )`
 
 </td>
 <td>
 
-`contrast-wcag( $primary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2949,13 +2890,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `$secondary`
 
 </td>
 <td>
 
-`$secondary`
+<span class="color-preview" style="background-color: #6c757d"></span>
+
+`#6c757d`
 
 </td>
 </tr>
@@ -2968,13 +2910,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $secondary )`
 
 </td>
 <td>
 
-`contrast-wcag( $secondary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2987,13 +2930,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `$purple`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #6f42c1"></span>
 
+`#6f42c1`
 
 </td>
 </tr>
@@ -3006,13 +2950,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $tertiary )`
 
 </td>
 <td>
 
-`contrast-wcag( $tertiary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -3025,13 +2970,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `$info`
 
 </td>
 <td>
 
-`$info`
+<span class="color-preview" style="background-color: #0dcaf0"></span>
+
+`#0dcaf0`
 
 </td>
 </tr>
@@ -3044,13 +2990,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `$success`
 
 </td>
 <td>
 
-`$success`
+<span class="color-preview" style="background-color: #198754"></span>
+
+`#198754`
 
 </td>
 </tr>
@@ -3063,13 +3010,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `$warning`
 
 </td>
 <td>
 
-`$warning`
+<span class="color-preview" style="background-color: #ffc107"></span>
+
+`#ffc107`
 
 </td>
 </tr>
@@ -3082,13 +3030,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `$danger`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -3101,13 +3050,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `$dark`
 
 </td>
 <td>
 
-`$dark`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -3120,13 +3070,14 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>Color</td>
 <td>
 
-
 `$light`
 
 </td>
 <td>
 
-`$light`
+<span class="color-preview" style="background-color: #f8f9fa"></span>
+
+`#f8f9fa`
 
 </td>
 </tr>
@@ -3136,16 +3087,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$inverse</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $light, $dark )`
 
 </td>
 <td>
 
-`if( $dark-theme, $light, $dark )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -3176,16 +3128,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$component-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -3195,16 +3148,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$component-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -3214,16 +3168,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$component-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $component-bg, $gray-300, $gray-700 )`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -3254,9 +3209,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$kendo-fab-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -3273,16 +3227,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius / 2`
 
 </td>
 <td>
 
-`$border-radius / 2`
+`0.125rem`
 
 </td>
 </tr>
@@ -3292,16 +3245,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
 </td>
 <td>
 
-`$font-family-sans-serif`
+`system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`
 
 </td>
 </tr>
@@ -3311,16 +3263,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
 </td>
 <td>
 
-`$font-size-base`
+`1rem`
 
 </td>
 </tr>
@@ -3330,16 +3281,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`$line-height-base`
+`1.5`
 
 </td>
 </tr>
@@ -3349,16 +3299,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$padding-x`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -3368,16 +3317,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-padding-x`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -3387,9 +3335,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `24px`
 
@@ -3406,9 +3353,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-icon-width`
 
@@ -3425,16 +3371,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-icon-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 ) / 2`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 ) / 2`
+`0.125rem`
 
 </td>
 </tr>
@@ -3444,9 +3389,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -3463,16 +3407,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -3482,16 +3425,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -3501,16 +3443,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-text-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -3520,9 +3461,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -3539,9 +3479,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `4px`
 
@@ -3558,16 +3497,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-text-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-xs`
 
 </td>
 <td>
 
-
+`0.75rem`
 
 </td>
 </tr>
@@ -3577,9 +3515,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-text-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -3596,16 +3533,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`0.5rem`
 
 </td>
 </tr>
@@ -3615,16 +3551,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`0.5rem`
 
 </td>
 </tr>
@@ -3634,9 +3569,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0`
 
@@ -3653,9 +3587,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -3672,9 +3605,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `24px`
 
@@ -3691,9 +3623,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-width`
 
@@ -3710,16 +3641,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #0d6efd, "secondary": #6c757d, "tertiary": #6f42c1, "info": #0dcaf0, "success": #198754, "warning": #ffc107, "error": #dc3545, "dark": #212529, "light": #f8f9fa, "inverse": #212529)`
 
 </td>
 </tr>
@@ -3729,16 +3659,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12), 0px 3px 5px rgba(0, 0, 0, .2)`
 
 </td>
 <td>
 
-`0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12), 0px 3px 5px rgba(0, 0, 0, .2)`
+`0px 6px 10px rgba(0, 0, 0, 0.14), 0px 1px 18px rgba(0, 0, 0, 0.12), 0px 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -3748,16 +3677,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0px 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0px 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0px 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
 
 </td>
 <td>
 
-`0px 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0px 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0px 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0px 6px 10px rgba(91, 91, 91, 0.1744), 0px 1px 18px rgba(101, 101, 101, 0.1552), 0px 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -3767,9 +3695,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -3786,16 +3713,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -3805,16 +3733,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -3824,16 +3753,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -3843,16 +3773,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-button-bg, $gray-900 )`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -3862,14 +3793,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #e4e7eb"></span>
 
 `#e4e7eb`
 
@@ -3881,14 +3813,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
-<td><span class="color-preview" style="background-color: #e4e7eb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #e4e7eb"></span>
 
 `#e4e7eb`
 
@@ -3900,16 +3833,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-shadow`
 
 </td>
 <td>
 
-`0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12), 0px 3px 5px rgba(0, 0, 0, .2)`
+`0px 6px 10px rgba(0, 0, 0, 0.14), 0px 1px 18px rgba(0, 0, 0, 0.12), 0px 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -3919,16 +3851,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-disabled-shadow`
 
 </td>
 <td>
 
-`0px 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0px 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0px 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0px 6px 10px rgba(91, 91, 91, 0.1744), 0px 1px 18px rgba(101, 101, 101, 0.1552), 0px 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -3938,9 +3869,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-fab-item-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-fab-active-shadow`
 
@@ -3978,16 +3908,17 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$grid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -3997,16 +3928,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -4016,16 +3948,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -4035,16 +3968,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -4054,16 +3988,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -4073,16 +4008,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -4092,16 +4028,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-header-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$header-gradient`
 
 </td>
 <td>
 
-
+`null`
 
 </td>
 </tr>
@@ -4111,16 +4046,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -4130,16 +4066,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -4149,16 +4086,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -4168,16 +4106,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-alt-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( contrast-wcag( $grid-bg ), .04 )`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -4187,9 +4126,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-alt-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4206,9 +4144,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-alt-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4225,16 +4162,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( contrast-wcag( $grid-bg ), .08 )`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -4244,9 +4182,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-hovered-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4263,9 +4200,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-hovered-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4282,16 +4218,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( $selected-bg, .25 )`
 
 </td>
 <td>
 
-`rgba( $selected-bg, .25 )`
+<span class="color-preview" style="background-color: rgba(13, 110, 253, 0.25)"></span>
+
+`rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -4301,16 +4238,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -4320,16 +4258,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$grid-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -4360,9 +4299,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$icon-font-url</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4400,9 +4338,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$kendo-list-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4419,9 +4356,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4438,9 +4374,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-header-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4457,9 +4392,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-header-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4476,9 +4410,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-header-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 1px`
 
@@ -4495,9 +4428,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-header-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4514,9 +4446,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-header-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4533,9 +4464,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-header-font-weight</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `bold`
 
@@ -4552,9 +4482,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4571,9 +4500,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4590,9 +4518,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4609,9 +4536,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4628,9 +4554,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4647,9 +4572,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4666,9 +4590,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-group-item-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `1px 0 0`
 
@@ -4685,9 +4608,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4704,9 +4626,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-group-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4723,9 +4644,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-weight</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `bold`
 
@@ -4742,16 +4662,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -4761,16 +4682,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -4780,16 +4702,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -4799,9 +4722,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-header-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4818,9 +4740,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-header-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4837,9 +4758,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-header-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -4856,9 +4776,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-header-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4875,9 +4794,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4894,9 +4812,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4913,16 +4830,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`$gray-200`
+<span class="color-preview" style="background-color: #e9ecef"></span>
+
+`#e9ecef`
 
 </td>
 </tr>
@@ -4932,16 +4850,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -4951,9 +4870,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4970,9 +4888,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4989,16 +4906,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `inset 0 0 0 3px rgba( $kendo-list-text, .15 )`
 
 </td>
 <td>
 
-`inset 0 0 0 3px rgba( $kendo-list-text, .15 )`
+`inset 0 0 0 3px rgba(33, 37, 41, 0.15)`
 
 </td>
 </tr>
@@ -5008,16 +4924,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -5027,16 +4944,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -5046,9 +4964,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-group-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5065,9 +4982,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-group-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5084,9 +5000,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-group-item-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -5103,9 +5018,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-group-item-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5122,16 +5036,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-list-no-data-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #6c757d"></span>
 
+`#6c757d`
 
 </td>
 </tr>
@@ -5162,9 +5077,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$kendo-menu-popup-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5181,9 +5095,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5200,16 +5113,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$popup-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -5219,16 +5131,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -5238,16 +5149,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.5`
 
 </td>
 </tr>
@@ -5257,16 +5167,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -5276,16 +5187,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -5295,16 +5207,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -5314,9 +5227,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5333,16 +5245,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -5352,16 +5263,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -5371,16 +5281,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-end</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
+`calc( 2rem + 16px )`
 
 </td>
 </tr>
@@ -5390,16 +5299,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-start-sm</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-menu-popup-item-padding-x-sm`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -5409,16 +5317,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-end-sm</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
 
 </td>
 <td>
 
-`calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
+`calc(-1 * (calc( 2rem + 16px ) - 0.5rem))`
 
 </td>
 </tr>
@@ -5428,9 +5335,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -5447,9 +5353,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5466,9 +5371,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5485,9 +5389,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5504,9 +5407,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5523,16 +5425,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-bg`
 
 </td>
 <td>
 
-`$gray-200`
+<span class="color-preview" style="background-color: #e9ecef"></span>
+
+`#e9ecef`
 
 </td>
 </tr>
@@ -5542,16 +5445,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -5561,9 +5465,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5580,9 +5483,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5599,16 +5501,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -5618,16 +5521,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -5637,9 +5541,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5656,9 +5559,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5675,16 +5577,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$menu-item-focus-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 3px rgba(33, 37, 41, 0.15)`
 
 </td>
 </tr>
@@ -5715,9 +5616,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$kendo-radio-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -5734,9 +5634,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -5753,16 +5652,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -5772,9 +5672,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-text`
 
@@ -5791,16 +5690,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-bg, $gray-400, $gray-600 )`
+<span class="color-preview" style="background-color: #ced4da"></span>
+
+`#ced4da`
 
 </td>
 </tr>
@@ -5810,9 +5710,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-bg`
 
@@ -5829,9 +5728,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-text`
 
@@ -5848,9 +5746,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-border`
 
@@ -5867,16 +5764,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -5886,16 +5784,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -5905,16 +5804,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -5924,16 +5824,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-focus-border`
 
 </td>
 <td>
 
-`try-tint( $primary, 50% )`
+<span class="color-preview" style="background-color: #86b7fe"></span>
+
+`#86b7fe`
 
 </td>
 </tr>
@@ -5943,16 +5844,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-shadow`
 
 </td>
 <td>
 
-`0 0 0 .25rem rgba( $primary, .25 )`
+`0 0 0 0.25rem rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -5962,16 +5862,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-border`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -5981,16 +5882,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-shadow`
 
 </td>
 <td>
 
-`0 0 0 .25rem rgba( $primary, .25 )`
+`0 0 0 0.25rem rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -6000,9 +5900,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-bg`
 
@@ -6019,9 +5918,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-text`
 
@@ -6038,9 +5936,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-border`
 
@@ -6057,9 +5954,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-bg`
 
@@ -6076,9 +5972,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-text`
 
@@ -6095,9 +5990,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-border`
 
@@ -6114,9 +6008,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-invalid-bg`
 
@@ -6133,16 +6026,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -6152,16 +6046,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dc3545"></span>
 
+`#dc3545`
 
 </td>
 </tr>
@@ -6171,9 +6066,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -6190,9 +6084,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -6209,9 +6102,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e308"`
 
@@ -6228,16 +6120,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$kendo-radio-checked-text}'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$kendo-radio-checked-text}'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='2' fill='white'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -6247,9 +6138,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-image</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6266,16 +6156,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -6285,16 +6174,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -6304,9 +6192,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -6323,16 +6210,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`0.25rem`
 
 </td>
 </tr>
@@ -6342,16 +6228,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-checked-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -6361,16 +6248,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-radio-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>
@@ -6401,9 +6287,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$kendo-switch-font-family</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6420,9 +6305,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-track-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -6439,9 +6323,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-thumb-border-width</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6458,9 +6341,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-label-text-transform</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6477,9 +6359,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-label-display</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `none`
 
@@ -6496,9 +6377,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: ( font-size: null, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: null ),
@@ -6509,11 +6389,7 @@ The following table lists the available variables for customizing the Bootstrap 
 </td>
 <td>
 
-`(
-    sm: ( font-size: null, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: null ),
-    md: ( font-size: null, track-width: 56px, track-height: 30px, thumb-width: 24px, thumb-height: 24px, thumb-offset: 3px, label-offset: null ),
-    lg: ( font-size: null, track-width: 64px, track-height: 34px, thumb-width: 28px, thumb-height: 28px, thumb-offset: 3px, label-offset: null )
-)`
+`(sm: (font-size: null, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: null), md: (font-size: null, track-width: 56px, track-height: 30px, thumb-width: 24px, thumb-height: 24px, thumb-offset: 3px, label-offset: null), lg: (font-size: null, track-width: 64px, track-height: 34px, thumb-width: 28px, thumb-height: 28px, thumb-offset: 3px, label-offset: null))`
 
 </td>
 </tr>
@@ -6523,16 +6399,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -6542,9 +6419,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6561,16 +6437,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$gray-500`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #adb5bd"></span>
 
+`#adb5bd`
 
 </td>
 </tr>
@@ -6580,9 +6457,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6599,9 +6475,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6618,9 +6493,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6637,9 +6511,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6656,9 +6529,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6675,9 +6547,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6694,9 +6565,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6713,16 +6583,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `mix( $kendo-switch-off-track-bg, $primary )`
 
 </td>
 <td>
 
-`mix( $kendo-switch-off-track-bg, $primary )`
+<span class="color-preview" style="background-color: #86b7fe"></span>
+
+`#86b7fe`
 
 </td>
 </tr>
@@ -6732,9 +6603,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6751,16 +6621,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `.25rem solid rgba( $primary, .25 )`
 
 </td>
 <td>
 
-`.25rem solid rgba( $primary, .25 )`
+`0.25rem solid rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -6770,16 +6639,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $gray-800, $gray-200 )`
 
 </td>
 <td>
 
-`if( $dark-theme, $gray-800, $gray-200 )`
+<span class="color-preview" style="background-color: #e9ecef"></span>
+
+`#e9ecef`
 
 </td>
 </tr>
@@ -6789,9 +6659,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6808,9 +6677,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6827,9 +6695,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6846,16 +6713,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$gray-500`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #adb5bd"></span>
 
+`#adb5bd`
 
 </td>
 </tr>
@@ -6865,9 +6733,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6884,9 +6751,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6903,9 +6769,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6922,9 +6787,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6941,9 +6805,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6960,9 +6823,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6979,9 +6841,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6998,16 +6859,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -7017,9 +6879,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7036,16 +6897,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-switch-on-track-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -7055,9 +6917,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7074,9 +6935,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7093,9 +6953,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7112,9 +6971,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7131,9 +6989,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7150,9 +7007,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7169,9 +7025,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7188,9 +7043,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7207,9 +7061,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7226,16 +7079,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `.25rem solid rgba( $kendo-switch-on-track-border, .25 )`
 
 </td>
 <td>
 
-`.25rem solid rgba( $kendo-switch-on-track-border, .25 )`
+`0.25rem solid rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -7245,16 +7097,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-switch-on-track-bg, 50% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-switch-on-track-bg, 50% )`
+<span class="color-preview" style="background-color: #86b7fe"></span>
+
+`#86b7fe`
 
 </td>
 </tr>
@@ -7264,9 +7117,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7283,9 +7135,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7302,9 +7153,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7321,16 +7171,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-switch-on-track-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-switch-on-track-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -7340,9 +7191,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7359,9 +7209,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7378,9 +7227,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7397,9 +7245,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7416,9 +7263,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7435,9 +7281,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7454,9 +7299,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7494,9 +7338,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$kendo-table-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -7513,16 +7356,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-cell-vertical-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-vertical-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -7532,16 +7374,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-cell-horizontal-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-horizontal-border-width`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -7551,9 +7392,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7570,9 +7410,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7589,9 +7428,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7608,9 +7446,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7627,9 +7464,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -7655,26 +7491,7 @@ The following table lists the available variables for customizing the Bootstrap 
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 1rem, line-height: 1.5, cell-padding-x: 0.5rem, cell-padding-y: 0.375rem), md: (font-size: 1rem, line-height: 1.5, cell-padding-x: 0.5rem, cell-padding-y: 0.5rem), lg: (font-size: 1rem, line-height: 1.5, cell-padding-x: 0.5rem, cell-padding-y: 0.625rem))`
 
 </td>
 </tr>
@@ -7684,16 +7501,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -7703,16 +7521,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -7722,16 +7541,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -7741,16 +7561,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -7760,16 +7581,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -7779,16 +7601,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -7798,16 +7621,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -7817,16 +7641,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -7836,16 +7661,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -7855,16 +7681,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-group-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f8f9fa"></span>
 
+`#f8f9fa`
 
 </td>
 </tr>
@@ -7874,16 +7701,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-group-row-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -7893,16 +7721,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-group-row-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #dee2e6"></span>
 
+`#dee2e6`
 
 </td>
 </tr>
@@ -7912,16 +7741,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-alt-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-alt-bg`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -7931,9 +7761,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-alt-row-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-text`
 
@@ -7950,9 +7779,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-alt-row-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-border`
 
@@ -7969,16 +7797,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-hovered-bg`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -7988,9 +7817,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-text`
 
@@ -8007,9 +7835,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-border`
 
@@ -8026,9 +7853,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8045,9 +7871,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8064,9 +7889,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8083,16 +7907,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$grid-focused-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -8102,16 +7925,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-bg`
 
 </td>
 <td>
 
-`rgba( $selected-bg, .25 )`
+<span class="color-preview" style="background-color: rgba(13, 110, 253, 0.25)"></span>
+
+`rgba(13, 110, 253, 0.25)`
 
 </td>
 </tr>
@@ -8121,16 +7945,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -8140,16 +7965,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-table-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -8180,9 +8006,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$tabstrip-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8199,16 +8024,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -8218,16 +8044,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -8237,16 +8064,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-x`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -8256,16 +8082,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-y`
 
 </td>
 <td>
 
-
+`0.5rem`
 
 </td>
 </tr>
@@ -8275,9 +8100,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -8294,16 +8118,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -8313,16 +8136,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-gap</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-margin`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -8332,9 +8154,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8351,16 +8172,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0d6efd"></span>
 
+`#0d6efd`
 
 </td>
 </tr>
@@ -8370,9 +8192,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8389,9 +8210,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8408,9 +8228,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8427,16 +8246,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0a58ca"></span>
 
+`#0a58ca`
 
 </td>
 </tr>
@@ -8446,16 +8266,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$gray-200`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #e9ecef"></span>
 
+`#e9ecef`
 
 </td>
 </tr>
@@ -8465,9 +8286,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8484,16 +8304,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -8503,16 +8324,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -8522,16 +8344,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -8541,9 +8364,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8560,16 +8382,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-content-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -8579,16 +8400,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-content-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`1rem`
 
 </td>
 </tr>
@@ -8598,16 +8418,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-content-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$tabstrip-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -8617,16 +8436,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-content-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -8636,16 +8456,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-content-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -8655,16 +8476,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-content-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`contrast-wcag( $component-bg, $gray-300, $gray-700 )`
+<span class="color-preview" style="background-color: #dee2e6"></span>
+
+`#dee2e6`
 
 </td>
 </tr>
@@ -8674,16 +8496,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$tabstrip-content-border-focused</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -8714,16 +8537,15 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$toolbar-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`0.5rem`
 
 </td>
 </tr>
@@ -8733,16 +8555,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$toolbar-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`0.5rem`
 
 </td>
 </tr>
@@ -8773,16 +8594,15 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$kendo-treeview-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
 </td>
 <td>
 
-`$font-family-sans-serif`
+`system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`
 
 </td>
 </tr>
@@ -8792,16 +8612,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -8811,16 +8630,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`$line-height-base`
+`1.5`
 
 </td>
 </tr>
@@ -8830,9 +8648,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-indent</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `16px`
 
@@ -8849,16 +8666,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 3 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 3 )`
+`0.75rem`
 
 </td>
 </tr>
@@ -8868,16 +8684,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -8887,9 +8702,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -8906,16 +8720,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`0.25rem`
 
 </td>
 </tr>
@@ -8925,9 +8738,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -8953,26 +8765,7 @@ The following table lists the available variables for customizing the Bootstrap 
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 3 ),
-        item-padding-y: map-get( $spacing, 1 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 3 ),
-        item-padding-y: map-get( $spacing, 1 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 3 ),
-        item-padding-y: map-get( $spacing, 1 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 1rem, line-height: 1.5, item-padding-x: 0.75rem, item-padding-y: 0.125rem), md: (font-size: 1rem, line-height: 1.5, item-padding-x: 0.75rem, item-padding-y: 0.25rem), lg: (font-size: 1rem, line-height: 1.5, item-padding-x: 0.75rem, item-padding-y: 0.375rem))`
 
 </td>
 </tr>
@@ -8982,9 +8775,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9001,16 +8793,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #212529"></span>
 
+`#212529`
 
 </td>
 </tr>
@@ -9020,9 +8813,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9039,16 +8831,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`$gray-200`
+<span class="color-preview" style="background-color: #e9ecef"></span>
+
+`#e9ecef`
 
 </td>
 </tr>
@@ -9058,16 +8851,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #212529"></span>
+
+`#212529`
 
 </td>
 </tr>
@@ -9077,16 +8871,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-treeview-item-hover-bg`
 
 </td>
 <td>
 
-`$gray-200`
+<span class="color-preview" style="background-color: #e9ecef"></span>
+
+`#e9ecef`
 
 </td>
 </tr>
@@ -9096,9 +8891,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9115,16 +8909,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -9134,16 +8929,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -9153,16 +8949,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-treeview-item-selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #0d6efd"></span>
+
+`#0d6efd`
 
 </td>
 </tr>
@@ -9172,9 +8969,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9191,16 +8987,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `inset 0 0 0 2px rgba( $kendo-treeview-text, .15 )`
 
 </td>
 <td>
 
-`inset 0 0 0 2px rgba( $kendo-treeview-text, .15 )`
+`inset 0 0 0 2px rgba(33, 37, 41, 0.15)`
 
 </td>
 </tr>
@@ -9210,14 +9005,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9229,16 +9025,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0d6efd"></span>
 
+`#0d6efd`
 
 </td>
 </tr>
@@ -9248,9 +9045,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9267,14 +9063,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9286,16 +9083,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0a58ca"></span>
 
+`#0a58ca`
 
 </td>
 </tr>
@@ -9305,9 +9103,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9324,14 +9121,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9343,16 +9141,17 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #0a58ca"></span>
 
+`#0a58ca`
 
 </td>
 </tr>
@@ -9362,9 +9161,8 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9381,16 +9179,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-treeview-item-focus-shadow`
 
 </td>
 <td>
 
-`inset 0 0 0 2px rgba( $kendo-treeview-text, .15 )`
+`inset 0 0 0 2px rgba(33, 37, 41, 0.15)`
 
 </td>
 </tr>
@@ -9421,9 +9218,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tbody>
         <tr>
     <td>$enable-typography</td>
-    <td></td>
+    <td>Bool</td>
 <td>
-
 
 `false`
 
@@ -9440,16 +9236,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-base`
 
 </td>
 <td>
 
-
+`1rem`
 
 </td>
 </tr>
@@ -9459,16 +9254,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family-sans-serif`
 
 </td>
 <td>
 
-
+`system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`
 
 </td>
 </tr>
@@ -9478,16 +9272,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$font-family-monospace</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family-monospace`
 
 </td>
 <td>
 
-`$font-family-monospace`
+`SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`
 
 </td>
 </tr>
@@ -9497,16 +9290,15 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td>$line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-base`
 
 </td>
 <td>
 
-
+`1.5`
 
 </td>
 </tr>
@@ -9522,6 +9314,12 @@ The following table lists the available variables for customizing the Bootstrap 
 
 ## Mixins
 
+### `exports`
+Outputs a module once, no matter how many times it is included.
+
+
+#### Parameters
+- name : `String` - The name of the exported module.
 
 
 

--- a/packages/classic/docs/customization-avatar.md
+++ b/packages/classic/docs/customization-avatar.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-avatar-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 4 ),
@@ -116,11 +111,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 4 ),
-    md: map-get( $spacing, 8 ),
-    lg: map-get( $spacing, 16 )
-)`
+`(sm: 16px, md: 32px, lg: 64px)`
 
 </td>
 </tr>
@@ -130,16 +121,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #f35800, "secondary": #e9e9e9, "tertiary": #03a9f4, "info": #2498bc, "success": #3ea44e, "warning": #ff9800, "error": #d92800, "dark": #404040, "light": #ebebeb, "inverse": #404040)`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-button.md
+++ b/packages/classic/docs/customization-button.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-button-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-border-radius</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -141,16 +135,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -160,16 +153,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
+`calc( 1.4285714286em + 8px + 2px )`
 
 </td>
 </tr>
@@ -179,16 +171,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-inner-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
+`calc( 1.4285714286em + 8px )`
 
 </td>
 </tr>
@@ -198,9 +189,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `map-merge(
     $kendo-theme-colors,
@@ -210,10 +200,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`map-merge(
-    $kendo-theme-colors,
-    ( "base": $base-bg )
-)`
+`("primary": #f35800, "secondary": #e9e9e9, "tertiary": #03a9f4, "info": #2498bc, "success": #3ea44e, "warning": #ff9800, "error": #d92800, "dark": #404040, "light": #ebebeb, "inverse": #404040, "base": #f0f0f0)`
 
 </td>
 </tr>
@@ -223,14 +210,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
 `#f0f0f0`
 
@@ -242,16 +230,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`$body-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -261,16 +250,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 2 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -280,16 +270,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -299,9 +288,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -318,16 +306,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -337,9 +326,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -356,16 +344,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 3 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 3 )`
+<span class="color-preview" style="background-color: #b6b6b6"></span>
+
+`#b6b6b6`
 
 </td>
 </tr>
@@ -375,9 +364,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -394,9 +382,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -413,16 +400,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 2 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -432,9 +420,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -451,16 +438,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 4 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 4 )`
+<span class="color-preview" style="background-color: #a3a3a3"></span>
+
+`#a3a3a3`
 
 </td>
 </tr>
@@ -470,9 +458,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -489,9 +476,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -508,14 +494,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -527,16 +514,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-button-selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-button-selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -546,14 +534,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-selected-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -565,9 +554,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-gradient`
 
@@ -584,9 +572,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-shadow`
 
@@ -603,9 +590,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -622,9 +608,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -641,9 +626,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -660,9 +644,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -679,16 +662,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 4px 0 rgba( $kendo-button-border, .75 )`
 
 </td>
 <td>
 
-`0 0 4px 0 rgba( $kendo-button-border, .75 )`
+`0 0 4px 0 rgba(202, 202, 202, 0.75)`
 
 </td>
 </tr>
@@ -698,9 +680,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -717,9 +698,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -736,9 +716,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -755,9 +734,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -774,9 +752,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -793,16 +770,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-hover-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.08`
 
 </td>
 <td>
 
-`.08`
+`0.08`
 
 </td>
 </tr>
@@ -812,16 +788,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-focus-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.12`
 
 </td>
 <td>
 
-`.12`
+`0.12`
 
 </td>
 </tr>
@@ -831,16 +806,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-active-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.16`
 
 </td>
 <td>
 
-`.16`
+`0.16`
 
 </td>
 </tr>
@@ -850,16 +824,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-selected-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.2`
 
 </td>
 <td>
 
-`.2`
+`0.2`
 
 </td>
 </tr>
@@ -869,16 +842,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-transition</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `color .2s ease-in-out`
 
 </td>
 <td>
 
-`color .2s ease-in-out`
+`color 0.2s ease-in-out`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-charts.md
+++ b/packages/classic/docs/customization-charts.md
@@ -27,14 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$series-a</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -46,14 +49,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-b</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ffd246"></span>
 
 `#ffd246`
 
 </td>
-<td><span class="color-preview" style="background-color: #ffd246"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ffd246"></span>
 
 `#ffd246`
 
@@ -65,14 +71,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-c</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #78d237"></span>
 
 `#78d237`
 
 </td>
-<td><span class="color-preview" style="background-color: #78d237"></span>
+<td>
+
+<span class="color-preview" style="background-color: #78d237"></span>
 
 `#78d237`
 
@@ -84,14 +93,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-d</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #28b4c8"></span>
 
 `#28b4c8`
 
 </td>
-<td><span class="color-preview" style="background-color: #28b4c8"></span>
+<td>
+
+<span class="color-preview" style="background-color: #28b4c8"></span>
 
 `#28b4c8`
 
@@ -103,14 +115,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-e</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #2d73f5"></span>
 
 `#2d73f5`
 
 </td>
-<td><span class="color-preview" style="background-color: #2d73f5"></span>
+<td>
+
+<span class="color-preview" style="background-color: #2d73f5"></span>
 
 `#2d73f5`
 
@@ -122,14 +137,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-f</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #aa46be"></span>
 
 `#aa46be`
 
 </td>
-<td><span class="color-preview" style="background-color: #aa46be"></span>
+<td>
+
+<span class="color-preview" style="background-color: #aa46be"></span>
 
 `#aa46be`
 
@@ -141,14 +159,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-1</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$series-a`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -160,16 +179,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$chart-major-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .08 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -179,16 +199,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$chart-minor-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .04 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-checkbox.md
+++ b/packages/classic/docs/customization-checkbox.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-checkbox-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -65,9 +65,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -84,16 +83,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`$base-border`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -103,9 +103,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -122,9 +121,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +139,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,14 +157,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -179,16 +177,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-checked-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -198,14 +197,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -217,16 +217,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -236,14 +237,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -255,16 +257,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`$base-border`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -274,9 +277,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -293,16 +295,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba(0, 0, 0, .06)`
 
 </td>
 <td>
 
-`0 0 0 2px rgba(0, 0, 0, .06)`
+`0 0 0 2px rgba(0, 0, 0, 0.06)`
 
 </td>
 </tr>
@@ -312,9 +313,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,16 +331,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $primary, .3 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $primary, .3 )`
+`0 0 0 2px rgba(243, 88, 0, 0.3)`
 
 </td>
 </tr>
@@ -350,9 +349,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,9 +367,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -388,9 +385,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -407,9 +403,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -426,9 +421,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +439,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,9 +457,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -483,16 +475,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #d92800"></span>
 
+`#d92800`
 
 </td>
 </tr>
@@ -502,16 +495,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(217, 40, 0, 0.5)"></span>
 
+`rgba(217, 40, 0, 0.5)`
 
 </td>
 </tr>
@@ -521,9 +515,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -540,9 +533,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -559,9 +551,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e118"`
 
@@ -578,9 +569,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e121"`
 
@@ -597,16 +587,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='white' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -616,16 +605,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23f35800' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -635,16 +623,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -654,16 +641,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -673,9 +659,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -692,16 +677,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`4px`
 
 </td>
 </tr>
@@ -711,14 +695,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -730,16 +715,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-chip.md
+++ b/packages/classic/docs/customization-chip.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-chip-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1`
 
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -169,26 +162,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        padding-x: $kendo-chip-padding-x-sm,
-        padding-y: $kendo-chip-padding-y-sm,
-        font-size: $kendo-chip-font-size-sm,
-        line-height: $kendo-chip-line-height-sm
-    ),
-    md: (
-        padding-x: $kendo-chip-padding-x-md,
-        padding-y: $kendo-chip-padding-y-md,
-        font-size: $kendo-chip-font-size-md,
-        line-height: $kendo-chip-line-height-md
-    ),
-    lg: (
-        padding-x: $kendo-chip-padding-x-lg,
-        padding-y: $kendo-chip-padding-y-lg,
-        font-size: $kendo-chip-font-size-lg,
-        line-height: $kendo-chip-line-height-lg
-    )
-)`
+`(sm: (padding-x: 4px, padding-y: 2px, font-size: 14px, line-height: 1), md: (padding-x: 4px, padding-y: 4px, font-size: 14px, line-height: 1), lg: (padding-x: 4px, padding-y: 6px, font-size: 14px, line-height: 1))`
 
 </td>
 </tr>
@@ -198,16 +172,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -217,9 +192,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     "base": $kendo-chip-base-bg,
@@ -232,13 +206,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    "base": $kendo-chip-base-bg,
-    "error": map-get( $kendo-theme-colors, "error" ),
-    "info": map-get( $kendo-theme-colors, "info" ),
-    "warning": map-get( $kendo-theme-colors, "warning" ),
-    "success": map-get( $kendo-theme-colors, "success" )
-)`
+`("base": #272727, "error": #d92800, "info": #2498bc, "warning": #ff9800, "success": #3ea44e)`
 
 </td>
 </tr>
@@ -248,16 +216,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #eeeeee"></span>
+
+`#eeeeee`
 
 </td>
 </tr>
@@ -267,16 +236,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -286,16 +256,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 70% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 70% )`
+<span class="color-preview" style="background-color: #bebebe"></span>
+
+`#bebebe`
 
 </td>
 </tr>
@@ -305,16 +276,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(39, 39, 39, 0.16)`
 
 </td>
 </tr>
@@ -324,16 +294,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #eeeeee"></span>
+
+`#eeeeee`
 
 </td>
 </tr>
@@ -343,9 +314,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -362,16 +332,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 84% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 84% )`
+<span class="color-preview" style="background-color: gainsboro"></span>
+
+`gainsboro`
 
 </td>
 </tr>
@@ -381,9 +352,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -400,16 +370,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 76% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 76% )`
+<span class="color-preview" style="background-color: #cbcbcb"></span>
+
+`#cbcbcb`
 
 </td>
 </tr>
@@ -419,9 +390,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -438,16 +408,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -457,16 +428,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -476,16 +448,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -495,16 +468,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(39, 39, 39, 0.16)`
 
 </td>
 </tr>
@@ -514,16 +486,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -533,16 +506,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-chip-base-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -552,16 +526,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -571,16 +546,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -590,9 +566,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-list-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 1 ),
@@ -603,11 +578,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 1 ),
-    md: map-get( $spacing, 1 ),
-    lg: map-get( $spacing, 1 )
-)`
+`(sm: 4px, md: 4px, lg: 4px)`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-color-system.md
+++ b/packages/classic/docs/customization-color-system.md
@@ -29,12 +29,15 @@ The following table lists the available variables for customization.
     <td>$primary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -49,13 +52,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $primary )`
 
 </td>
 <td>
 
-`contrast-wcag( $primary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -67,12 +71,15 @@ The following table lists the available variables for customization.
     <td>$secondary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #e9e9e9"></span>
 
 `#e9e9e9`
 
 </td>
-<td><span class="color-preview" style="background-color: #e9e9e9"></span>
+<td>
+
+<span class="color-preview" style="background-color: #e9e9e9"></span>
 
 `#e9e9e9`
 
@@ -87,13 +94,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $secondary )`
 
 </td>
 <td>
 
-`contrast-wcag( $secondary )`
+<span class="color-preview" style="background-color: black"></span>
+
+`black`
 
 </td>
 </tr>
@@ -105,12 +113,15 @@ The following table lists the available variables for customization.
     <td>$tertiary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
 </td>
-<td><span class="color-preview" style="background-color: #03a9f4"></span>
+<td>
+
+<span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
@@ -125,13 +136,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $tertiary )`
 
 </td>
 <td>
 
-`contrast-wcag( $tertiary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -143,12 +155,15 @@ The following table lists the available variables for customization.
     <td>$info</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #2498bc"></span>
 
 `#2498bc`
 
 </td>
-<td><span class="color-preview" style="background-color: #2498bc"></span>
+<td>
+
+<span class="color-preview" style="background-color: #2498bc"></span>
 
 `#2498bc`
 
@@ -162,12 +177,15 @@ The following table lists the available variables for customization.
     <td>$success</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #3ea44e"></span>
 
 `#3ea44e`
 
 </td>
-<td><span class="color-preview" style="background-color: #3ea44e"></span>
+<td>
+
+<span class="color-preview" style="background-color: #3ea44e"></span>
 
 `#3ea44e`
 
@@ -181,12 +199,15 @@ The following table lists the available variables for customization.
     <td>$warning</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff9800"></span>
 
 `#ff9800`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff9800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff9800"></span>
 
 `#ff9800`
 
@@ -200,12 +221,15 @@ The following table lists the available variables for customization.
     <td>$error</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #d92800"></span>
 
 `#d92800`
 
 </td>
-<td><span class="color-preview" style="background-color: #d92800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #d92800"></span>
 
 `#d92800`
 
@@ -219,12 +243,15 @@ The following table lists the available variables for customization.
     <td>$dark</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #404040"></span>
 
 `#404040`
 
 </td>
-<td><span class="color-preview" style="background-color: #404040"></span>
+<td>
+
+<span class="color-preview" style="background-color: #404040"></span>
 
 `#404040`
 
@@ -238,12 +265,15 @@ The following table lists the available variables for customization.
     <td>$light</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
 </td>
-<td><span class="color-preview" style="background-color: #ebebeb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
@@ -255,16 +285,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$inverse</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $light, $dark )`
 
 </td>
 <td>
 
-`if( $dark-theme, $light, $dark )`
+<span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-common.md
+++ b/packages/classic/docs/customization-common.md
@@ -27,16 +27,15 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -46,14 +45,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f0f0f0"></span>
 
 `#f0f0f0`
 
 </td>
-<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
 `#f0f0f0`
 
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $base-bg, 2 )`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -103,16 +107,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `rgba( white, .1 ), rgba( white, 0 )`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -122,16 +125,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $base-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -141,16 +145,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -160,16 +165,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $hovered-bg, 2 )`
 
 </td>
 <td>
 
-`try-shade( $hovered-bg, 2 )`
+<span class="color-preview" style="background-color: #bababa"></span>
+
+`#bababa`
 
 </td>
 </tr>
@@ -179,16 +185,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -198,14 +203,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -217,16 +223,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -236,16 +243,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $selected-bg, 2 )`
 
 </td>
 <td>
 
-`try-shade( $selected-bg, 2 )`
+<span class="color-preview" style="background-color: #cc4a00"></span>
+
+`#cc4a00`
 
 </td>
 </tr>
@@ -255,16 +263,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-component.md
+++ b/packages/classic/docs/customization-component.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$component-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$component-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$component-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-floating-action-button.md
+++ b/packages/classic/docs/customization-floating-action-button.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-fab-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -141,16 +135,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-icon-width`
 
@@ -198,16 +189,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 ) / 2`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 ) / 2`
+`2px`
 
 </td>
 </tr>
@@ -217,9 +207,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -236,16 +225,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -255,16 +243,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -274,16 +261,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-text-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -293,9 +279,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -312,9 +297,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -331,16 +315,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-xs`
 
 </td>
 <td>
 
-
+`10px`
 
 </td>
 </tr>
@@ -350,9 +333,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.2`
 
@@ -369,16 +351,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -388,16 +369,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -407,9 +387,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0`
 
@@ -426,9 +405,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -445,9 +423,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -464,9 +441,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-width`
 
@@ -483,16 +459,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #f35800, "secondary": #e9e9e9, "tertiary": #03a9f4, "info": #2498bc, "success": #3ea44e, "warning": #ff9800, "error": #d92800, "dark": #404040, "light": #ebebeb, "inverse": #404040)`
 
 </td>
 </tr>
@@ -502,16 +477,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
 
 </td>
 <td>
 
-`0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
+`0 6px 10px rgba(0, 0, 0, 0.14), 0 1px 18px rgba(0, 0, 0, 0.12), 0 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -521,16 +495,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
 
 </td>
 <td>
 
-`0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0 6px 10px rgba(91, 91, 91, 0.1744), 0 1px 18px rgba(101, 101, 101, 0.1552), 0 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -540,9 +513,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -559,16 +531,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -578,16 +551,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -597,16 +571,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -616,16 +591,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
 <td>
 
-`$body-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -635,14 +611,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
 `#f0f0f0`
 
@@ -654,16 +631,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -673,16 +651,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-shadow`
 
 </td>
 <td>
 
-`0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
+`0 6px 10px rgba(0, 0, 0, 0.14), 0 1px 18px rgba(0, 0, 0, 0.12), 0 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -692,16 +669,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-disabled-shadow`
 
 </td>
 <td>
 
-`0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0 6px 10px rgba(91, 91, 91, 0.1744), 0 1px 18px rgba(101, 101, 101, 0.1552), 0 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -711,9 +687,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-fab-active-shadow`
 

--- a/packages/classic/docs/customization-grid.md
+++ b/packages/classic/docs/customization-grid.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$grid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
+`#f0f0f0`
 
 </td>
 </tr>
@@ -103,16 +107,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -122,16 +127,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -141,16 +147,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$header-gradient`
 
 </td>
 <td>
 
-
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -160,16 +165,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
+`#f0f0f0`
 
 </td>
 </tr>
@@ -179,16 +185,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -198,16 +205,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -217,16 +225,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $grid-bg, .5 )`
 
 </td>
 <td>
 
-`try-shade( $grid-bg, .5 )`
+<span class="color-preview" style="background-color: whitesmoke"></span>
+
+`whitesmoke`
 
 </td>
 </tr>
@@ -236,9 +245,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,9 +263,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -274,16 +281,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $grid-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $grid-bg, 1 )`
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
 
 </td>
 </tr>
@@ -293,9 +301,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -312,9 +319,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,16 +337,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( $selected-bg, .25 )`
 
 </td>
 <td>
 
-`rgba( $selected-bg, .25 )`
+<span class="color-preview" style="background-color: rgba(243, 88, 0, 0.25)"></span>
+
+`rgba(243, 88, 0, 0.25)`
 
 </td>
 </tr>
@@ -350,9 +357,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,9 +375,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/classic/docs/customization-icons.md
+++ b/packages/classic/docs/customization-icons.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$icon-font-url</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/classic/docs/customization-list.md
+++ b/packages/classic/docs/customization-list.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-list-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 1px`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,9 +189,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -217,9 +207,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -236,9 +225,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,9 +243,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -274,9 +261,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -293,9 +279,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `1px 0 0`
 
@@ -312,9 +297,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +315,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,9 +333,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,16 +351,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -388,16 +371,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -407,16 +391,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -426,9 +411,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +429,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,9 +447,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -483,9 +465,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -502,9 +483,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,9 +501,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -540,16 +519,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -559,16 +539,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -578,9 +559,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -597,9 +577,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -616,16 +595,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `inset 0 0 0 2px rgba(0, 0, 0, .12)`
 
 </td>
 <td>
 
-`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+`inset 0 0 0 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -635,16 +613,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
 
 </td>
 </tr>
@@ -654,16 +633,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -673,9 +653,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -692,9 +671,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -711,9 +689,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -730,9 +707,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -749,16 +725,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-no-data-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #646464"></span>
 
+`#646464`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-menu.md
+++ b/packages/classic/docs/customization-menu.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-menu-popup-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$popup-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -122,16 +117,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -141,16 +137,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -160,16 +157,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #cacaca"></span>
 
+`#cacaca`
 
 </td>
 </tr>
@@ -179,9 +177,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,16 +195,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -217,16 +213,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -236,16 +231,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-end</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
+`calc( 16px + 16px )`
 
 </td>
 </tr>
@@ -255,16 +249,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-start-sm</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-menu-popup-item-padding-x-sm`
 
 </td>
 <td>
 
-
+`8px`
 
 </td>
 </tr>
@@ -274,16 +267,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-end-sm</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
 
 </td>
 <td>
 
-`calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
+`calc(-1 * (calc( 16px + 16px ) - 4px))`
 
 </td>
 </tr>
@@ -293,9 +285,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -312,9 +303,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +321,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,9 +339,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,9 +357,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -388,16 +375,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -407,16 +395,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -426,9 +415,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +433,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,16 +451,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
 
 </td>
 </tr>
@@ -483,16 +471,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -502,9 +491,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,9 +509,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -540,16 +527,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$menu-item-focus-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 3px 1px rgba(39, 39, 39, 0.25)`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-radio.md
+++ b/packages/classic/docs/customization-radio.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-radio-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -65,16 +63,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -84,9 +83,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-text`
 
@@ -103,16 +101,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`$base-border`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -122,9 +121,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-bg`
 
@@ -141,9 +139,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-text`
 
@@ -160,9 +157,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-border`
 
@@ -179,14 +175,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -198,16 +195,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -217,14 +215,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -236,9 +235,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-border`
 
@@ -255,16 +253,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-shadow`
 
 </td>
 <td>
 
-`0 0 0 2px rgba(0, 0, 0, .06)`
+`0 0 0 2px rgba(0, 0, 0, 0.06)`
 
 </td>
 </tr>
@@ -274,9 +271,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-border`
 
@@ -293,16 +289,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-shadow`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $primary, .3 )`
+`0 0 0 2px rgba(243, 88, 0, 0.3)`
 
 </td>
 </tr>
@@ -312,9 +307,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-bg`
 
@@ -331,9 +325,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-text`
 
@@ -350,9 +343,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-border`
 
@@ -369,9 +361,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-bg`
 
@@ -388,9 +379,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-text`
 
@@ -407,9 +397,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-border`
 
@@ -426,9 +415,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-invalid-bg`
 
@@ -445,16 +433,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #d92800"></span>
 
+`#d92800`
 
 </td>
 </tr>
@@ -464,16 +453,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(217, 40, 0, 0.5)"></span>
 
+`rgba(217, 40, 0, 0.5)`
 
 </td>
 </tr>
@@ -483,9 +473,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -502,9 +491,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -521,9 +509,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e308"`
 
@@ -540,16 +527,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'%3e%3ccircle cx='50%25' cy='50%25' r='4' fill='white'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -559,9 +545,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-image</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -578,16 +563,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -597,16 +581,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -616,9 +599,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -635,16 +617,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`4px`
 
 </td>
 </tr>
@@ -654,14 +635,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -673,16 +655,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-switch.md
+++ b/packages/classic/docs/customization-switch.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-switch-font-family</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-track-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-thumb-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-label-text-transform</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-label-display</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inline`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: ( font-size: 12px, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: 4px ),
@@ -135,11 +129,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: ( font-size: 12px, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: 4px ),
-    md: ( font-size: 12px, track-width: 56px, track-height: 30px, thumb-width: 24px, thumb-height: 24px, thumb-offset: 3px, label-offset: 6px ),
-    lg: ( font-size: 12px, track-width: 64px, track-height: 34px, thumb-width: 28px, thumb-height: 28px, thumb-offset: 3px, label-offset: 8px )
-)`
+`(sm: (font-size: 12px, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: 4px), md: (font-size: 12px, track-width: 56px, track-height: 30px, thumb-width: 24px, thumb-height: 24px, thumb-offset: 3px, label-offset: 6px), lg: (font-size: 12px, track-width: 64px, track-height: 34px, thumb-width: 28px, thumb-height: 28px, thumb-offset: 3px, label-offset: 8px))`
 
 </td>
 </tr>
@@ -149,16 +139,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -168,16 +159,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -187,16 +179,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -206,9 +199,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -225,9 +217,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -244,9 +235,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -263,9 +253,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -282,9 +271,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -301,9 +289,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -320,9 +307,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -339,9 +325,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -358,9 +343,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -377,16 +361,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 3px 1px rgba( if($dark-theme, $white, $black), .25 )`
 
 </td>
 <td>
 
-`0 0 3px 1px rgba( if($dark-theme, $white, $black), .25 )`
+`0 0 3px 1px rgba(0, 0, 0, 0.25)`
 
 </td>
 </tr>
@@ -396,9 +379,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -415,9 +397,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -434,9 +415,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -453,9 +433,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -472,16 +451,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-off-track-bg )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-off-track-bg )`
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
 
 </td>
 </tr>
@@ -491,9 +471,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -510,16 +489,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-switch-off-track-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -529,16 +509,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -548,16 +527,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-off-thumb-bg )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-off-thumb-bg )`
+<span class="color-preview" style="background-color: #d8d8d8"></span>
+
+`#d8d8d8`
 
 </td>
 </tr>
@@ -567,9 +547,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -586,16 +565,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-switch-off-thumb-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -605,9 +585,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -624,16 +603,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -643,14 +623,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -662,16 +643,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -681,9 +663,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -700,9 +681,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -719,9 +699,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -738,9 +717,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -757,9 +735,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -776,9 +753,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -795,9 +771,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -814,9 +789,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -833,9 +807,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -852,16 +825,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 3px 1px rgba( if($dark-theme, $white, $black), .25 )`
 
 </td>
 <td>
 
-`0 0 3px 1px rgba( if($dark-theme, $white, $black), .25 )`
+`0 0 3px 1px rgba(0, 0, 0, 0.25)`
 
 </td>
 </tr>
@@ -871,9 +843,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -890,9 +861,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -909,9 +879,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -928,9 +897,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -947,14 +915,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -966,9 +935,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -985,16 +953,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-on-thumb-bg )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-on-thumb-bg )`
+<span class="color-preview" style="background-color: #e05100"></span>
+
+`#e05100`
 
 </td>
 </tr>
@@ -1004,16 +973,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -1023,16 +991,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-on-thumb-bg )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-on-thumb-bg )`
+<span class="color-preview" style="background-color: #e05100"></span>
+
+`#e05100`
 
 </td>
 </tr>
@@ -1042,9 +1011,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1061,16 +1029,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-on-thumb-hover-bg )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-on-thumb-hover-bg )`
+<span class="color-preview" style="background-color: #ce4b00"></span>
+
+`#ce4b00`
 
 </td>
 </tr>
@@ -1080,9 +1049,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/classic/docs/customization-table.md
+++ b/packages/classic/docs/customization-table.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-table-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-vertical-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-vertical-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-horizontal-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-horizontal-border-width`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -188,26 +180,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 10px), md: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 10px), lg: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 10px))`
 
 </td>
 </tr>
@@ -217,16 +190,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -236,16 +210,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -255,16 +230,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -274,16 +250,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
+`#f0f0f0`
 
 </td>
 </tr>
@@ -293,16 +270,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -312,16 +290,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -331,16 +310,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
+`#f0f0f0`
 
 </td>
 </tr>
@@ -350,16 +330,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -369,16 +350,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -388,16 +370,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
+`#f0f0f0`
 
 </td>
 </tr>
@@ -407,16 +390,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -426,16 +410,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -445,16 +430,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-alt-bg`
 
 </td>
 <td>
 
-`try-shade( $grid-bg, .5 )`
+<span class="color-preview" style="background-color: whitesmoke"></span>
+
+`whitesmoke`
 
 </td>
 </tr>
@@ -464,9 +450,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-text`
 
@@ -483,9 +468,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-border`
 
@@ -502,16 +486,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $grid-bg, 1 )`
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
 
 </td>
 </tr>
@@ -521,9 +506,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-text`
 
@@ -540,9 +524,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-border`
 
@@ -559,9 +542,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -578,9 +560,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -597,9 +578,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -616,16 +596,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$grid-focused-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -635,16 +614,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-bg`
 
 </td>
 <td>
 
-`rgba( $selected-bg, .25 )`
+<span class="color-preview" style="background-color: rgba(243, 88, 0, 0.25)"></span>
+
+`rgba(243, 88, 0, 0.25)`
 
 </td>
 </tr>
@@ -654,9 +634,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-selected-text`
 
@@ -673,9 +652,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-selected-border`
 

--- a/packages/classic/docs/customization-tabstrip.md
+++ b/packages/classic/docs/customization-tabstrip.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$tabstrip-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,16 +45,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -65,16 +65,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -84,16 +85,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-x`
 
 </td>
 <td>
 
-
+`8px`
 
 </td>
 </tr>
@@ -103,16 +103,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-y`
 
 </td>
 <td>
 
-
+`4px`
 
 </td>
 </tr>
@@ -122,9 +121,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -141,16 +139,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -160,16 +157,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-gap</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-margin`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -179,14 +175,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
 `#f0f0f0`
 
@@ -198,16 +195,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`$body-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -217,16 +215,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -236,16 +235,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -255,16 +253,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -274,16 +273,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -293,16 +293,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-border`
 
 </td>
 <td>
 
-`try-shade( $hovered-bg, 2 )`
+<span class="color-preview" style="background-color: #bababa"></span>
+
+`#bababa`
 
 </td>
 </tr>
@@ -312,9 +313,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,16 +331,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -350,16 +351,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -369,16 +371,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -388,9 +391,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
-    <td></td>
+    <td>Bool</td>
 <td>
-
 
 `false`
 
@@ -407,16 +409,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -426,16 +427,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -445,9 +445,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -464,16 +463,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -483,16 +483,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -502,16 +503,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -521,16 +523,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border-focused</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-toolbar.md
+++ b/packages/classic/docs/customization-toolbar.md
@@ -27,16 +27,15 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$toolbar-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$toolbar-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-treeview.md
+++ b/packages/classic/docs/customization-treeview.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-treeview-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-indent</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `16px`
 
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -160,16 +153,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -207,26 +198,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 2px), md: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 4px), lg: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 6px))`
 
 </td>
 </tr>
@@ -236,9 +208,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,16 +226,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -274,9 +246,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -293,16 +264,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -312,16 +284,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -331,16 +304,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-border`
 
 </td>
 <td>
 
-`try-shade( $hovered-bg, 2 )`
+<span class="color-preview" style="background-color: #bababa"></span>
+
+`#bababa`
 
 </td>
 </tr>
@@ -350,16 +324,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$hovered-gradient`
 
 </td>
 <td>
 
-`$base-gradient`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -369,16 +342,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
 
 </td>
 </tr>
@@ -388,16 +362,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -407,16 +382,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-border`
 
 </td>
 <td>
 
-`try-shade( $selected-bg, 2 )`
+<span class="color-preview" style="background-color: #cc4a00"></span>
+
+`#cc4a00`
 
 </td>
 </tr>
@@ -426,16 +402,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$selected-gradient`
 
 </td>
 <td>
 
-`$base-gradient`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -445,16 +420,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$focused-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.13)`
 
 </td>
 </tr>
@@ -464,14 +438,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -483,16 +458,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f35800"></span>
 
+`#f35800`
 
 </td>
 </tr>
@@ -502,9 +478,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,14 +496,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -540,16 +516,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #cc4a00"></span>
 
+`#cc4a00`
 
 </td>
 </tr>
@@ -559,9 +536,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -578,14 +554,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -597,16 +574,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #cc4a00"></span>
 
+`#cc4a00`
 
 </td>
 </tr>
@@ -616,9 +594,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -635,16 +612,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-treeview-item-focus-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.13)`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization-typography.md
+++ b/packages/classic/docs/customization-typography.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$enable-typography</td>
-    <td></td>
+    <td>Bool</td>
 <td>
-
 
 `false`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-family-monospace</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
 
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(20 / 14)`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>

--- a/packages/classic/docs/customization.md
+++ b/packages/classic/docs/customization.md
@@ -31,16 +31,15 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -50,14 +49,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f0f0f0"></span>
 
 `#f0f0f0`
 
 </td>
-<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
 `#f0f0f0`
 
@@ -69,16 +71,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$base-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -88,16 +91,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$base-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $base-bg, 2 )`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -107,16 +111,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$base-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `rgba( white, .1 ), rgba( white, 0 )`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -126,16 +129,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $base-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -145,16 +149,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -164,16 +169,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $hovered-bg, 2 )`
 
 </td>
 <td>
 
-`try-shade( $hovered-bg, 2 )`
+<span class="color-preview" style="background-color: #bababa"></span>
+
+`#bababa`
 
 </td>
 </tr>
@@ -183,16 +189,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$hovered-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -202,14 +207,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -221,16 +227,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -240,16 +247,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $selected-bg, 2 )`
 
 </td>
 <td>
 
-`try-shade( $selected-bg, 2 )`
+<span class="color-preview" style="background-color: #cc4a00"></span>
+
+`#cc4a00`
 
 </td>
 </tr>
@@ -259,16 +267,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$selected-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -299,9 +306,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$kendo-avatar-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -318,9 +324,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-avatar-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -337,9 +342,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-avatar-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -356,16 +360,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-avatar-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>
@@ -375,9 +378,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-avatar-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 4 ),
@@ -388,11 +390,7 @@ The following table lists the available variables for customizing the Classic th
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 4 ),
-    md: map-get( $spacing, 8 ),
-    lg: map-get( $spacing, 16 )
-)`
+`(sm: 16px, md: 32px, lg: 64px)`
 
 </td>
 </tr>
@@ -402,16 +400,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-avatar-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #f35800, "secondary": #e9e9e9, "tertiary": #03a9f4, "info": #2498bc, "success": #3ea44e, "warning": #ff9800, "error": #d92800, "dark": #404040, "light": #ebebeb, "inverse": #404040)`
 
 </td>
 </tr>
@@ -442,9 +439,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$kendo-button-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -461,9 +457,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-border-radius</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -480,16 +475,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -499,16 +493,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -518,9 +511,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -537,16 +529,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -556,16 +547,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -575,16 +565,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
+`calc( 1.4285714286em + 8px + 2px )`
 
 </td>
 </tr>
@@ -594,16 +583,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-inner-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
+`calc( 1.4285714286em + 8px )`
 
 </td>
 </tr>
@@ -613,9 +601,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `map-merge(
     $kendo-theme-colors,
@@ -625,10 +612,7 @@ The following table lists the available variables for customizing the Classic th
 </td>
 <td>
 
-`map-merge(
-    $kendo-theme-colors,
-    ( "base": $base-bg )
-)`
+`("primary": #f35800, "secondary": #e9e9e9, "tertiary": #03a9f4, "info": #2498bc, "success": #3ea44e, "warning": #ff9800, "error": #d92800, "dark": #404040, "light": #ebebeb, "inverse": #404040, "base": #f0f0f0)`
 
 </td>
 </tr>
@@ -638,14 +622,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
 `#f0f0f0`
 
@@ -657,16 +642,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`$body-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -676,16 +662,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 2 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -695,16 +682,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -714,9 +700,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -733,16 +718,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -752,9 +738,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -771,16 +756,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 3 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 3 )`
+<span class="color-preview" style="background-color: #b6b6b6"></span>
+
+`#b6b6b6`
 
 </td>
 </tr>
@@ -790,9 +776,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -809,9 +794,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-hover-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -828,16 +812,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-active-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 2 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -847,9 +832,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-active-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -866,16 +850,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-active-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 4 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 4 )`
+<span class="color-preview" style="background-color: #a3a3a3"></span>
+
+`#a3a3a3`
 
 </td>
 </tr>
@@ -885,9 +870,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-active-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -904,9 +888,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -923,14 +906,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -942,16 +926,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-button-selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-button-selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -961,14 +946,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-selected-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -980,9 +966,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-gradient`
 
@@ -999,9 +984,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-selected-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-shadow`
 
@@ -1018,9 +1002,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1037,9 +1020,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1056,9 +1038,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1075,9 +1056,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1094,16 +1074,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 4px 0 rgba( $kendo-button-border, .75 )`
 
 </td>
 <td>
 
-`0 0 4px 0 rgba( $kendo-button-border, .75 )`
+`0 0 4px 0 rgba(202, 202, 202, 0.75)`
 
 </td>
 </tr>
@@ -1113,9 +1092,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1132,9 +1110,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1151,9 +1128,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1170,9 +1146,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1189,9 +1164,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-disabled-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1208,16 +1182,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-flat-button-hover-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.08`
 
 </td>
 <td>
 
-`.08`
+`0.08`
 
 </td>
 </tr>
@@ -1227,16 +1200,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-flat-button-focus-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.12`
 
 </td>
 <td>
 
-`.12`
+`0.12`
 
 </td>
 </tr>
@@ -1246,16 +1218,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-flat-button-active-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.16`
 
 </td>
 <td>
 
-`.16`
+`0.16`
 
 </td>
 </tr>
@@ -1265,16 +1236,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-flat-button-selected-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.2`
 
 </td>
 <td>
 
-`.2`
+`0.2`
 
 </td>
 </tr>
@@ -1284,16 +1254,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-button-transition</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `color .2s ease-in-out`
 
 </td>
 <td>
 
-`color .2s ease-in-out`
+`color 0.2s ease-in-out`
 
 </td>
 </tr>
@@ -1324,14 +1293,17 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$series-a</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -1343,14 +1315,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$series-b</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ffd246"></span>
 
 `#ffd246`
 
 </td>
-<td><span class="color-preview" style="background-color: #ffd246"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ffd246"></span>
 
 `#ffd246`
 
@@ -1362,14 +1337,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$series-c</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #78d237"></span>
 
 `#78d237`
 
 </td>
-<td><span class="color-preview" style="background-color: #78d237"></span>
+<td>
+
+<span class="color-preview" style="background-color: #78d237"></span>
 
 `#78d237`
 
@@ -1381,14 +1359,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$series-d</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #28b4c8"></span>
 
 `#28b4c8`
 
 </td>
-<td><span class="color-preview" style="background-color: #28b4c8"></span>
+<td>
+
+<span class="color-preview" style="background-color: #28b4c8"></span>
 
 `#28b4c8`
 
@@ -1400,14 +1381,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$series-e</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #2d73f5"></span>
 
 `#2d73f5`
 
 </td>
-<td><span class="color-preview" style="background-color: #2d73f5"></span>
+<td>
+
+<span class="color-preview" style="background-color: #2d73f5"></span>
 
 `#2d73f5`
 
@@ -1419,14 +1403,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$series-f</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #aa46be"></span>
 
 `#aa46be`
 
 </td>
-<td><span class="color-preview" style="background-color: #aa46be"></span>
+<td>
+
+<span class="color-preview" style="background-color: #aa46be"></span>
 
 `#aa46be`
 
@@ -1438,14 +1425,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$series-1</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$series-a`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -1457,16 +1445,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$chart-major-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .08 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1476,16 +1465,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$chart-minor-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .04 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -1516,9 +1506,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$kendo-checkbox-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -1535,16 +1524,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -1554,9 +1544,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1573,16 +1562,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`$base-border`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -1592,9 +1582,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1611,9 +1600,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1630,9 +1618,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1649,14 +1636,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -1668,16 +1656,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-checked-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -1687,14 +1676,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -1706,16 +1696,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -1725,14 +1716,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -1744,16 +1736,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`$base-border`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -1763,9 +1756,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1782,16 +1774,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba(0, 0, 0, .06)`
 
 </td>
 <td>
 
-`0 0 0 2px rgba(0, 0, 0, .06)`
+`0 0 0 2px rgba(0, 0, 0, 0.06)`
 
 </td>
 </tr>
@@ -1801,9 +1792,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1820,16 +1810,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $primary, .3 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $primary, .3 )`
+`0 0 0 2px rgba(243, 88, 0, 0.3)`
 
 </td>
 </tr>
@@ -1839,9 +1828,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1858,9 +1846,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1877,9 +1864,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1896,9 +1882,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1915,9 +1900,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1934,9 +1918,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1953,9 +1936,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1972,16 +1954,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #d92800"></span>
 
+`#d92800`
 
 </td>
 </tr>
@@ -1991,16 +1974,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(217, 40, 0, 0.5)"></span>
 
+`rgba(217, 40, 0, 0.5)`
 
 </td>
 </tr>
@@ -2010,9 +1994,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -2029,9 +2012,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -2048,9 +2030,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e118"`
 
@@ -2067,9 +2048,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e121"`
 
@@ -2086,16 +2066,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='white' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -2105,16 +2084,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23f35800' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -2124,16 +2102,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2143,16 +2120,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -2162,9 +2138,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -2181,16 +2156,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`4px`
 
 </td>
 </tr>
@@ -2200,14 +2174,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -2219,16 +2194,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>
@@ -2259,9 +2233,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$kendo-chip-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -2278,16 +2251,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2297,16 +2269,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2316,16 +2287,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2335,16 +2305,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -2354,9 +2323,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1`
 
@@ -2373,9 +2341,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -2401,26 +2368,7 @@ The following table lists the available variables for customizing the Classic th
 </td>
 <td>
 
-`(
-    sm: (
-        padding-x: $kendo-chip-padding-x-sm,
-        padding-y: $kendo-chip-padding-y-sm,
-        font-size: $kendo-chip-font-size-sm,
-        line-height: $kendo-chip-line-height-sm
-    ),
-    md: (
-        padding-x: $kendo-chip-padding-x-md,
-        padding-y: $kendo-chip-padding-y-md,
-        font-size: $kendo-chip-font-size-md,
-        line-height: $kendo-chip-line-height-md
-    ),
-    lg: (
-        padding-x: $kendo-chip-padding-x-lg,
-        padding-y: $kendo-chip-padding-y-lg,
-        font-size: $kendo-chip-font-size-lg,
-        line-height: $kendo-chip-line-height-lg
-    )
-)`
+`(sm: (padding-x: 4px, padding-y: 2px, font-size: 14px, line-height: 1), md: (padding-x: 4px, padding-y: 4px, font-size: 14px, line-height: 1), lg: (padding-x: 4px, padding-y: 6px, font-size: 14px, line-height: 1))`
 
 </td>
 </tr>
@@ -2430,16 +2378,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -2449,9 +2398,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     "base": $kendo-chip-base-bg,
@@ -2464,13 +2412,7 @@ The following table lists the available variables for customizing the Classic th
 </td>
 <td>
 
-`(
-    "base": $kendo-chip-base-bg,
-    "error": map-get( $kendo-theme-colors, "error" ),
-    "info": map-get( $kendo-theme-colors, "info" ),
-    "warning": map-get( $kendo-theme-colors, "warning" ),
-    "success": map-get( $kendo-theme-colors, "success" )
-)`
+`("base": #272727, "error": #d92800, "info": #2498bc, "warning": #ff9800, "success": #3ea44e)`
 
 </td>
 </tr>
@@ -2480,16 +2422,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-solid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #eeeeee"></span>
+
+`#eeeeee`
 
 </td>
 </tr>
@@ -2499,16 +2442,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-solid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -2518,16 +2462,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-solid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 70% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 70% )`
+<span class="color-preview" style="background-color: #bebebe"></span>
+
+`#bebebe`
 
 </td>
 </tr>
@@ -2537,16 +2482,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-solid-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(39, 39, 39, 0.16)`
 
 </td>
 </tr>
@@ -2556,16 +2500,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #eeeeee"></span>
+
+`#eeeeee`
 
 </td>
 </tr>
@@ -2575,9 +2520,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2594,16 +2538,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 84% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 84% )`
+<span class="color-preview" style="background-color: gainsboro"></span>
+
+`gainsboro`
 
 </td>
 </tr>
@@ -2613,9 +2558,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2632,16 +2576,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 76% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 76% )`
+<span class="color-preview" style="background-color: #cbcbcb"></span>
+
+`#cbcbcb`
 
 </td>
 </tr>
@@ -2651,9 +2596,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2670,16 +2614,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-outline-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -2689,16 +2634,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-outline-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -2708,16 +2654,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-outline-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -2727,16 +2674,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-outline-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(39, 39, 39, 0.16)`
 
 </td>
 </tr>
@@ -2746,16 +2692,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -2765,16 +2712,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-chip-base-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2784,16 +2732,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -2803,16 +2752,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2822,9 +2772,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-chip-list-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 1 ),
@@ -2835,11 +2784,7 @@ The following table lists the available variables for customizing the Classic th
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 1 ),
-    md: map-get( $spacing, 1 ),
-    lg: map-get( $spacing, 1 )
-)`
+`(sm: 4px, md: 4px, lg: 4px)`
 
 </td>
 </tr>
@@ -2872,12 +2817,15 @@ The following table lists the available variables for customizing the Classic th
     <td>$primary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -2892,13 +2840,14 @@ The following table lists the available variables for customizing the Classic th
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $primary )`
 
 </td>
 <td>
 
-`contrast-wcag( $primary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2910,12 +2859,15 @@ The following table lists the available variables for customizing the Classic th
     <td>$secondary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #e9e9e9"></span>
 
 `#e9e9e9`
 
 </td>
-<td><span class="color-preview" style="background-color: #e9e9e9"></span>
+<td>
+
+<span class="color-preview" style="background-color: #e9e9e9"></span>
 
 `#e9e9e9`
 
@@ -2930,13 +2882,14 @@ The following table lists the available variables for customizing the Classic th
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $secondary )`
 
 </td>
 <td>
 
-`contrast-wcag( $secondary )`
+<span class="color-preview" style="background-color: black"></span>
+
+`black`
 
 </td>
 </tr>
@@ -2948,12 +2901,15 @@ The following table lists the available variables for customizing the Classic th
     <td>$tertiary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
 </td>
-<td><span class="color-preview" style="background-color: #03a9f4"></span>
+<td>
+
+<span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
@@ -2968,13 +2924,14 @@ The following table lists the available variables for customizing the Classic th
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $tertiary )`
 
 </td>
 <td>
 
-`contrast-wcag( $tertiary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2986,12 +2943,15 @@ The following table lists the available variables for customizing the Classic th
     <td>$info</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #2498bc"></span>
 
 `#2498bc`
 
 </td>
-<td><span class="color-preview" style="background-color: #2498bc"></span>
+<td>
+
+<span class="color-preview" style="background-color: #2498bc"></span>
 
 `#2498bc`
 
@@ -3005,12 +2965,15 @@ The following table lists the available variables for customizing the Classic th
     <td>$success</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #3ea44e"></span>
 
 `#3ea44e`
 
 </td>
-<td><span class="color-preview" style="background-color: #3ea44e"></span>
+<td>
+
+<span class="color-preview" style="background-color: #3ea44e"></span>
 
 `#3ea44e`
 
@@ -3024,12 +2987,15 @@ The following table lists the available variables for customizing the Classic th
     <td>$warning</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff9800"></span>
 
 `#ff9800`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff9800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff9800"></span>
 
 `#ff9800`
 
@@ -3043,12 +3009,15 @@ The following table lists the available variables for customizing the Classic th
     <td>$error</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #d92800"></span>
 
 `#d92800`
 
 </td>
-<td><span class="color-preview" style="background-color: #d92800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #d92800"></span>
 
 `#d92800`
 
@@ -3062,12 +3031,15 @@ The following table lists the available variables for customizing the Classic th
     <td>$dark</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #404040"></span>
 
 `#404040`
 
 </td>
-<td><span class="color-preview" style="background-color: #404040"></span>
+<td>
+
+<span class="color-preview" style="background-color: #404040"></span>
 
 `#404040`
 
@@ -3081,12 +3053,15 @@ The following table lists the available variables for customizing the Classic th
     <td>$light</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
 </td>
-<td><span class="color-preview" style="background-color: #ebebeb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
@@ -3098,16 +3073,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$inverse</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $light, $dark )`
 
 </td>
 <td>
 
-`if( $dark-theme, $light, $dark )`
+<span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
 
 </td>
 </tr>
@@ -3138,16 +3114,17 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$component-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -3157,16 +3134,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$component-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -3176,16 +3154,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$component-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -3216,9 +3195,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$kendo-fab-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -3235,16 +3213,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -3254,9 +3231,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -3273,9 +3249,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -3292,16 +3267,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>
@@ -3311,16 +3285,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -3330,16 +3303,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -3349,9 +3321,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -3368,9 +3339,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-icon-width`
 
@@ -3387,16 +3357,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-icon-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 ) / 2`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 ) / 2`
+`2px`
 
 </td>
 </tr>
@@ -3406,9 +3375,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -3425,16 +3393,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -3444,16 +3411,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -3463,16 +3429,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-text-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -3482,9 +3447,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -3501,9 +3465,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -3520,16 +3483,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-xs`
 
 </td>
 <td>
 
-
+`10px`
 
 </td>
 </tr>
@@ -3539,9 +3501,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.2`
 
@@ -3558,16 +3519,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -3577,16 +3537,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -3596,9 +3555,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0`
 
@@ -3615,9 +3573,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -3634,9 +3591,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -3653,9 +3609,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-width`
 
@@ -3672,16 +3627,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #f35800, "secondary": #e9e9e9, "tertiary": #03a9f4, "info": #2498bc, "success": #3ea44e, "warning": #ff9800, "error": #d92800, "dark": #404040, "light": #ebebeb, "inverse": #404040)`
 
 </td>
 </tr>
@@ -3691,16 +3645,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
 
 </td>
 <td>
 
-`0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
+`0 6px 10px rgba(0, 0, 0, 0.14), 0 1px 18px rgba(0, 0, 0, 0.12), 0 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -3710,16 +3663,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
 
 </td>
 <td>
 
-`0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0 6px 10px rgba(91, 91, 91, 0.1744), 0 1px 18px rgba(101, 101, 101, 0.1552), 0 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -3729,9 +3681,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -3748,16 +3699,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -3767,16 +3719,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -3786,16 +3739,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -3805,16 +3759,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
 <td>
 
-`$body-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -3824,14 +3779,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
 `#f0f0f0`
 
@@ -3843,16 +3799,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -3862,16 +3819,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-shadow`
 
 </td>
 <td>
 
-`0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
+`0 6px 10px rgba(0, 0, 0, 0.14), 0 1px 18px rgba(0, 0, 0, 0.12), 0 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -3881,16 +3837,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-disabled-shadow`
 
 </td>
 <td>
 
-`0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0 6px 10px rgba(91, 91, 91, 0.1744), 0 1px 18px rgba(101, 101, 101, 0.1552), 0 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -3900,9 +3855,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-fab-item-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-fab-active-shadow`
 
@@ -3940,16 +3894,17 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$grid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -3959,16 +3914,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -3978,16 +3934,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -3997,16 +3954,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
+`#f0f0f0`
 
 </td>
 </tr>
@@ -4016,16 +3974,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -4035,16 +3994,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -4054,16 +4014,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-header-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$header-gradient`
 
 </td>
 <td>
 
-
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -4073,16 +4032,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
+`#f0f0f0`
 
 </td>
 </tr>
@@ -4092,16 +4052,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -4111,16 +4072,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -4130,16 +4092,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-alt-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $grid-bg, .5 )`
 
 </td>
 <td>
 
-`try-shade( $grid-bg, .5 )`
+<span class="color-preview" style="background-color: whitesmoke"></span>
+
+`whitesmoke`
 
 </td>
 </tr>
@@ -4149,9 +4112,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-alt-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4168,9 +4130,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-alt-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4187,16 +4148,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $grid-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $grid-bg, 1 )`
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
 
 </td>
 </tr>
@@ -4206,9 +4168,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-hovered-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4225,9 +4186,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-hovered-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4244,16 +4204,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( $selected-bg, .25 )`
 
 </td>
 <td>
 
-`rgba( $selected-bg, .25 )`
+<span class="color-preview" style="background-color: rgba(243, 88, 0, 0.25)"></span>
+
+`rgba(243, 88, 0, 0.25)`
 
 </td>
 </tr>
@@ -4263,9 +4224,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4282,9 +4242,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$grid-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4322,9 +4281,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$icon-font-url</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4362,9 +4320,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$kendo-list-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4381,9 +4338,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4400,9 +4356,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-header-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4419,9 +4374,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-header-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4438,9 +4392,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-header-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 1px`
 
@@ -4457,9 +4410,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-header-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4476,9 +4428,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-header-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4495,9 +4446,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-header-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4514,9 +4464,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4533,9 +4482,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4552,9 +4500,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4571,9 +4518,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4590,9 +4536,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4609,9 +4554,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4628,9 +4572,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-group-item-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `1px 0 0`
 
@@ -4647,9 +4590,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4666,9 +4608,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-group-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4685,9 +4626,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4704,16 +4644,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -4723,16 +4664,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -4742,16 +4684,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -4761,9 +4704,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-header-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4780,9 +4722,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-header-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4799,9 +4740,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-header-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -4818,9 +4758,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-header-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4837,9 +4776,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4856,9 +4794,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4875,16 +4812,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -4894,16 +4832,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -4913,9 +4852,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4932,9 +4870,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4951,16 +4888,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `inset 0 0 0 2px rgba(0, 0, 0, .12)`
 
 </td>
 <td>
 
-`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+`inset 0 0 0 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -4970,16 +4906,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
 
 </td>
 </tr>
@@ -4989,16 +4926,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -5008,9 +4946,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-group-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5027,9 +4964,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-group-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5046,9 +4982,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-group-item-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -5065,9 +5000,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-group-item-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5084,16 +5018,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-list-no-data-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #646464"></span>
 
+`#646464`
 
 </td>
 </tr>
@@ -5124,9 +5059,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$kendo-menu-popup-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5143,9 +5077,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5162,16 +5095,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$popup-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -5181,16 +5113,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -5200,16 +5131,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -5219,16 +5149,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -5238,16 +5169,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -5257,16 +5189,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #cacaca"></span>
 
+`#cacaca`
 
 </td>
 </tr>
@@ -5276,9 +5209,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5295,16 +5227,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -5314,16 +5245,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -5333,16 +5263,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-end</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
+`calc( 16px + 16px )`
 
 </td>
 </tr>
@@ -5352,16 +5281,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-start-sm</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-menu-popup-item-padding-x-sm`
 
 </td>
 <td>
 
-
+`8px`
 
 </td>
 </tr>
@@ -5371,16 +5299,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-end-sm</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
 
 </td>
 <td>
 
-`calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
+`calc(-1 * (calc( 16px + 16px ) - 4px))`
 
 </td>
 </tr>
@@ -5390,9 +5317,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -5409,9 +5335,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5428,9 +5353,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5447,9 +5371,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5466,9 +5389,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5485,16 +5407,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -5504,16 +5427,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -5523,9 +5447,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5542,9 +5465,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5561,16 +5483,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
 
 </td>
 </tr>
@@ -5580,16 +5503,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -5599,9 +5523,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5618,9 +5541,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5637,16 +5559,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$menu-item-focus-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 3px 1px rgba(39, 39, 39, 0.25)`
 
 </td>
 </tr>
@@ -5677,9 +5598,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$kendo-radio-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -5696,9 +5616,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -5715,16 +5634,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -5734,9 +5654,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-text`
 
@@ -5753,16 +5672,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`$base-border`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -5772,9 +5692,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-bg`
 
@@ -5791,9 +5710,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-text`
 
@@ -5810,9 +5728,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-border`
 
@@ -5829,14 +5746,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -5848,16 +5766,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -5867,14 +5786,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -5886,9 +5806,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-border`
 
@@ -5905,16 +5824,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-shadow`
 
 </td>
 <td>
 
-`0 0 0 2px rgba(0, 0, 0, .06)`
+`0 0 0 2px rgba(0, 0, 0, 0.06)`
 
 </td>
 </tr>
@@ -5924,9 +5842,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-border`
 
@@ -5943,16 +5860,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-shadow`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $primary, .3 )`
+`0 0 0 2px rgba(243, 88, 0, 0.3)`
 
 </td>
 </tr>
@@ -5962,9 +5878,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-bg`
 
@@ -5981,9 +5896,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-text`
 
@@ -6000,9 +5914,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-border`
 
@@ -6019,9 +5932,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-bg`
 
@@ -6038,9 +5950,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-text`
 
@@ -6057,9 +5968,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-border`
 
@@ -6076,9 +5986,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-invalid-bg`
 
@@ -6095,16 +6004,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #d92800"></span>
 
+`#d92800`
 
 </td>
 </tr>
@@ -6114,16 +6024,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(217, 40, 0, 0.5)"></span>
 
+`rgba(217, 40, 0, 0.5)`
 
 </td>
 </tr>
@@ -6133,9 +6044,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -6152,9 +6062,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -6171,9 +6080,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e308"`
 
@@ -6190,16 +6098,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'%3e%3ccircle cx='50%25' cy='50%25' r='4' fill='white'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -6209,9 +6116,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-image</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6228,16 +6134,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -6247,16 +6152,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -6266,9 +6170,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -6285,16 +6188,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`4px`
 
 </td>
 </tr>
@@ -6304,14 +6206,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -6323,16 +6226,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-radio-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>
@@ -6363,9 +6265,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$kendo-switch-font-family</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6382,9 +6283,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-track-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -6401,9 +6301,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-thumb-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -6420,9 +6319,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-label-text-transform</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6439,9 +6337,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-label-display</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inline`
 
@@ -6458,9 +6355,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: ( font-size: 12px, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: 4px ),
@@ -6471,11 +6367,7 @@ The following table lists the available variables for customizing the Classic th
 </td>
 <td>
 
-`(
-    sm: ( font-size: 12px, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: 4px ),
-    md: ( font-size: 12px, track-width: 56px, track-height: 30px, thumb-width: 24px, thumb-height: 24px, thumb-offset: 3px, label-offset: 6px ),
-    lg: ( font-size: 12px, track-width: 64px, track-height: 34px, thumb-width: 28px, thumb-height: 28px, thumb-offset: 3px, label-offset: 8px )
-)`
+`(sm: (font-size: 12px, track-width: 48px, track-height: 26px, thumb-width: 20px, thumb-height: 20px, thumb-offset: 3px, label-offset: 4px), md: (font-size: 12px, track-width: 56px, track-height: 30px, thumb-width: 24px, thumb-height: 24px, thumb-offset: 3px, label-offset: 6px), lg: (font-size: 12px, track-width: 64px, track-height: 34px, thumb-width: 28px, thumb-height: 28px, thumb-offset: 3px, label-offset: 8px))`
 
 </td>
 </tr>
@@ -6485,16 +6377,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -6504,16 +6397,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -6523,16 +6417,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -6542,9 +6437,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6561,9 +6455,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6580,9 +6473,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6599,9 +6491,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6618,9 +6509,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6637,9 +6527,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6656,9 +6545,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6675,9 +6563,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6694,9 +6581,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6713,16 +6599,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 3px 1px rgba( if($dark-theme, $white, $black), .25 )`
 
 </td>
 <td>
 
-`0 0 3px 1px rgba( if($dark-theme, $white, $black), .25 )`
+`0 0 3px 1px rgba(0, 0, 0, 0.25)`
 
 </td>
 </tr>
@@ -6732,9 +6617,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6751,9 +6635,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6770,9 +6653,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6789,9 +6671,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6808,16 +6689,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-off-track-bg )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-off-track-bg )`
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
 
 </td>
 </tr>
@@ -6827,9 +6709,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6846,16 +6727,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-switch-off-track-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -6865,16 +6747,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -6884,16 +6765,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-off-thumb-bg )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-off-thumb-bg )`
+<span class="color-preview" style="background-color: #d8d8d8"></span>
+
+`#d8d8d8`
 
 </td>
 </tr>
@@ -6903,9 +6785,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6922,16 +6803,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-switch-off-thumb-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -6941,9 +6823,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6960,16 +6841,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -6979,14 +6861,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -6998,16 +6881,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -7017,9 +6901,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7036,9 +6919,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7055,9 +6937,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7074,9 +6955,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7093,9 +6973,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7112,9 +6991,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7131,9 +7009,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7150,9 +7027,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7169,9 +7045,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7188,16 +7063,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 3px 1px rgba( if($dark-theme, $white, $black), .25 )`
 
 </td>
 <td>
 
-`0 0 3px 1px rgba( if($dark-theme, $white, $black), .25 )`
+`0 0 3px 1px rgba(0, 0, 0, 0.25)`
 
 </td>
 </tr>
@@ -7207,9 +7081,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7226,9 +7099,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7245,9 +7117,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7264,9 +7135,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7283,14 +7153,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #f35800"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f35800"></span>
 
 `#f35800`
 
@@ -7302,9 +7173,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7321,16 +7191,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-on-thumb-bg )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-on-thumb-bg )`
+<span class="color-preview" style="background-color: #e05100"></span>
+
+`#e05100`
 
 </td>
 </tr>
@@ -7340,16 +7211,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -7359,16 +7229,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-on-thumb-bg )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-on-thumb-bg )`
+<span class="color-preview" style="background-color: #e05100"></span>
+
+`#e05100`
 
 </td>
 </tr>
@@ -7378,9 +7249,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7397,16 +7267,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-on-thumb-hover-bg )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-on-thumb-hover-bg )`
+<span class="color-preview" style="background-color: #ce4b00"></span>
+
+`#ce4b00`
 
 </td>
 </tr>
@@ -7416,9 +7287,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7456,9 +7326,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$kendo-table-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -7475,16 +7344,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-cell-vertical-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-vertical-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -7494,16 +7362,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-cell-horizontal-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-horizontal-border-width`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -7513,9 +7380,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7532,9 +7398,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7551,9 +7416,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7570,9 +7434,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7589,9 +7452,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -7617,26 +7479,7 @@ The following table lists the available variables for customizing the Classic th
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 10px), md: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 10px), lg: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 10px))`
 
 </td>
 </tr>
@@ -7646,16 +7489,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -7665,16 +7509,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -7684,16 +7529,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -7703,16 +7549,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
+`#f0f0f0`
 
 </td>
 </tr>
@@ -7722,16 +7569,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -7741,16 +7589,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -7760,16 +7609,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
+`#f0f0f0`
 
 </td>
 </tr>
@@ -7779,16 +7629,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -7798,16 +7649,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -7817,16 +7669,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-group-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
+`#f0f0f0`
 
 </td>
 </tr>
@@ -7836,16 +7689,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-group-row-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -7855,16 +7709,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-group-row-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -7874,16 +7729,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-alt-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-alt-bg`
 
 </td>
 <td>
 
-`try-shade( $grid-bg, .5 )`
+<span class="color-preview" style="background-color: whitesmoke"></span>
+
+`whitesmoke`
 
 </td>
 </tr>
@@ -7893,9 +7749,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-alt-row-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-text`
 
@@ -7912,9 +7767,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-alt-row-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-border`
 
@@ -7931,16 +7785,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $grid-bg, 1 )`
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
 
 </td>
 </tr>
@@ -7950,9 +7805,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-text`
 
@@ -7969,9 +7823,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-border`
 
@@ -7988,9 +7841,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8007,9 +7859,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8026,9 +7877,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8045,16 +7895,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$grid-focused-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -8064,16 +7913,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-bg`
 
 </td>
 <td>
 
-`rgba( $selected-bg, .25 )`
+<span class="color-preview" style="background-color: rgba(243, 88, 0, 0.25)"></span>
+
+`rgba(243, 88, 0, 0.25)`
 
 </td>
 </tr>
@@ -8083,9 +7933,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-selected-text`
 
@@ -8102,9 +7951,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-table-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-selected-border`
 
@@ -8142,9 +7990,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$tabstrip-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8161,16 +8008,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -8180,16 +8028,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -8199,16 +8048,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-x`
 
 </td>
 <td>
 
-
+`8px`
 
 </td>
 </tr>
@@ -8218,16 +8066,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-y`
 
 </td>
 <td>
 
-
+`4px`
 
 </td>
 </tr>
@@ -8237,9 +8084,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -8256,16 +8102,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -8275,16 +8120,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-gap</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-margin`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -8294,14 +8138,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f0f0f0"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f0f0f0"></span>
 
 `#f0f0f0`
 
@@ -8313,16 +8158,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`$body-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -8332,16 +8178,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -8351,16 +8198,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( white, .1 ), rgba( white, 0 )`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -8370,16 +8216,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -8389,16 +8236,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -8408,16 +8256,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-border`
 
 </td>
 <td>
 
-`try-shade( $hovered-bg, 2 )`
+<span class="color-preview" style="background-color: #bababa"></span>
+
+`#bababa`
 
 </td>
 </tr>
@@ -8427,9 +8276,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8446,16 +8294,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -8465,16 +8314,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -8484,16 +8334,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -8503,9 +8354,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
-    <td></td>
+    <td>Bool</td>
 <td>
-
 
 `false`
 
@@ -8522,16 +8372,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-content-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -8541,16 +8390,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-content-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -8560,9 +8408,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-content-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -8579,16 +8426,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-content-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -8598,16 +8446,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-content-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -8617,16 +8466,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-content-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 2 )`
+<span class="color-preview" style="background-color: #cacaca"></span>
+
+`#cacaca`
 
 </td>
 </tr>
@@ -8636,16 +8486,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$tabstrip-content-border-focused</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -8676,16 +8527,15 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$toolbar-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -8695,16 +8545,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$toolbar-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -8735,9 +8584,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$kendo-treeview-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -8754,16 +8602,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -8773,16 +8620,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -8792,9 +8638,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-indent</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `16px`
 
@@ -8811,16 +8656,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -8830,16 +8674,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -8849,9 +8692,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -8868,16 +8710,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -8887,9 +8728,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -8915,26 +8755,7 @@ The following table lists the available variables for customizing the Classic th
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 2px), md: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 4px), lg: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 6px))`
 
 </td>
 </tr>
@@ -8944,9 +8765,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8963,16 +8783,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #272727"></span>
 
+`#272727`
 
 </td>
 </tr>
@@ -8982,9 +8803,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9001,16 +8821,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, 1 )`
+<span class="color-preview" style="background-color: #dddddd"></span>
+
+`#dddddd`
 
 </td>
 </tr>
@@ -9020,16 +8841,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #272727"></span>
+
+`#272727`
 
 </td>
 </tr>
@@ -9039,16 +8861,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-border`
 
 </td>
 <td>
 
-`try-shade( $hovered-bg, 2 )`
+<span class="color-preview" style="background-color: #bababa"></span>
+
+`#bababa`
 
 </td>
 </tr>
@@ -9058,16 +8881,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$hovered-gradient`
 
 </td>
 <td>
 
-`$base-gradient`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -9077,16 +8899,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #f35800"></span>
+
+`#f35800`
 
 </td>
 </tr>
@@ -9096,16 +8919,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -9115,16 +8939,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-border`
 
 </td>
 <td>
 
-`try-shade( $selected-bg, 2 )`
+<span class="color-preview" style="background-color: #cc4a00"></span>
+
+`#cc4a00`
 
 </td>
 </tr>
@@ -9134,16 +8959,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$selected-gradient`
 
 </td>
 <td>
 
-`$base-gradient`
+`rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)`
 
 </td>
 </tr>
@@ -9153,16 +8977,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$focused-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.13)`
 
 </td>
 </tr>
@@ -9172,14 +8995,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9191,16 +9015,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f35800"></span>
 
+`#f35800`
 
 </td>
 </tr>
@@ -9210,9 +9035,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9229,14 +9053,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9248,16 +9073,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #cc4a00"></span>
 
+`#cc4a00`
 
 </td>
 </tr>
@@ -9267,9 +9093,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9286,14 +9111,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9305,16 +9131,17 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #cc4a00"></span>
 
+`#cc4a00`
 
 </td>
 </tr>
@@ -9324,9 +9151,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9343,16 +9169,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-treeview-item-focus-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.13)`
 
 </td>
 </tr>
@@ -9383,9 +9208,8 @@ The following table lists the available variables for customizing the Classic th
 <tbody>
         <tr>
     <td>$enable-typography</td>
-    <td></td>
+    <td>Bool</td>
 <td>
-
 
 `false`
 
@@ -9402,9 +9226,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -9421,9 +9244,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -9440,9 +9262,8 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$font-family-monospace</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
 
@@ -9459,16 +9280,15 @@ The following table lists the available variables for customizing the Classic th
 </tr>
 <tr>
     <td>$line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(20 / 14)`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>
@@ -9484,6 +9304,12 @@ The following table lists the available variables for customizing the Classic th
 
 ## Mixins
 
+### `exports`
+Outputs a module once, no matter how many times it is included.
+
+
+#### Parameters
+- name : `String` - The name of the exported module.
 
 
 

--- a/packages/default/docs/customization-avatar.md
+++ b/packages/default/docs/customization-avatar.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-avatar-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 4 ),
@@ -116,11 +111,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 4 ),
-    md: map-get( $spacing, 8 ),
-    lg: map-get( $spacing, 16 )
-)`
+`(sm: 16px, md: 32px, lg: 64px)`
 
 </td>
 </tr>
@@ -130,16 +121,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #ff6358, "secondary": #666666, "tertiary": #03a9f4, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #ebebeb, "inverse": #424242)`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-button.md
+++ b/packages/default/docs/customization-button.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-button-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-border-radius</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -141,16 +135,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -160,16 +153,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
+`calc( 1.4285714286em + 8px + 2px )`
 
 </td>
 </tr>
@@ -179,16 +171,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-inner-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
+`calc( 1.4285714286em + 8px )`
 
 </td>
 </tr>
@@ -198,9 +189,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `map-merge(
     $kendo-theme-colors,
@@ -210,10 +200,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`map-merge(
-    $kendo-theme-colors,
-    ( "base": #f5f5f5 )
-)`
+`("primary": #ff6358, "secondary": #666666, "tertiary": #03a9f4, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #ebebeb, "inverse": #424242, "base": #f5f5f5)`
 
 </td>
 </tr>
@@ -223,14 +210,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f5f5f5"></span>
 
 `#f5f5f5`
 
 </td>
-<td><span class="color-preview" style="background-color: #f5f5f5"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f5f5f5"></span>
 
 `#f5f5f5`
 
@@ -242,14 +232,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #424242"></span>
 
 `#424242`
 
 </td>
-<td><span class="color-preview" style="background-color: #424242"></span>
+<td>
+
+<span class="color-preview" style="background-color: #424242"></span>
 
 `#424242`
 
@@ -261,16 +254,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .08 )`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -280,16 +274,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `rgba( black, 0 ), rgba( black, .02 )`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -299,9 +292,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -318,16 +310,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, .5 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, .5 )`
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
 
 </td>
 </tr>
@@ -337,9 +330,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -356,9 +348,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -375,9 +366,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -394,9 +384,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -413,16 +402,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 1.5 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 1.5 )`
+<span class="color-preview" style="background-color: #d8d8d8"></span>
+
+`#d8d8d8`
 
 </td>
 </tr>
@@ -432,9 +422,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -451,9 +440,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -470,9 +458,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -489,9 +476,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -508,14 +494,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -527,16 +514,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-button-selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-button-selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -546,14 +534,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-selected-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -565,9 +554,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-gradient`
 
@@ -584,9 +572,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-shadow`
 
@@ -603,9 +590,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -622,9 +608,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -641,9 +626,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -660,9 +644,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -679,16 +662,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-button-border, .08 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-button-border, .08 )`
+`0 0 0 2px rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -698,9 +680,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -717,9 +698,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -736,9 +716,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -755,9 +734,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -774,9 +752,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -793,16 +770,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-hover-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.04`
 
 </td>
 <td>
 
-`.04`
+`0.04`
 
 </td>
 </tr>
@@ -812,9 +788,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-focus-opacity</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -831,16 +806,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-active-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.16`
 
 </td>
 <td>
 
-`.16`
+`0.16`
 
 </td>
 </tr>
@@ -850,16 +824,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-selected-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.2`
 
 </td>
 <td>
 
-`.2`
+`0.2`
 
 </td>
 </tr>
@@ -869,16 +842,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-transition</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `color .2s ease-in-out`
 
 </td>
 <td>
 
-`color .2s ease-in-out`
+`color 0.2s ease-in-out`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-charts.md
+++ b/packages/default/docs/customization-charts.md
@@ -27,14 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$series-a</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -46,14 +49,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-b</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ffe162"></span>
 
 `#ffe162`
 
 </td>
-<td><span class="color-preview" style="background-color: #ffe162"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ffe162"></span>
 
 `#ffe162`
 
@@ -65,14 +71,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-c</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #4cd180"></span>
 
 `#4cd180`
 
 </td>
-<td><span class="color-preview" style="background-color: #4cd180"></span>
+<td>
+
+<span class="color-preview" style="background-color: #4cd180"></span>
 
 `#4cd180`
 
@@ -84,14 +93,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-d</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #4b5ffa"></span>
 
 `#4b5ffa`
 
 </td>
-<td><span class="color-preview" style="background-color: #4b5ffa"></span>
+<td>
+
+<span class="color-preview" style="background-color: #4b5ffa"></span>
 
 `#4b5ffa`
 
@@ -103,14 +115,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-e</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ac58ff"></span>
 
 `#ac58ff`
 
 </td>
-<td><span class="color-preview" style="background-color: #ac58ff"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ac58ff"></span>
 
 `#ac58ff`
 
@@ -122,14 +137,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-f</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff5892"></span>
 
 `#ff5892`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff5892"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff5892"></span>
 
 `#ff5892`
 
@@ -141,14 +159,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-1</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$series-a`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -160,16 +179,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$chart-major-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .08 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -179,16 +199,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$chart-minor-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .04 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-checkbox.md
+++ b/packages/default/docs/customization-checkbox.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-checkbox-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -65,9 +65,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -84,16 +83,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -103,9 +103,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -122,9 +121,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +139,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,14 +157,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -179,16 +177,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-checked-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -198,14 +197,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -217,16 +217,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -236,14 +237,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -255,16 +257,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -274,9 +277,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -293,16 +295,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba(0, 0, 0, .06)`
 
 </td>
 <td>
 
-`0 0 0 2px rgba(0, 0, 0, .06)`
+`0 0 0 2px rgba(0, 0, 0, 0.06)`
 
 </td>
 </tr>
@@ -312,9 +313,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,16 +331,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $primary, .3 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $primary, .3 )`
+`0 0 0 2px rgba(255, 99, 88, 0.3)`
 
 </td>
 </tr>
@@ -350,9 +349,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,9 +367,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -388,9 +385,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -407,9 +403,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -426,9 +421,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +439,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,9 +457,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -483,16 +475,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -502,16 +495,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(243, 23, 0, 0.5)"></span>
 
+`rgba(243, 23, 0, 0.5)`
 
 </td>
 </tr>
@@ -521,9 +515,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -540,9 +533,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -559,9 +551,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e118"`
 
@@ -578,9 +569,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e121"`
 
@@ -597,16 +587,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='white' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -616,16 +605,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23ff6358' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -635,16 +623,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -654,16 +641,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -673,9 +659,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -692,16 +677,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`4px`
 
 </td>
 </tr>
@@ -711,14 +695,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -730,16 +715,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-chip.md
+++ b/packages/default/docs/customization-chip.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-chip-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1`
 
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -169,26 +162,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        padding-x: $kendo-chip-padding-x-sm,
-        padding-y: $kendo-chip-padding-y-sm,
-        font-size: $kendo-chip-font-size-sm,
-        line-height: $kendo-chip-line-height-sm
-    ),
-    md: (
-        padding-x: $kendo-chip-padding-x-md,
-        padding-y: $kendo-chip-padding-y-md,
-        font-size: $kendo-chip-font-size-md,
-        line-height: $kendo-chip-line-height-md
-    ),
-    lg: (
-        padding-x: $kendo-chip-padding-x-lg,
-        padding-y: $kendo-chip-padding-y-lg,
-        font-size: $kendo-chip-font-size-lg,
-        line-height: $kendo-chip-line-height-lg
-    )
-)`
+`(sm: (padding-x: 4px, padding-y: 2px, font-size: 14px, line-height: 1), md: (padding-x: 4px, padding-y: 4px, font-size: 14px, line-height: 1), lg: (padding-x: 4px, padding-y: 6px, font-size: 14px, line-height: 1))`
 
 </td>
 </tr>
@@ -198,16 +172,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -217,9 +192,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     "base": $kendo-chip-base-bg,
@@ -232,13 +206,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    "base": $kendo-chip-base-bg,
-    "error": map-get($kendo-theme-colors, "error"),
-    "info": map-get($kendo-theme-colors, "info"),
-    "warning": map-get($kendo-theme-colors, "warning"),
-    "success": map-get($kendo-theme-colors, "success")
-)`
+`("base": #424242, "error": #f31700, "info": #0058e9, "warning": #ffc000, "success": #37b400)`
 
 </td>
 </tr>
@@ -248,16 +216,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -267,16 +236,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -286,16 +256,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 70% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 70% )`
+<span class="color-preview" style="background-color: #c6c6c6"></span>
+
+`#c6c6c6`
 
 </td>
 </tr>
@@ -305,16 +276,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(66, 66, 66, 0.16)`
 
 </td>
 </tr>
@@ -324,16 +294,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -343,9 +314,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -362,16 +332,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 84% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 84% )`
+<span class="color-preview" style="background-color: #e1e1e1"></span>
+
+`#e1e1e1`
 
 </td>
 </tr>
@@ -381,9 +352,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -400,16 +370,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 76% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 76% )`
+<span class="color-preview" style="background-color: #d2d2d2"></span>
+
+`#d2d2d2`
 
 </td>
 </tr>
@@ -419,9 +390,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -438,16 +408,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -457,16 +428,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -476,16 +448,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -495,16 +468,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(66, 66, 66, 0.16)`
 
 </td>
 </tr>
@@ -514,16 +486,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -533,16 +506,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-chip-base-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -552,16 +526,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -571,16 +546,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -590,9 +566,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-list-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 1 ),
@@ -603,11 +578,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 1 ),
-    md: map-get( $spacing, 1 ),
-    lg: map-get( $spacing, 1 )
-)`
+`(sm: 4px, md: 4px, lg: 4px)`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-color-system.md
+++ b/packages/default/docs/customization-color-system.md
@@ -29,12 +29,15 @@ The following table lists the available variables for customization.
     <td>$accent</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -49,13 +52,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $accent )`
 
 </td>
 <td>
 
-`contrast-wcag( $accent )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -67,12 +71,15 @@ The following table lists the available variables for customization.
     <td>$primary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -87,13 +94,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $primary )`
 
 </td>
 <td>
 
-`contrast-wcag( $primary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -105,12 +113,15 @@ The following table lists the available variables for customization.
     <td>$secondary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #666666"></span>
 
 `#666666`
 
 </td>
-<td><span class="color-preview" style="background-color: #666666"></span>
+<td>
+
+<span class="color-preview" style="background-color: #666666"></span>
 
 `#666666`
 
@@ -125,13 +136,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $secondary )`
 
 </td>
 <td>
 
-`contrast-wcag( $secondary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -143,12 +155,15 @@ The following table lists the available variables for customization.
     <td>$tertiary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
 </td>
-<td><span class="color-preview" style="background-color: #03a9f4"></span>
+<td>
+
+<span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
@@ -163,13 +178,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $tertiary )`
 
 </td>
 <td>
 
-`contrast-wcag( $tertiary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -181,12 +197,15 @@ The following table lists the available variables for customization.
     <td>$info</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
 </td>
-<td><span class="color-preview" style="background-color: #0058e9"></span>
+<td>
+
+<span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
@@ -200,12 +219,15 @@ The following table lists the available variables for customization.
     <td>$success</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
 </td>
-<td><span class="color-preview" style="background-color: #37b400"></span>
+<td>
+
+<span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
@@ -219,12 +241,15 @@ The following table lists the available variables for customization.
     <td>$warning</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
 </td>
-<td><span class="color-preview" style="background-color: #ffc000"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
@@ -238,12 +263,15 @@ The following table lists the available variables for customization.
     <td>$error</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
 </td>
-<td><span class="color-preview" style="background-color: #f31700"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
@@ -257,12 +285,15 @@ The following table lists the available variables for customization.
     <td>$dark</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #424242"></span>
 
 `#424242`
 
 </td>
-<td><span class="color-preview" style="background-color: #424242"></span>
+<td>
+
+<span class="color-preview" style="background-color: #424242"></span>
 
 `#424242`
 
@@ -276,12 +307,15 @@ The following table lists the available variables for customization.
     <td>$light</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
 </td>
-<td><span class="color-preview" style="background-color: #ebebeb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
@@ -293,16 +327,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$inverse</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $light, $dark )`
 
 </td>
 <td>
 
-`if( $dark-theme, $light, $dark )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-common.md
+++ b/packages/default/docs/customization-common.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -46,14 +45,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #fafafa"></span>
 
 `#fafafa`
 
 </td>
-<td><span class="color-preview" style="background-color: #fafafa"></span>
+<td>
+
+<span class="color-preview" style="background-color: #fafafa"></span>
 
 `#fafafa`
 
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .08 )`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -103,16 +107,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `rgba( black, 0 ), rgba( black, .02 )`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -122,16 +125,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $base-bg, .5 )`
 
 </td>
 <td>
 
-`try-shade( $base-bg, .5 )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -141,16 +145,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -160,16 +165,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -179,16 +185,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -198,14 +203,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -217,16 +223,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -236,16 +243,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -255,16 +263,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-component.md
+++ b/packages/default/docs/customization-component.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$component-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$component-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$component-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .08 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-floating-action-button.md
+++ b/packages/default/docs/customization-floating-action-button.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-fab-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -141,16 +135,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-icon-width`
 
@@ -198,16 +189,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 ) / 2`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 ) / 2`
+`2px`
 
 </td>
 </tr>
@@ -217,9 +207,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -236,16 +225,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -255,16 +243,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -274,16 +261,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-text-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -293,9 +279,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -312,9 +297,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -331,16 +315,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-xs`
 
 </td>
 <td>
 
-
+`10px`
 
 </td>
 </tr>
@@ -350,9 +333,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.2`
 
@@ -369,16 +351,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -388,16 +369,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -407,9 +387,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0`
 
@@ -426,9 +405,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -445,9 +423,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -464,9 +441,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-width`
 
@@ -483,16 +459,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #ff6358, "secondary": #666666, "tertiary": #03a9f4, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #ebebeb, "inverse": #424242)`
 
 </td>
 </tr>
@@ -502,16 +477,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
 
 </td>
 <td>
 
-`0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
+`0 6px 10px rgba(0, 0, 0, 0.14), 0 1px 18px rgba(0, 0, 0, 0.12), 0 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -521,16 +495,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
 
 </td>
 <td>
 
-`0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0 6px 10px rgba(91, 91, 91, 0.1744), 0 1px 18px rgba(101, 101, 101, 0.1552), 0 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -540,9 +513,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -559,16 +531,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -578,16 +551,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -597,16 +571,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -616,14 +591,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #424242"></span>
+<td>
+
+<span class="color-preview" style="background-color: #424242"></span>
 
 `#424242`
 
@@ -635,14 +611,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f5f5f5"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f5f5f5"></span>
 
 `#f5f5f5`
 
@@ -654,16 +631,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -673,16 +651,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-shadow`
 
 </td>
 <td>
 
-`0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
+`0 6px 10px rgba(0, 0, 0, 0.14), 0 1px 18px rgba(0, 0, 0, 0.12), 0 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -692,16 +669,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-disabled-shadow`
 
 </td>
 <td>
 
-`0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0 6px 10px rgba(91, 91, 91, 0.1744), 0 1px 18px rgba(101, 101, 101, 0.1552), 0 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -711,9 +687,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-fab-active-shadow`
 

--- a/packages/default/docs/customization-grid.md
+++ b/packages/default/docs/customization-grid.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$grid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #fafafa"></span>
 
+`#fafafa`
 
 </td>
 </tr>
@@ -103,16 +107,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -122,16 +127,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -141,16 +147,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$header-gradient`
 
 </td>
 <td>
 
-
+`null`
 
 </td>
 </tr>
@@ -160,16 +165,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #fafafa"></span>
 
+`#fafafa`
 
 </td>
 </tr>
@@ -179,16 +185,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -198,16 +205,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -217,16 +225,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( contrast-wcag( $grid-bg ), .04 )`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -236,9 +245,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,9 +263,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -274,16 +281,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `darken($grid-bg, 7%)`
 
 </td>
 <td>
 
-`darken($grid-bg, 7%)`
+<span class="color-preview" style="background-color: #ededed"></span>
+
+`#ededed`
 
 </td>
 </tr>
@@ -293,9 +301,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -312,9 +319,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,16 +337,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba($selected-bg, .25)`
 
 </td>
 <td>
 
-`rgba($selected-bg, .25)`
+<span class="color-preview" style="background-color: rgba(255, 99, 88, 0.25)"></span>
+
+`rgba(255, 99, 88, 0.25)`
 
 </td>
 </tr>
@@ -350,9 +357,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,9 +375,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/default/docs/customization-icons.md
+++ b/packages/default/docs/customization-icons.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$icon-font-url</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/default/docs/customization-list.md
+++ b/packages/default/docs/customization-list.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-list-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 1px`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,9 +189,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -217,9 +207,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -236,9 +225,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,9 +243,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -274,9 +261,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -293,9 +279,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `1px 0 0`
 
@@ -312,9 +297,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +315,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,9 +333,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,16 +351,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -388,16 +371,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -407,16 +391,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -426,9 +411,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +429,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,9 +447,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -483,16 +465,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 5px 10px 0 rgba(0, 0, 0, .06)`
 
 </td>
 <td>
 
-`0 5px 10px 0 rgba(0, 0, 0, .06)`
+`0 5px 10px 0 rgba(0, 0, 0, 0.06)`
 
 </td>
 </tr>
@@ -502,9 +483,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,9 +501,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -540,16 +519,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, .5 )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -559,16 +539,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -578,9 +559,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -597,9 +577,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -616,16 +595,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `inset 0 0 0 2px rgba(0, 0, 0, .12)`
 
 </td>
 <td>
 
-`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+`inset 0 0 0 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -635,16 +613,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
 
 </td>
 </tr>
@@ -654,16 +633,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -673,9 +653,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -692,9 +671,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -711,9 +689,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -730,9 +707,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -749,16 +725,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-no-data-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #666666"></span>
 
+`#666666`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-menu.md
+++ b/packages/default/docs/customization-menu.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-menu-popup-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$popup-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -122,16 +117,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -141,16 +137,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -160,16 +157,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
 
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -179,9 +177,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,16 +195,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -217,16 +213,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -236,16 +231,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-end</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
+`calc( 16px + 16px )`
 
 </td>
 </tr>
@@ -255,16 +249,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-start-sm</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-menu-popup-item-padding-x-sm`
 
 </td>
 <td>
 
-
+`8px`
 
 </td>
 </tr>
@@ -274,16 +267,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-end-sm</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
 
 </td>
 <td>
 
-`calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
+`calc(-1 * (calc( 16px + 16px ) - 4px))`
 
 </td>
 </tr>
@@ -293,9 +285,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -312,9 +303,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +321,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,9 +339,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,9 +357,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -388,16 +375,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, .5 )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -407,16 +395,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -426,9 +415,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +433,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,16 +451,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
 
 </td>
 </tr>
@@ -483,16 +471,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -502,9 +491,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,9 +509,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -540,16 +527,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$menu-item-focus-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-radio.md
+++ b/packages/default/docs/customization-radio.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-radio-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -65,16 +63,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -84,9 +83,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-text`
 
@@ -103,16 +101,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -122,9 +121,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-bg`
 
@@ -141,9 +139,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-text`
 
@@ -160,9 +157,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-border`
 
@@ -179,14 +175,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -198,16 +195,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -217,14 +215,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -236,9 +235,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-border`
 
@@ -255,16 +253,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-shadow`
 
 </td>
 <td>
 
-`0 0 0 2px rgba(0, 0, 0, .06)`
+`0 0 0 2px rgba(0, 0, 0, 0.06)`
 
 </td>
 </tr>
@@ -274,9 +271,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-border`
 
@@ -293,16 +289,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-shadow`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $primary, .3 )`
+`0 0 0 2px rgba(255, 99, 88, 0.3)`
 
 </td>
 </tr>
@@ -312,9 +307,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-bg`
 
@@ -331,9 +325,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-text`
 
@@ -350,9 +343,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-border`
 
@@ -369,9 +361,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-bg`
 
@@ -388,9 +379,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-text`
 
@@ -407,9 +397,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-border`
 
@@ -426,9 +415,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-invalid-bg`
 
@@ -445,16 +433,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -464,16 +453,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(243, 23, 0, 0.5)"></span>
 
+`rgba(243, 23, 0, 0.5)`
 
 </td>
 </tr>
@@ -483,9 +473,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -502,9 +491,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -521,9 +509,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e308"`
 
@@ -540,16 +527,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'%3e%3ccircle cx='50%25' cy='50%25' r='4' fill='white'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -559,9 +545,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-image</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -578,16 +563,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -597,16 +581,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -616,9 +599,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -635,16 +617,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`4px`
 
 </td>
 </tr>
@@ -654,14 +635,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -673,16 +655,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-switch.md
+++ b/packages/default/docs/customization-switch.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-switch-font-family</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-track-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-thumb-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-label-text-transform</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `uppercase`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-label-display</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inline`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: ( font-size: 10px, track-width: 52px, track-height: 26px, thumb-width: 26px, thumb-height: 26px, thumb-offset: 0px, label-offset: 4px ),
@@ -135,11 +129,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: ( font-size: 10px, track-width: 52px, track-height: 26px, thumb-width: 26px, thumb-height: 26px, thumb-offset: 0px, label-offset: 4px ),
-    md: ( font-size: 10px, track-width: 60px, track-height: 30px, thumb-width: 30px, thumb-height: 30px, thumb-offset: 0px, label-offset: 6px ),
-    lg: ( font-size: 10px, track-width: 68px, track-height: 34px, thumb-width: 34px, thumb-height: 34px, thumb-offset: 0px, label-offset: 8px )
-)`
+`(sm: (font-size: 10px, track-width: 52px, track-height: 26px, thumb-width: 26px, thumb-height: 26px, thumb-offset: 0px, label-offset: 4px), md: (font-size: 10px, track-width: 60px, track-height: 30px, thumb-width: 30px, thumb-height: 30px, thumb-offset: 0px, label-offset: 6px), lg: (font-size: 10px, track-width: 68px, track-height: 34px, thumb-width: 34px, thumb-height: 34px, thumb-offset: 0px, label-offset: 8px))`
 
 </td>
 </tr>
@@ -149,16 +139,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -168,16 +159,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -187,16 +179,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-off-track-bg, 8% )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-off-track-bg, 8% )`
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
 
 </td>
 </tr>
@@ -206,9 +199,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -225,9 +217,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -244,9 +235,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -263,9 +253,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -282,9 +271,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -301,9 +289,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -320,9 +307,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -339,9 +325,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -358,9 +343,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -377,16 +361,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `2px solid rgba( if( $dark-theme, $white, $black ) , .08 )`
 
 </td>
 <td>
 
-`2px solid rgba( if( $dark-theme, $white, $black ) , .08 )`
+`2px solid rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -396,9 +379,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -415,9 +397,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -434,9 +415,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -453,9 +433,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -472,14 +451,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #fafafa"></span>
+<td>
+
+<span class="color-preview" style="background-color: #fafafa"></span>
 
 `#fafafa`
 
@@ -491,16 +471,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`$body-text`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -510,16 +491,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -529,9 +511,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -548,9 +529,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -567,9 +547,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -586,9 +565,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -605,9 +583,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -624,14 +601,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -643,16 +621,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-switch-on-track-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-switch-on-track-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -662,14 +641,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-switch-on-track-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -681,9 +661,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -700,9 +679,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -719,9 +697,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -738,9 +715,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -757,9 +733,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -776,9 +751,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -795,9 +769,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -814,9 +787,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -833,9 +805,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -852,16 +823,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `2px solid rgba( $kendo-switch-on-track-border, .25 )`
 
 </td>
 <td>
 
-`2px solid rgba( $kendo-switch-on-track-border, .25 )`
+`2px solid rgba(255, 99, 88, 0.25)`
 
 </td>
 </tr>
@@ -871,9 +841,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -890,9 +859,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -909,9 +877,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -928,9 +895,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -947,14 +913,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #fafafa"></span>
+<td>
+
+<span class="color-preview" style="background-color: #fafafa"></span>
 
 `#fafafa`
 
@@ -966,16 +933,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`$body-text`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -985,16 +953,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1004,9 +973,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1023,9 +991,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1042,9 +1009,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1061,9 +1027,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1080,9 +1045,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/default/docs/customization-table.md
+++ b/packages/default/docs/customization-table.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-table-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-vertical-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-vertical-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-horizontal-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-horizontal-border-width`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -188,26 +180,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 6px), md: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 8px), lg: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 10px))`
 
 </td>
 </tr>
@@ -217,16 +190,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -236,16 +210,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -255,16 +230,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -274,16 +250,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #fafafa"></span>
 
+`#fafafa`
 
 </td>
 </tr>
@@ -293,16 +270,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -312,16 +290,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -331,16 +310,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #fafafa"></span>
 
+`#fafafa`
 
 </td>
 </tr>
@@ -350,16 +330,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -369,16 +350,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -388,16 +370,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #fafafa"></span>
 
+`#fafafa`
 
 </td>
 </tr>
@@ -407,16 +390,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -426,16 +410,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -445,16 +430,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-alt-bg`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -464,9 +450,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-text`
 
@@ -483,9 +468,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-border`
 
@@ -502,16 +486,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-hovered-bg`
 
 </td>
 <td>
 
-`darken($grid-bg, 7%)`
+<span class="color-preview" style="background-color: #ededed"></span>
+
+`#ededed`
 
 </td>
 </tr>
@@ -521,9 +506,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-text`
 
@@ -540,9 +524,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-border`
 
@@ -559,9 +542,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -578,9 +560,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -597,9 +578,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -616,16 +596,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$grid-focused-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -635,16 +614,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-bg`
 
 </td>
 <td>
 
-`rgba($selected-bg, .25)`
+<span class="color-preview" style="background-color: rgba(255, 99, 88, 0.25)"></span>
+
+`rgba(255, 99, 88, 0.25)`
 
 </td>
 </tr>
@@ -654,9 +634,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-selected-text`
 
@@ -673,9 +652,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-selected-border`
 

--- a/packages/default/docs/customization-tabstrip.md
+++ b/packages/default/docs/customization-tabstrip.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$tabstrip-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,16 +45,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -65,16 +65,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -84,16 +85,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-x`
 
 </td>
 <td>
 
-
+`12px`
 
 </td>
 </tr>
@@ -103,16 +103,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-y`
 
 </td>
 <td>
 
-
+`6px`
 
 </td>
 </tr>
@@ -122,9 +121,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -141,9 +139,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
@@ -160,16 +157,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-gap</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-margin`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -179,9 +175,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,16 +193,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ff6358"></span>
 
+`#ff6358`
 
 </td>
 </tr>
@@ -217,9 +213,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -236,9 +231,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,9 +249,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -274,16 +267,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #d6534a"></span>
 
+`#d6534a`
 
 </td>
 </tr>
@@ -293,9 +287,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -312,9 +305,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,16 +323,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -350,16 +343,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -369,16 +363,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -388,9 +383,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -407,16 +401,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -426,16 +419,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -445,9 +437,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -464,16 +455,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -483,16 +475,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -502,16 +495,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -521,16 +515,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border-focused</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-toolbar.md
+++ b/packages/default/docs/customization-toolbar.md
@@ -27,16 +27,15 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$toolbar-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$toolbar-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-treeview.md
+++ b/packages/default/docs/customization-treeview.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-treeview-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-indent</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `16px`
 
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -207,26 +198,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 2px), md: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 4px), lg: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 6px))`
 
 </td>
 </tr>
@@ -236,9 +208,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,16 +226,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -274,9 +246,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -293,16 +264,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, .5 )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -312,16 +284,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -331,9 +304,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,9 +322,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,16 +340,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
 
 </td>
 </tr>
@@ -388,16 +360,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -407,9 +380,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -426,9 +398,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,16 +416,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$focused-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.13)`
 
 </td>
 </tr>
@@ -464,14 +434,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -483,16 +454,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ff6358"></span>
 
+`#ff6358`
 
 </td>
 </tr>
@@ -502,9 +474,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,14 +492,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -540,16 +512,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #d6534a"></span>
 
+`#d6534a`
 
 </td>
 </tr>
@@ -559,9 +532,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -578,14 +550,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -597,16 +570,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #d6534a"></span>
 
+`#d6534a`
 
 </td>
 </tr>
@@ -616,9 +590,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -635,16 +608,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-treeview-item-focus-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.13)`
 
 </td>
 </tr>

--- a/packages/default/docs/customization-typography.md
+++ b/packages/default/docs/customization-typography.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$enable-typography</td>
-    <td></td>
+    <td>Bool</td>
 <td>
-
 
 `false`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-family-monospace</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
 
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(20 / 14)`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>

--- a/packages/default/docs/customization.md
+++ b/packages/default/docs/customization.md
@@ -31,9 +31,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -50,14 +49,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #fafafa"></span>
 
 `#fafafa`
 
 </td>
-<td><span class="color-preview" style="background-color: #fafafa"></span>
+<td>
+
+<span class="color-preview" style="background-color: #fafafa"></span>
 
 `#fafafa`
 
@@ -69,16 +71,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$base-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -88,16 +91,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$base-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .08 )`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -107,16 +111,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$base-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `rgba( black, 0 ), rgba( black, .02 )`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -126,16 +129,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $base-bg, .5 )`
 
 </td>
 <td>
 
-`try-shade( $base-bg, .5 )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -145,16 +149,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -164,16 +169,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -183,16 +189,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$hovered-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -202,14 +207,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -221,16 +227,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -240,16 +247,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -259,16 +267,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$selected-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$base-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -299,9 +306,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$kendo-avatar-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -318,9 +324,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-avatar-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -337,9 +342,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-avatar-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -356,16 +360,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-avatar-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>
@@ -375,9 +378,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-avatar-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 4 ),
@@ -388,11 +390,7 @@ The following table lists the available variables for customizing the Default th
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 4 ),
-    md: map-get( $spacing, 8 ),
-    lg: map-get( $spacing, 16 )
-)`
+`(sm: 16px, md: 32px, lg: 64px)`
 
 </td>
 </tr>
@@ -402,16 +400,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-avatar-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #ff6358, "secondary": #666666, "tertiary": #03a9f4, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #ebebeb, "inverse": #424242)`
 
 </td>
 </tr>
@@ -442,9 +439,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$kendo-button-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -461,9 +457,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-border-radius</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -480,16 +475,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -499,16 +493,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -518,9 +511,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -537,16 +529,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -556,16 +547,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -575,16 +565,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
+`calc( 1.4285714286em + 8px + 2px )`
 
 </td>
 </tr>
@@ -594,16 +583,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-inner-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
+`calc( 1.4285714286em + 8px )`
 
 </td>
 </tr>
@@ -613,9 +601,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `map-merge(
     $kendo-theme-colors,
@@ -625,10 +612,7 @@ The following table lists the available variables for customizing the Default th
 </td>
 <td>
 
-`map-merge(
-    $kendo-theme-colors,
-    ( "base": #f5f5f5 )
-)`
+`("primary": #ff6358, "secondary": #666666, "tertiary": #03a9f4, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #ebebeb, "inverse": #424242, "base": #f5f5f5)`
 
 </td>
 </tr>
@@ -638,14 +622,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f5f5f5"></span>
 
 `#f5f5f5`
 
 </td>
-<td><span class="color-preview" style="background-color: #f5f5f5"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f5f5f5"></span>
 
 `#f5f5f5`
 
@@ -657,14 +644,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #424242"></span>
 
 `#424242`
 
 </td>
-<td><span class="color-preview" style="background-color: #424242"></span>
+<td>
+
+<span class="color-preview" style="background-color: #424242"></span>
 
 `#424242`
 
@@ -676,16 +666,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .08 )`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -695,16 +686,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `rgba( black, 0 ), rgba( black, .02 )`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -714,9 +704,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -733,16 +722,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, .5 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, .5 )`
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
 
 </td>
 </tr>
@@ -752,9 +742,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -771,9 +760,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -790,9 +778,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -809,9 +796,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-hover-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -828,16 +814,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-active-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 1.5 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 1.5 )`
+<span class="color-preview" style="background-color: #d8d8d8"></span>
+
+`#d8d8d8`
 
 </td>
 </tr>
@@ -847,9 +834,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-active-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -866,9 +852,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-active-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -885,9 +870,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-active-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -904,9 +888,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -923,14 +906,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -942,16 +926,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-button-selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-button-selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -961,14 +946,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-selected-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -980,9 +966,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-gradient`
 
@@ -999,9 +984,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-selected-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-shadow`
 
@@ -1018,9 +1002,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1037,9 +1020,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1056,9 +1038,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1075,9 +1056,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1094,16 +1074,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-button-border, .08 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-button-border, .08 )`
+`0 0 0 2px rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1113,9 +1092,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1132,9 +1110,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1151,9 +1128,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1170,9 +1146,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1189,9 +1164,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-disabled-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1208,16 +1182,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-flat-button-hover-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.04`
 
 </td>
 <td>
 
-`.04`
+`0.04`
 
 </td>
 </tr>
@@ -1227,9 +1200,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-flat-button-focus-opacity</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1246,16 +1218,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-flat-button-active-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.16`
 
 </td>
 <td>
 
-`.16`
+`0.16`
 
 </td>
 </tr>
@@ -1265,16 +1236,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-flat-button-selected-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.2`
 
 </td>
 <td>
 
-`.2`
+`0.2`
 
 </td>
 </tr>
@@ -1284,16 +1254,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-button-transition</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `color .2s ease-in-out`
 
 </td>
 <td>
 
-`color .2s ease-in-out`
+`color 0.2s ease-in-out`
 
 </td>
 </tr>
@@ -1324,14 +1293,17 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$series-a</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -1343,14 +1315,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$series-b</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ffe162"></span>
 
 `#ffe162`
 
 </td>
-<td><span class="color-preview" style="background-color: #ffe162"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ffe162"></span>
 
 `#ffe162`
 
@@ -1362,14 +1337,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$series-c</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #4cd180"></span>
 
 `#4cd180`
 
 </td>
-<td><span class="color-preview" style="background-color: #4cd180"></span>
+<td>
+
+<span class="color-preview" style="background-color: #4cd180"></span>
 
 `#4cd180`
 
@@ -1381,14 +1359,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$series-d</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #4b5ffa"></span>
 
 `#4b5ffa`
 
 </td>
-<td><span class="color-preview" style="background-color: #4b5ffa"></span>
+<td>
+
+<span class="color-preview" style="background-color: #4b5ffa"></span>
 
 `#4b5ffa`
 
@@ -1400,14 +1381,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$series-e</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ac58ff"></span>
 
 `#ac58ff`
 
 </td>
-<td><span class="color-preview" style="background-color: #ac58ff"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ac58ff"></span>
 
 `#ac58ff`
 
@@ -1419,14 +1403,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$series-f</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff5892"></span>
 
 `#ff5892`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff5892"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff5892"></span>
 
 `#ff5892`
 
@@ -1438,14 +1425,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$series-1</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$series-a`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -1457,16 +1445,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$chart-major-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .08 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1476,16 +1465,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$chart-minor-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .04 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -1516,9 +1506,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$kendo-checkbox-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -1535,16 +1524,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -1554,9 +1544,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1573,16 +1562,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1592,9 +1582,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1611,9 +1600,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1630,9 +1618,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1649,14 +1636,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -1668,16 +1656,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-checked-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -1687,14 +1676,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -1706,16 +1696,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -1725,14 +1716,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -1744,16 +1736,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1763,9 +1756,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1782,16 +1774,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba(0, 0, 0, .06)`
 
 </td>
 <td>
 
-`0 0 0 2px rgba(0, 0, 0, .06)`
+`0 0 0 2px rgba(0, 0, 0, 0.06)`
 
 </td>
 </tr>
@@ -1801,9 +1792,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1820,16 +1810,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $primary, .3 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $primary, .3 )`
+`0 0 0 2px rgba(255, 99, 88, 0.3)`
 
 </td>
 </tr>
@@ -1839,9 +1828,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1858,9 +1846,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1877,9 +1864,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1896,9 +1882,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1915,9 +1900,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1934,9 +1918,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1953,9 +1936,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1972,16 +1954,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -1991,16 +1974,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(243, 23, 0, 0.5)"></span>
 
+`rgba(243, 23, 0, 0.5)`
 
 </td>
 </tr>
@@ -2010,9 +1994,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -2029,9 +2012,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -2048,9 +2030,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e118"`
 
@@ -2067,9 +2048,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e121"`
 
@@ -2086,16 +2066,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='white' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M3,8 l3,3 l7-7'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -2105,16 +2084,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23ff6358' stroke-linecap='square' stroke-linejoin='square' stroke-width='2' d='M4,8 h8'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -2124,16 +2102,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2143,16 +2120,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -2162,9 +2138,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -2181,16 +2156,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`4px`
 
 </td>
 </tr>
@@ -2200,14 +2174,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -2219,16 +2194,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>
@@ -2259,9 +2233,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$kendo-chip-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -2278,16 +2251,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2297,16 +2269,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2316,16 +2287,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2335,16 +2305,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -2354,9 +2323,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1`
 
@@ -2373,9 +2341,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -2401,26 +2368,7 @@ The following table lists the available variables for customizing the Default th
 </td>
 <td>
 
-`(
-    sm: (
-        padding-x: $kendo-chip-padding-x-sm,
-        padding-y: $kendo-chip-padding-y-sm,
-        font-size: $kendo-chip-font-size-sm,
-        line-height: $kendo-chip-line-height-sm
-    ),
-    md: (
-        padding-x: $kendo-chip-padding-x-md,
-        padding-y: $kendo-chip-padding-y-md,
-        font-size: $kendo-chip-font-size-md,
-        line-height: $kendo-chip-line-height-md
-    ),
-    lg: (
-        padding-x: $kendo-chip-padding-x-lg,
-        padding-y: $kendo-chip-padding-y-lg,
-        font-size: $kendo-chip-font-size-lg,
-        line-height: $kendo-chip-line-height-lg
-    )
-)`
+`(sm: (padding-x: 4px, padding-y: 2px, font-size: 14px, line-height: 1), md: (padding-x: 4px, padding-y: 4px, font-size: 14px, line-height: 1), lg: (padding-x: 4px, padding-y: 6px, font-size: 14px, line-height: 1))`
 
 </td>
 </tr>
@@ -2430,16 +2378,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -2449,9 +2398,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     "base": $kendo-chip-base-bg,
@@ -2464,13 +2412,7 @@ The following table lists the available variables for customizing the Default th
 </td>
 <td>
 
-`(
-    "base": $kendo-chip-base-bg,
-    "error": map-get($kendo-theme-colors, "error"),
-    "info": map-get($kendo-theme-colors, "info"),
-    "warning": map-get($kendo-theme-colors, "warning"),
-    "success": map-get($kendo-theme-colors, "success")
-)`
+`("base": #424242, "error": #f31700, "info": #0058e9, "warning": #ffc000, "success": #37b400)`
 
 </td>
 </tr>
@@ -2480,16 +2422,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-solid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -2499,16 +2442,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-solid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -2518,16 +2462,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-solid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 70% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 70% )`
+<span class="color-preview" style="background-color: #c6c6c6"></span>
+
+`#c6c6c6`
 
 </td>
 </tr>
@@ -2537,16 +2482,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-solid-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(66, 66, 66, 0.16)`
 
 </td>
 </tr>
@@ -2556,16 +2500,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -2575,9 +2520,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2594,16 +2538,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 84% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 84% )`
+<span class="color-preview" style="background-color: #e1e1e1"></span>
+
+`#e1e1e1`
 
 </td>
 </tr>
@@ -2613,9 +2558,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2632,16 +2576,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 76% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 76% )`
+<span class="color-preview" style="background-color: #d2d2d2"></span>
+
+`#d2d2d2`
 
 </td>
 </tr>
@@ -2651,9 +2596,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2670,16 +2614,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-outline-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -2689,16 +2634,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-outline-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -2708,16 +2654,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-outline-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -2727,16 +2674,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-outline-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $kendo-chip-base-bg, .16 )`
+`0 0 0 2px rgba(66, 66, 66, 0.16)`
 
 </td>
 </tr>
@@ -2746,16 +2692,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -2765,16 +2712,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-chip-base-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2784,16 +2732,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, contrast-wcag($kendo-button-text), $kendo-button-text )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -2803,16 +2752,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2822,9 +2772,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-chip-list-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 1 ),
@@ -2835,11 +2784,7 @@ The following table lists the available variables for customizing the Default th
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 1 ),
-    md: map-get( $spacing, 1 ),
-    lg: map-get( $spacing, 1 )
-)`
+`(sm: 4px, md: 4px, lg: 4px)`
 
 </td>
 </tr>
@@ -2872,12 +2817,15 @@ The following table lists the available variables for customizing the Default th
     <td>$accent</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -2892,13 +2840,14 @@ The following table lists the available variables for customizing the Default th
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $accent )`
 
 </td>
 <td>
 
-`contrast-wcag( $accent )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2910,12 +2859,15 @@ The following table lists the available variables for customizing the Default th
     <td>$primary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -2930,13 +2882,14 @@ The following table lists the available variables for customizing the Default th
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $primary )`
 
 </td>
 <td>
 
-`contrast-wcag( $primary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2948,12 +2901,15 @@ The following table lists the available variables for customizing the Default th
     <td>$secondary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #666666"></span>
 
 `#666666`
 
 </td>
-<td><span class="color-preview" style="background-color: #666666"></span>
+<td>
+
+<span class="color-preview" style="background-color: #666666"></span>
 
 `#666666`
 
@@ -2968,13 +2924,14 @@ The following table lists the available variables for customizing the Default th
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $secondary )`
 
 </td>
 <td>
 
-`contrast-wcag( $secondary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2986,12 +2943,15 @@ The following table lists the available variables for customizing the Default th
     <td>$tertiary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
 </td>
-<td><span class="color-preview" style="background-color: #03a9f4"></span>
+<td>
+
+<span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
@@ -3006,13 +2966,14 @@ The following table lists the available variables for customizing the Default th
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $tertiary )`
 
 </td>
 <td>
 
-`contrast-wcag( $tertiary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -3024,12 +2985,15 @@ The following table lists the available variables for customizing the Default th
     <td>$info</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
 </td>
-<td><span class="color-preview" style="background-color: #0058e9"></span>
+<td>
+
+<span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
@@ -3043,12 +3007,15 @@ The following table lists the available variables for customizing the Default th
     <td>$success</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
 </td>
-<td><span class="color-preview" style="background-color: #37b400"></span>
+<td>
+
+<span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
@@ -3062,12 +3029,15 @@ The following table lists the available variables for customizing the Default th
     <td>$warning</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
 </td>
-<td><span class="color-preview" style="background-color: #ffc000"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
@@ -3081,12 +3051,15 @@ The following table lists the available variables for customizing the Default th
     <td>$error</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
 </td>
-<td><span class="color-preview" style="background-color: #f31700"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
@@ -3100,12 +3073,15 @@ The following table lists the available variables for customizing the Default th
     <td>$dark</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #424242"></span>
 
 `#424242`
 
 </td>
-<td><span class="color-preview" style="background-color: #424242"></span>
+<td>
+
+<span class="color-preview" style="background-color: #424242"></span>
 
 `#424242`
 
@@ -3119,12 +3095,15 @@ The following table lists the available variables for customizing the Default th
     <td>$light</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
 </td>
-<td><span class="color-preview" style="background-color: #ebebeb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
@@ -3136,16 +3115,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$inverse</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $light, $dark )`
 
 </td>
 <td>
 
-`if( $dark-theme, $light, $dark )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -3176,16 +3156,17 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$component-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -3195,16 +3176,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$component-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -3214,16 +3196,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$component-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .08 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -3254,9 +3237,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$kendo-fab-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -3273,9 +3255,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
@@ -3292,9 +3273,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -3311,9 +3291,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -3330,16 +3309,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>
@@ -3349,16 +3327,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -3368,16 +3345,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -3387,9 +3363,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -3406,9 +3381,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-icon-width`
 
@@ -3425,16 +3399,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-icon-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 ) / 2`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 ) / 2`
+`2px`
 
 </td>
 </tr>
@@ -3444,9 +3417,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -3463,16 +3435,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -3482,16 +3453,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -3501,16 +3471,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-text-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -3520,9 +3489,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -3539,9 +3507,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -3558,16 +3525,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-xs`
 
 </td>
 <td>
 
-
+`10px`
 
 </td>
 </tr>
@@ -3577,9 +3543,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-text-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.2`
 
@@ -3596,16 +3561,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -3615,16 +3579,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -3634,9 +3597,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0`
 
@@ -3653,9 +3615,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -3672,9 +3633,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -3691,9 +3651,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-width`
 
@@ -3710,16 +3669,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #ff6358, "secondary": #666666, "tertiary": #03a9f4, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #ebebeb, "inverse": #424242)`
 
 </td>
 </tr>
@@ -3729,16 +3687,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
 
 </td>
 <td>
 
-`0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
+`0 6px 10px rgba(0, 0, 0, 0.14), 0 1px 18px rgba(0, 0, 0, 0.12), 0 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -3748,16 +3705,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
 
 </td>
 <td>
 
-`0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0 6px 10px rgba(91, 91, 91, 0.1744), 0 1px 18px rgba(101, 101, 101, 0.1552), 0 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -3767,9 +3723,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -3786,16 +3741,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -3805,16 +3761,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -3824,16 +3781,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -3843,14 +3801,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #424242"></span>
+<td>
+
+<span class="color-preview" style="background-color: #424242"></span>
 
 `#424242`
 
@@ -3862,14 +3821,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f5f5f5"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f5f5f5"></span>
 
 `#f5f5f5`
 
@@ -3881,16 +3841,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -3900,16 +3861,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-shadow`
 
 </td>
 <td>
 
-`0 6px 10px rgba(0, 0, 0, .14), 0 1px 18px rgba(0, 0, 0, .12), 0 3px 5px rgba(0, 0, 0, .2)`
+`0 6px 10px rgba(0, 0, 0, 0.14), 0 1px 18px rgba(0, 0, 0, 0.12), 0 3px 5px rgba(0, 0, 0, 0.2)`
 
 </td>
 </tr>
@@ -3919,16 +3879,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-disabled-shadow`
 
 </td>
 <td>
 
-`0 6px 10px try-tint( rgba(0, 0, 0, .14), .5 ), 0 1px 18px try-tint( rgba(0, 0, 0, .12), .5 ), 0 3px 5px try-tint( rgba(0, 0, 0, .2), .5 )`
+`0 6px 10px rgba(91, 91, 91, 0.1744), 0 1px 18px rgba(101, 101, 101, 0.1552), 0 3px 5px rgba(70, 70, 70, 0.232)`
 
 </td>
 </tr>
@@ -3938,9 +3897,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-fab-item-active-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-fab-active-shadow`
 
@@ -3978,16 +3936,17 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$grid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -3997,16 +3956,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -4016,16 +3976,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -4035,16 +3996,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #fafafa"></span>
 
+`#fafafa`
 
 </td>
 </tr>
@@ -4054,16 +4016,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -4073,16 +4036,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -4092,16 +4056,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-header-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$header-gradient`
 
 </td>
 <td>
 
-
+`null`
 
 </td>
 </tr>
@@ -4111,16 +4074,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #fafafa"></span>
 
+`#fafafa`
 
 </td>
 </tr>
@@ -4130,16 +4094,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -4149,16 +4114,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -4168,16 +4134,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-alt-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( contrast-wcag( $grid-bg ), .04 )`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -4187,9 +4154,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-alt-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4206,9 +4172,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-alt-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4225,16 +4190,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `darken($grid-bg, 7%)`
 
 </td>
 <td>
 
-`darken($grid-bg, 7%)`
+<span class="color-preview" style="background-color: #ededed"></span>
+
+`#ededed`
 
 </td>
 </tr>
@@ -4244,9 +4210,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-hovered-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4263,9 +4228,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-hovered-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4282,16 +4246,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba($selected-bg, .25)`
 
 </td>
 <td>
 
-`rgba($selected-bg, .25)`
+<span class="color-preview" style="background-color: rgba(255, 99, 88, 0.25)"></span>
+
+`rgba(255, 99, 88, 0.25)`
 
 </td>
 </tr>
@@ -4301,9 +4266,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4320,9 +4284,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$grid-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4360,9 +4323,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$icon-font-url</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4400,9 +4362,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$kendo-list-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4419,9 +4380,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4438,9 +4398,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-header-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4457,9 +4416,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-header-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4476,9 +4434,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-header-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 1px`
 
@@ -4495,9 +4452,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-header-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4514,9 +4470,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-header-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4533,9 +4488,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-header-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4552,9 +4506,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4571,9 +4524,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4590,9 +4542,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4609,9 +4560,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4628,9 +4578,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4647,9 +4596,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4666,9 +4614,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-group-item-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `1px 0 0`
 
@@ -4685,9 +4632,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4704,9 +4650,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-group-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4723,9 +4668,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4742,16 +4686,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -4761,16 +4706,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -4780,16 +4726,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -4799,9 +4746,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-header-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4818,9 +4764,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-header-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4837,9 +4782,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-header-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -4856,16 +4800,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-header-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 5px 10px 0 rgba(0, 0, 0, .06)`
 
 </td>
 <td>
 
-`0 5px 10px 0 rgba(0, 0, 0, .06)`
+`0 5px 10px 0 rgba(0, 0, 0, 0.06)`
 
 </td>
 </tr>
@@ -4875,9 +4818,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4894,9 +4836,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4913,16 +4854,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, .5 )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -4932,16 +4874,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -4951,9 +4894,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4970,9 +4912,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4989,16 +4930,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `inset 0 0 0 2px rgba(0, 0, 0, .12)`
 
 </td>
 <td>
 
-`inset 0 0 0 2px rgba(0, 0, 0, .12)`
+`inset 0 0 0 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -5008,16 +4948,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
 
 </td>
 </tr>
@@ -5027,16 +4968,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -5046,9 +4988,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-group-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5065,9 +5006,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-group-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5084,9 +5024,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-group-item-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -5103,9 +5042,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-group-item-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5122,16 +5060,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-list-no-data-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #666666"></span>
 
+`#666666`
 
 </td>
 </tr>
@@ -5162,9 +5101,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$kendo-menu-popup-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5181,9 +5119,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5200,16 +5137,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$popup-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -5219,16 +5155,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -5238,16 +5173,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -5257,16 +5191,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -5276,16 +5211,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -5295,16 +5231,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
 
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -5314,9 +5251,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5333,16 +5269,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -5352,16 +5287,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -5371,16 +5305,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-end</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
+`calc( 16px + 16px )`
 
 </td>
 </tr>
@@ -5390,16 +5323,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-start-sm</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-menu-popup-item-padding-x-sm`
 
 </td>
 <td>
 
-
+`8px`
 
 </td>
 </tr>
@@ -5409,16 +5341,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-end-sm</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
 
 </td>
 <td>
 
-`calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
+`calc(-1 * (calc( 16px + 16px ) - 4px))`
 
 </td>
 </tr>
@@ -5428,9 +5359,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -5447,9 +5377,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5466,9 +5395,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5485,9 +5413,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5504,9 +5431,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5523,16 +5449,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, .5 )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -5542,16 +5469,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -5561,9 +5489,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5580,9 +5507,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5599,16 +5525,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
 
 </td>
 </tr>
@@ -5618,16 +5545,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -5637,9 +5565,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5656,9 +5583,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5675,16 +5601,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$menu-item-focus-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -5715,9 +5640,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$kendo-radio-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -5734,9 +5658,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -5753,16 +5676,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
 </td>
 <td>
 
-`$body-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -5772,9 +5696,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-text`
 
@@ -5791,16 +5714,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -5810,9 +5734,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-bg`
 
@@ -5829,9 +5752,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-text`
 
@@ -5848,9 +5770,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-hover-border`
 
@@ -5867,14 +5788,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -5886,16 +5808,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -5905,14 +5828,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -5924,9 +5848,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-border`
 
@@ -5943,16 +5866,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-shadow`
 
 </td>
 <td>
 
-`0 0 0 2px rgba(0, 0, 0, .06)`
+`0 0 0 2px rgba(0, 0, 0, 0.06)`
 
 </td>
 </tr>
@@ -5962,9 +5884,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-border`
 
@@ -5981,16 +5902,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-shadow`
 
 </td>
 <td>
 
-`0 0 0 2px rgba( $primary, .3 )`
+`0 0 0 2px rgba(255, 99, 88, 0.3)`
 
 </td>
 </tr>
@@ -6000,9 +5920,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-bg`
 
@@ -6019,9 +5938,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-text`
 
@@ -6038,9 +5956,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-border`
 
@@ -6057,9 +5974,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-bg`
 
@@ -6076,9 +5992,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-text`
 
@@ -6095,9 +6010,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-border`
 
@@ -6114,9 +6028,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-invalid-bg`
 
@@ -6133,16 +6046,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -6152,16 +6066,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(243, 23, 0, 0.5)"></span>
 
+`rgba(243, 23, 0, 0.5)`
 
 </td>
 </tr>
@@ -6171,9 +6086,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -6190,9 +6104,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -6209,9 +6122,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e308"`
 
@@ -6228,16 +6140,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'%3e%3ccircle cx='50%25' cy='50%25' r='4' fill='white'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -6247,9 +6158,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-image</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6266,16 +6176,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -6285,16 +6194,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -6304,9 +6212,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -6323,16 +6230,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`4px`
 
 </td>
 </tr>
@@ -6342,14 +6248,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-checked-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -6361,16 +6268,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-radio-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.25`
 
 </td>
 <td>
 
-`.25`
+`0.25`
 
 </td>
 </tr>
@@ -6401,9 +6307,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$kendo-switch-font-family</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6420,9 +6325,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-track-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -6439,9 +6343,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-thumb-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -6458,9 +6361,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-label-text-transform</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `uppercase`
 
@@ -6477,9 +6379,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-label-display</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inline`
 
@@ -6496,9 +6397,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: ( font-size: 10px, track-width: 52px, track-height: 26px, thumb-width: 26px, thumb-height: 26px, thumb-offset: 0px, label-offset: 4px ),
@@ -6509,11 +6409,7 @@ The following table lists the available variables for customizing the Default th
 </td>
 <td>
 
-`(
-    sm: ( font-size: 10px, track-width: 52px, track-height: 26px, thumb-width: 26px, thumb-height: 26px, thumb-offset: 0px, label-offset: 4px ),
-    md: ( font-size: 10px, track-width: 60px, track-height: 30px, thumb-width: 30px, thumb-height: 30px, thumb-offset: 0px, label-offset: 6px ),
-    lg: ( font-size: 10px, track-width: 68px, track-height: 34px, thumb-width: 34px, thumb-height: 34px, thumb-offset: 0px, label-offset: 8px )
-)`
+`(sm: (font-size: 10px, track-width: 52px, track-height: 26px, thumb-width: 26px, thumb-height: 26px, thumb-offset: 0px, label-offset: 4px), md: (font-size: 10px, track-width: 60px, track-height: 30px, thumb-width: 30px, thumb-height: 30px, thumb-offset: 0px, label-offset: 6px), lg: (font-size: 10px, track-width: 68px, track-height: 34px, thumb-width: 34px, thumb-height: 34px, thumb-offset: 0px, label-offset: 8px))`
 
 </td>
 </tr>
@@ -6523,16 +6419,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -6542,16 +6439,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -6561,16 +6459,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-switch-off-track-bg, 8% )`
 
 </td>
 <td>
 
-`try-shade( $kendo-switch-off-track-bg, 8% )`
+<span class="color-preview" style="background-color: #ebebeb"></span>
+
+`#ebebeb`
 
 </td>
 </tr>
@@ -6580,9 +6479,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6599,9 +6497,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6618,9 +6515,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6637,9 +6533,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6656,9 +6551,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6675,9 +6569,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6694,9 +6587,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6713,9 +6605,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6732,9 +6623,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6751,16 +6641,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `2px solid rgba( if( $dark-theme, $white, $black ) , .08 )`
 
 </td>
 <td>
 
-`2px solid rgba( if( $dark-theme, $white, $black ) , .08 )`
+`2px solid rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -6770,9 +6659,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6789,9 +6677,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6808,9 +6695,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6827,9 +6713,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6846,14 +6731,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #fafafa"></span>
+<td>
+
+<span class="color-preview" style="background-color: #fafafa"></span>
 
 `#fafafa`
 
@@ -6865,16 +6751,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`$body-text`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -6884,16 +6771,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -6903,9 +6791,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6922,9 +6809,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6941,9 +6827,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6960,9 +6845,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6979,9 +6863,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6998,14 +6881,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -7017,16 +6901,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-switch-on-track-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-switch-on-track-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -7036,14 +6921,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-switch-on-track-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -7055,9 +6941,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7074,9 +6959,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7093,9 +6977,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7112,9 +6995,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7131,9 +7013,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7150,9 +7031,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7169,9 +7049,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7188,9 +7067,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7207,9 +7085,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7226,16 +7103,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-ring</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `2px solid rgba( $kendo-switch-on-track-border, .25 )`
 
 </td>
 <td>
 
-`2px solid rgba( $kendo-switch-on-track-border, .25 )`
+`2px solid rgba(255, 99, 88, 0.25)`
 
 </td>
 </tr>
@@ -7245,9 +7121,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7264,9 +7139,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7283,9 +7157,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7302,9 +7175,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7321,14 +7193,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #fafafa"></span>
+<td>
+
+<span class="color-preview" style="background-color: #fafafa"></span>
 
 `#fafafa`
 
@@ -7340,16 +7213,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`$body-text`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -7359,16 +7233,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -7378,9 +7253,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7397,9 +7271,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7416,9 +7289,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7435,9 +7307,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7454,9 +7325,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7494,9 +7364,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$kendo-table-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -7513,16 +7382,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-cell-vertical-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-vertical-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -7532,16 +7400,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-cell-horizontal-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-horizontal-border-width`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -7551,9 +7418,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7570,9 +7436,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7589,9 +7454,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7608,9 +7472,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7627,9 +7490,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -7655,26 +7517,7 @@ The following table lists the available variables for customizing the Default th
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        cell-padding-x: map-get( $spacing, 2 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 6px), md: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 8px), lg: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 8px, cell-padding-y: 10px))`
 
 </td>
 </tr>
@@ -7684,16 +7527,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -7703,16 +7547,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -7722,16 +7567,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -7741,16 +7587,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #fafafa"></span>
 
+`#fafafa`
 
 </td>
 </tr>
@@ -7760,16 +7607,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -7779,16 +7627,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -7798,16 +7647,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #fafafa"></span>
 
+`#fafafa`
 
 </td>
 </tr>
@@ -7817,16 +7667,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -7836,16 +7687,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -7855,16 +7707,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-group-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #fafafa"></span>
 
+`#fafafa`
 
 </td>
 </tr>
@@ -7874,16 +7727,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-group-row-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -7893,16 +7747,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-group-row-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -7912,16 +7767,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-alt-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-alt-bg`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -7931,9 +7787,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-alt-row-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-text`
 
@@ -7950,9 +7805,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-alt-row-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-border`
 
@@ -7969,16 +7823,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-hovered-bg`
 
 </td>
 <td>
 
-`darken($grid-bg, 7%)`
+<span class="color-preview" style="background-color: #ededed"></span>
+
+`#ededed`
 
 </td>
 </tr>
@@ -7988,9 +7843,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-text`
 
@@ -8007,9 +7861,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-border`
 
@@ -8026,9 +7879,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8045,9 +7897,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8064,9 +7915,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8083,16 +7933,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$grid-focused-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -8102,16 +7951,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-bg`
 
 </td>
 <td>
 
-`rgba($selected-bg, .25)`
+<span class="color-preview" style="background-color: rgba(255, 99, 88, 0.25)"></span>
+
+`rgba(255, 99, 88, 0.25)`
 
 </td>
 </tr>
@@ -8121,9 +7971,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-selected-text`
 
@@ -8140,9 +7989,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-table-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-selected-border`
 
@@ -8180,9 +8028,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$tabstrip-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8199,16 +8046,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -8218,16 +8066,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -8237,16 +8086,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-x`
 
 </td>
 <td>
 
-
+`12px`
 
 </td>
 </tr>
@@ -8256,16 +8104,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-padding-y`
 
 </td>
 <td>
 
-
+`6px`
 
 </td>
 </tr>
@@ -8275,9 +8122,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -8294,9 +8140,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
@@ -8313,16 +8158,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-gap</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$nav-item-margin`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -8332,9 +8176,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8351,16 +8194,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ff6358"></span>
 
+`#ff6358`
 
 </td>
 </tr>
@@ -8370,9 +8214,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8389,9 +8232,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8408,9 +8250,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8427,16 +8268,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #d6534a"></span>
 
+`#d6534a`
 
 </td>
 </tr>
@@ -8446,9 +8288,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8465,9 +8306,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8484,16 +8324,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -8503,16 +8344,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -8522,16 +8364,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -8541,9 +8384,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8560,16 +8402,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-content-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -8579,16 +8420,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-content-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -8598,9 +8438,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-content-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -8617,16 +8456,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-content-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -8636,16 +8476,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-content-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -8655,16 +8496,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-content-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -8674,16 +8516,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$tabstrip-content-border-focused</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -8714,16 +8557,15 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$toolbar-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -8733,16 +8575,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$toolbar-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -8773,9 +8614,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$kendo-treeview-font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `$font-family`
 
@@ -8792,16 +8632,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -8811,16 +8650,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height-md`
 
 </td>
 <td>
 
-
+`1.4285714286`
 
 </td>
 </tr>
@@ -8830,9 +8668,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-indent</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `16px`
 
@@ -8849,16 +8686,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -8868,16 +8704,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -8887,9 +8722,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -8906,9 +8740,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
@@ -8925,9 +8758,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -8953,26 +8785,7 @@ The following table lists the available variables for customizing the Default th
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: $line-height-md,
-        item-padding-x: map-get( $spacing, 2 ),
-        item-padding-y: map-get( $spacing, 1 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 2px), md: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 4px), lg: (font-size: 14px, line-height: 1.4285714286, item-padding-x: 8px, item-padding-y: 6px))`
 
 </td>
 </tr>
@@ -8982,9 +8795,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9001,16 +8813,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #424242"></span>
 
+`#424242`
 
 </td>
 </tr>
@@ -9020,9 +8833,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9039,16 +8851,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`try-shade( $base-bg, .5 )`
+<span class="color-preview" style="background-color: #f0f0f0"></span>
+
+`#f0f0f0`
 
 </td>
 </tr>
@@ -9058,16 +8871,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -9077,9 +8891,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9096,9 +8909,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9115,16 +8927,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$primary`
+<span class="color-preview" style="background-color: #ff6358"></span>
+
+`#ff6358`
 
 </td>
 </tr>
@@ -9134,16 +8947,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-text`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -9153,9 +8967,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9172,9 +8985,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9191,16 +9003,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-item-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$focused-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.13)`
 
 </td>
 </tr>
@@ -9210,14 +9021,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9229,16 +9041,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ff6358"></span>
 
+`#ff6358`
 
 </td>
 </tr>
@@ -9248,9 +9061,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9267,14 +9079,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9286,16 +9099,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #d6534a"></span>
 
+`#d6534a`
 
 </td>
 </tr>
@@ -9305,9 +9119,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9324,14 +9137,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9343,16 +9157,17 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$link-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #d6534a"></span>
 
+`#d6534a`
 
 </td>
 </tr>
@@ -9362,9 +9177,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9381,16 +9195,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-treeview-item-focus-shadow`
 
 </td>
 <td>
 
-
+`inset 0 0 0 2px rgba(0, 0, 0, 0.13)`
 
 </td>
 </tr>
@@ -9421,9 +9234,8 @@ The following table lists the available variables for customizing the Default th
 <tbody>
         <tr>
     <td>$enable-typography</td>
-    <td></td>
+    <td>Bool</td>
 <td>
-
 
 `false`
 
@@ -9440,9 +9252,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -9459,9 +9270,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -9478,9 +9288,8 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$font-family-monospace</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
 
@@ -9497,16 +9306,15 @@ The following table lists the available variables for customizing the Default th
 </tr>
 <tr>
     <td>$line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(20 / 14)`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-avatar.md
+++ b/packages/material/docs/customization-avatar.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-avatar-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`(28 / 14)`
+`2`
 
 </td>
 </tr>
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 4 ),
@@ -116,11 +111,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 4 ),
-    md: map-get( $spacing, 8 ),
-    lg: map-get( $spacing, 16 )
-)`
+`(sm: 16px, md: 32px, lg: 64px)`
 
 </td>
 </tr>
@@ -130,16 +121,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-avatar-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #3f51b5, "secondary": #e51a5f, "tertiary": #00695c, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #f5f5f5, "inverse": #424242)`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-button.md
+++ b/packages/material/docs/customization-button.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-button-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-border-radius</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -141,16 +135,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `( 20 / 14 )`
 
 </td>
 <td>
 
-`( 20 / 14 )`
+`1.4285714286`
 
 </td>
 </tr>
@@ -160,16 +153,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
+`calc( 1.4285714286em + 16px + 2px )`
 
 </td>
 </tr>
@@ -179,16 +171,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-inner-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
+`calc( 1.4285714286em + 16px )`
 
 </td>
 </tr>
@@ -198,9 +189,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `map-merge(
     $kendo-theme-colors,
@@ -210,10 +200,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`map-merge(
-    $kendo-theme-colors,
-    ( "base": $base-bg )
-)`
+`("primary": #3f51b5, "secondary": #e51a5f, "tertiary": #00695c, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #f5f5f5, "inverse": #424242, "base": white)`
 
 </td>
 </tr>
@@ -223,16 +210,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-bg`
 
 </td>
 <td>
 
-`map-get( $theme, base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -242,16 +230,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -261,16 +250,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
 <td>
 
-`map-get( $theme, base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -280,9 +270,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -299,16 +288,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$box-shadow-depth-2`
 
 </td>
 <td>
 
-`0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )`
+`0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -318,9 +306,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -337,9 +324,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -356,9 +342,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -375,9 +360,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -394,9 +378,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -413,9 +396,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -432,9 +414,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -451,9 +432,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -470,9 +450,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -489,16 +468,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$box-shadow-depth-3`
 
 </td>
 <td>
 
-`0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )`
+`0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -508,9 +486,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-bg`
 
@@ -527,9 +504,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-text`
 
@@ -546,9 +522,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-bg`
 
@@ -565,9 +540,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -584,9 +558,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-selected-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -603,9 +576,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -622,9 +594,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -641,9 +612,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -660,9 +630,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -679,9 +648,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -698,16 +666,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $body-bg, 12% )`
 
 </td>
 <td>
 
-`try-shade( $body-bg, 12% )`
+<span class="color-preview" style="background-color: #e0e0e0"></span>
+
+`#e0e0e0`
 
 </td>
 </tr>
@@ -717,16 +686,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$disabled-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.38)"></span>
 
+`rgba(0, 0, 0, 0.38)`
 
 </td>
 </tr>
@@ -736,16 +706,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-disabled-bg`
 
 </td>
 <td>
 
-`try-shade( $body-bg, 12% )`
+<span class="color-preview" style="background-color: #e0e0e0"></span>
+
+`#e0e0e0`
 
 </td>
 </tr>
@@ -755,9 +726,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -774,9 +744,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-disabled-shadow</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `none`
 
@@ -793,16 +762,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-hover-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.08`
 
 </td>
 <td>
 
-`.08`
+`0.08`
 
 </td>
 </tr>
@@ -812,16 +780,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-focus-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.12`
 
 </td>
 <td>
 
-`.12`
+`0.12`
 
 </td>
 </tr>
@@ -831,16 +798,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-active-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.16`
 
 </td>
 <td>
 
-`.16`
+`0.16`
 
 </td>
 </tr>
@@ -850,16 +816,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-flat-button-selected-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.22`
 
 </td>
 <td>
 
-`.22`
+`0.22`
 
 </td>
 </tr>
@@ -869,16 +834,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-transition</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `box-shadow 280ms cubic-bezier( .4, 0, .2, 1 )`
 
 </td>
 <td>
 
-`box-shadow 280ms cubic-bezier( .4, 0, .2, 1 )`
+`box-shadow 280ms cubic-bezier(0.4, 0, 0.2, 1)`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-charts.md
+++ b/packages/material/docs/customization-charts.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$series-a</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( purple, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( purple, 500 )`
+<span class="color-preview" style="background-color: #9c27b0"></span>
+
+`#9c27b0`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-b</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( blue, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( blue, 500 )`
+<span class="color-preview" style="background-color: #2196f3"></span>
+
+`#2196f3`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-c</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( teal, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( teal, 500 )`
+<span class="color-preview" style="background-color: #009688"></span>
+
+`#009688`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-d</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( yellow, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( yellow, 500 )`
+<span class="color-preview" style="background-color: #ffeb3b"></span>
+
+`#ffeb3b`
 
 </td>
 </tr>
@@ -103,16 +107,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-e</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( red, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( red, 500 )`
+<span class="color-preview" style="background-color: #f44336"></span>
+
+`#f44336`
 
 </td>
 </tr>
@@ -122,16 +127,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-f</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( green, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( green, 500 )`
+<span class="color-preview" style="background-color: #4caf50"></span>
+
+`#4caf50`
 
 </td>
 </tr>
@@ -141,16 +147,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$series-1</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$series-a`
 
 </td>
 <td>
 
-`get-base-hue( purple, 500 )`
+<span class="color-preview" style="background-color: #9c27b0"></span>
+
+`#9c27b0`
 
 </td>
 </tr>
@@ -160,16 +167,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$chart-major-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .08 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -179,16 +187,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$chart-minor-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .04 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-checkbox.md
+++ b/packages/material/docs/customization-checkbox.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-checkbox-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -84,16 +81,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .54 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .54 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -103,9 +101,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -122,9 +119,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +137,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,16 +155,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -179,16 +175,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-checked-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -198,16 +195,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -217,16 +215,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -236,16 +235,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -255,16 +255,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -274,9 +275,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -293,9 +293,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -312,9 +311,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +329,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,9 +347,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,9 +365,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -388,16 +383,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $component-bg, 4 )`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -407,16 +403,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-disabled-border`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -426,16 +423,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-disabled-checked-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-disabled-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -445,16 +443,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-bg`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -464,9 +463,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -483,16 +481,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -502,16 +501,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -521,9 +521,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -540,9 +539,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -559,9 +557,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e118"`
 
@@ -578,9 +575,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e121"`
 
@@ -597,16 +593,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3e%3cpath fill='none' stroke='white' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -616,16 +611,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='white' stroke-width='3' d='M4 10h12'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -635,16 +629,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -654,16 +647,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -673,9 +665,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -692,16 +683,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`8px`
 
 </td>
 </tr>
@@ -711,16 +701,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -730,16 +721,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.2`
 
 </td>
 <td>
 
-`.2`
+`0.2`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-chip.md
+++ b/packages/material/docs/customization-chip.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-chip-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(18 / 14)`
 
 </td>
 <td>
 
-`(18 / 14)`
+`1.2857142857`
 
 </td>
 </tr>
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -169,26 +162,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        padding-x: $kendo-chip-padding-x-sm,
-        padding-y: $kendo-chip-padding-y-sm,
-        font-size: $kendo-chip-font-size-sm,
-        line-height: $kendo-chip-line-height-sm
-    ),
-    md: (
-        padding-x: $kendo-chip-padding-x-md,
-        padding-y: $kendo-chip-padding-y-md,
-        font-size: $kendo-chip-font-size-md,
-        line-height: $kendo-chip-line-height-md
-    ),
-    lg: (
-        padding-x: $kendo-chip-padding-x-lg,
-        padding-y: $kendo-chip-padding-y-lg,
-        font-size: $kendo-chip-font-size-lg,
-        line-height: $kendo-chip-line-height-lg
-    )
-)`
+`(sm: (padding-x: 4px, padding-y: 2px, font-size: 14px, line-height: 1.2857142857), md: (padding-x: 4px, padding-y: 4px, font-size: 14px, line-height: 1.2857142857), lg: (padding-x: 4px, padding-y: 6px, font-size: 14px, line-height: 1.2857142857))`
 
 </td>
 </tr>
@@ -198,16 +172,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $white, $kendo-button-text )`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -217,9 +192,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     "base": $kendo-chip-base-bg,
@@ -232,13 +206,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    "base": $kendo-chip-base-bg,
-    "error": map-get( $kendo-theme-colors, "error" ),
-    "info": map-get( $kendo-theme-colors, "info" ),
-    "warning": map-get( $kendo-theme-colors, "warning" ),
-    "success": map-get( $kendo-theme-colors, "success" )
-)`
+`("base": rgba(0, 0, 0, 0.87), "error": #f31700, "info": #0058e9, "warning": #ffc000, "success": #37b400)`
 
 </td>
 </tr>
@@ -248,16 +216,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: rgba(239, 239, 239, 0.9896)"></span>
+
+`rgba(239, 239, 239, 0.9896)`
 
 </td>
 </tr>
@@ -267,16 +236,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -286,16 +256,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 70% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 70% )`
+<span class="color-preview" style="background-color: rgba(192, 192, 192, 0.961)"></span>
+
+`rgba(192, 192, 192, 0.961)`
 
 </td>
 </tr>
@@ -305,9 +276,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -324,16 +294,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: rgba(239, 239, 239, 0.9896)"></span>
+
+`rgba(239, 239, 239, 0.9896)`
 
 </td>
 </tr>
@@ -343,9 +314,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -362,16 +332,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 84% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 84% )`
+<span class="color-preview" style="background-color: rgba(222, 222, 222, 0.9792)"></span>
+
+`rgba(222, 222, 222, 0.9792)`
 
 </td>
 </tr>
@@ -381,9 +352,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -400,16 +370,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 76% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 76% )`
+<span class="color-preview" style="background-color: rgba(205, 205, 205, 0.9688)"></span>
+
+`rgba(205, 205, 205, 0.9688)`
 
 </td>
 </tr>
@@ -419,9 +390,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -438,16 +408,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -457,16 +428,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -476,16 +448,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -495,9 +468,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -514,16 +486,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -533,16 +506,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-chip-base-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -552,16 +526,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -571,16 +546,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -590,9 +566,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-chip-list-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 1 ),
@@ -603,11 +578,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 1 ),
-    md: map-get( $spacing, 1 ),
-    lg: map-get( $spacing, 1 )
-)`
+`(sm: 4px, md: 4px, lg: 4px)`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-color-system.md
+++ b/packages/material/docs/customization-color-system.md
@@ -30,13 +30,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `material-color( $primary-palette, main )`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -49,13 +50,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `material-color( $primary-palette, main-contrast )`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main-contrast )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -68,13 +70,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `material-color( $secondary-palette, main )`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main )`
+<span class="color-preview" style="background-color: #e51a5f"></span>
+
+`#e51a5f`
 
 </td>
 </tr>
@@ -87,13 +90,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `material-color( $secondary-palette, main-contrast )`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main-contrast )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -106,13 +110,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `material-color($tertiary-palette, main)`
 
 </td>
 <td>
 
-`material-color($tertiary-palette, main)`
+<span class="color-preview" style="background-color: #00695c"></span>
+
+`#00695c`
 
 </td>
 </tr>
@@ -125,13 +130,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `material-color($tertiary-palette, main-contrast)`
 
 </td>
 <td>
 
-`material-color($tertiary-palette, main-contrast)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -143,12 +149,15 @@ The following table lists the available variables for customization.
     <td>$info</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
 </td>
-<td><span class="color-preview" style="background-color: #0058e9"></span>
+<td>
+
+<span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
@@ -162,12 +171,15 @@ The following table lists the available variables for customization.
     <td>$success</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
 </td>
-<td><span class="color-preview" style="background-color: #37b400"></span>
+<td>
+
+<span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
@@ -181,12 +193,15 @@ The following table lists the available variables for customization.
     <td>$warning</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
 </td>
-<td><span class="color-preview" style="background-color: #ffc000"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
@@ -200,12 +215,15 @@ The following table lists the available variables for customization.
     <td>$error</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
 </td>
-<td><span class="color-preview" style="background-color: #f31700"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
@@ -220,13 +238,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `get-base-hue( gray, 800 )`
 
 </td>
 <td>
 
-`get-base-hue( gray, 800 )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -239,13 +258,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `get-base-hue( gray, 100 )`
 
 </td>
 <td>
 
-`get-base-hue( gray, 100 )`
+<span class="color-preview" style="background-color: #f5f5f5"></span>
+
+`#f5f5f5`
 
 </td>
 </tr>
@@ -255,16 +275,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$inverse</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $light, $dark )`
 
 </td>
 <td>
 
-`if( $dark-theme, $light, $dark )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-common.md
+++ b/packages/material/docs/customization-common.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -46,16 +45,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get( $theme, base-bg )`
 
 </td>
 <td>
 
-`map-get( $theme, base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -65,16 +65,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get($theme, component-text)`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -84,16 +85,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if($theme-type == dark, white, black), .08 )`
 
 </td>
 <td>
 
-`rgba( if($theme-type == dark, white, black), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -103,9 +105,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$base-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -122,16 +123,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get( $theme, hover-bg )`
 
 </td>
 <td>
 
-`map-get( $theme, hover-bg )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -141,16 +143,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -160,16 +163,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if($theme-type == dark, white, black), .15 )`
 
 </td>
 <td>
 
-`rgba( if($theme-type == dark, white, black), .15 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.15)"></span>
+
+`rgba(0, 0, 0, 0.15)`
 
 </td>
 </tr>
@@ -179,9 +183,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,16 +201,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$secondary`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main )`
+<span class="color-preview" style="background-color: #e51a5f"></span>
+
+`#e51a5f`
 
 </td>
 </tr>
@@ -217,16 +221,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$secondary-contrast`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main-contrast )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -236,16 +241,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if($theme-type == dark, white, black), .1 )`
 
 </td>
 <td>
 
-`rgba( if($theme-type == dark, white, black), .1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1)"></span>
+
+`rgba(0, 0, 0, 0.1)`
 
 </td>
 </tr>
@@ -255,9 +261,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/material/docs/customization-component.md
+++ b/packages/material/docs/customization-component.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$component-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get($theme, component-bg)`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$component-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get($theme, component-text)`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$component-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get($theme, component-border)`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-floating-action-button.md
+++ b/packages/material/docs/customization-floating-action-button.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-fab-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(20 / 14)`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$padding-x`
 
 </td>
 <td>
 
-
+`16px`
 
 </td>
 </tr>
@@ -141,16 +135,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-padding-x`
 
 </td>
 <td>
 
-
+`16px`
 
 </td>
 </tr>
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-icon-width`
 
@@ -198,16 +189,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-icon-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 ) * 1.5`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 ) * 1.5`
+`6px`
 
 </td>
 </tr>
@@ -217,9 +207,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -236,16 +225,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -255,16 +243,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -274,16 +261,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-text-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -293,9 +279,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -312,9 +297,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -331,16 +315,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-xs`
 
 </td>
 <td>
 
-
+`10px`
 
 </td>
 </tr>
@@ -350,9 +333,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.2`
 
@@ -369,16 +351,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -388,16 +369,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -407,9 +387,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0`
 
@@ -426,9 +405,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -445,9 +423,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -464,9 +441,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-width`
 
@@ -483,16 +459,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #3f51b5, "secondary": #e51a5f, "tertiary": #00695c, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #f5f5f5, "inverse": #424242)`
 
 </td>
 </tr>
@@ -502,16 +477,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0px 3px 5px -1px rgba(0, 0, 0, .2), 0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12)`
 
 </td>
 <td>
 
-`0px 3px 5px -1px rgba(0, 0, 0, .2), 0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12)`
+`0px 3px 5px -1px rgba(0, 0, 0, 0.2), 0px 6px 10px rgba(0, 0, 0, 0.14), 0px 1px 18px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -521,16 +495,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0px 3px 5px -1px try-tint(rgba(0, 0, 0, .2), .5), 0px 6px 10px try-tint(rgba(0, 0, 0, .14), .5), 0px 1px 18px try-tint(rgba(0, 0, 0, .12), .5)`
 
 </td>
 <td>
 
-`0px 3px 5px -1px try-tint(rgba(0, 0, 0, .2), .5), 0px 6px 10px try-tint(rgba(0, 0, 0, .14), .5), 0px 1px 18px try-tint(rgba(0, 0, 0, .12), .5)`
+`0px 3px 5px -1px rgba(70, 70, 70, 0.232), 0px 6px 10px rgba(91, 91, 91, 0.1744), 0px 1px 18px rgba(101, 101, 101, 0.1552)`
 
 </td>
 </tr>
@@ -540,16 +513,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-active-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0px 5px 5px -3px rgba(0, 0, 0, .2), 0px 8px 10px 1px rgba(0, 0, 0, .14), 0px 3px 14px 2px rgba(0, 0, 0, .12)`
 
 </td>
 <td>
 
-`0px 5px 5px -3px rgba(0, 0, 0, .2), 0px 8px 10px 1px rgba(0, 0, 0, .14), 0px 3px 14px 2px rgba(0, 0, 0, .12)`
+`0px 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -559,16 +531,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -578,16 +551,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -597,16 +571,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -616,16 +591,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -635,16 +611,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
 <td>
 
-`map-get( $theme, base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -654,16 +631,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`map-get( $theme, base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -673,16 +651,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-shadow`
 
 </td>
 <td>
 
-`0px 3px 5px -1px rgba(0, 0, 0, .2), 0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12)`
+`0px 3px 5px -1px rgba(0, 0, 0, 0.2), 0px 6px 10px rgba(0, 0, 0, 0.14), 0px 1px 18px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -692,16 +669,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-disabled-shadow`
 
 </td>
 <td>
 
-`0px 3px 5px -1px try-tint(rgba(0, 0, 0, .2), .5), 0px 6px 10px try-tint(rgba(0, 0, 0, .14), .5), 0px 1px 18px try-tint(rgba(0, 0, 0, .12), .5)`
+`0px 3px 5px -1px rgba(70, 70, 70, 0.232), 0px 6px 10px rgba(91, 91, 91, 0.1744), 0px 1px 18px rgba(101, 101, 101, 0.1552)`
 
 </td>
 </tr>
@@ -711,16 +687,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-fab-item-active-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-active-shadow`
 
 </td>
 <td>
 
-`0px 5px 5px -3px rgba(0, 0, 0, .2), 0px 8px 10px 1px rgba(0, 0, 0, .14), 0px 3px 14px 2px rgba(0, 0, 0, .12)`
+`0px 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-grid.md
+++ b/packages/material/docs/customization-grid.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$grid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -103,16 +107,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
 
 </td>
 <td>
 
-`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -122,16 +127,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -141,9 +147,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-header-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,16 +165,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -179,16 +185,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
-`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -198,16 +205,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -217,14 +225,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -236,9 +245,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,9 +263,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-alt-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -274,16 +281,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( contrast-wcag( $grid-bg ), .07 )`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .07 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.07)"></span>
+
+`rgba(0, 0, 0, 0.07)`
 
 </td>
 </tr>
@@ -293,9 +301,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -312,16 +319,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -331,16 +339,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( contrast-wcag( $grid-bg ), .04 )`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -350,9 +359,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,16 +377,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$grid-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-icons.md
+++ b/packages/material/docs/customization-icons.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$icon-font-url</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/material/docs/customization-list.md
+++ b/packages/material/docs/customization-list.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-list-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 1px`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,9 +189,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -217,9 +207,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -236,9 +225,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,9 +243,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -274,9 +261,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -293,9 +279,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `1px 0 0`
 
@@ -312,9 +297,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +315,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,9 +333,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,16 +351,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -388,16 +371,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -407,16 +391,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -426,9 +411,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +429,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,9 +447,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -483,9 +465,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-header-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -502,9 +483,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,9 +501,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -540,16 +519,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`map-get( $theme, hover-bg )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -559,16 +539,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -578,16 +559,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-bg`
 
 </td>
 <td>
 
-`map-get( $theme, hover-bg )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -597,9 +579,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -616,9 +597,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -635,16 +615,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -654,16 +635,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$secondary`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main )`
+<span class="color-preview" style="background-color: #e51a5f"></span>
+
+`#e51a5f`
 
 </td>
 </tr>
@@ -673,9 +655,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -692,9 +673,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -711,9 +691,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -730,9 +709,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-group-item-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -749,16 +727,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-no-data-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
 
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-menu.md
+++ b/packages/material/docs/customization-menu.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-menu-popup-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$popup-border-width`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-lg`
 
 </td>
 <td>
 
-
+`16px`
 
 </td>
 </tr>
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.25`
 
@@ -122,16 +117,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: white"></span>
 
+`white`
 
 </td>
 </tr>
@@ -141,16 +137,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
 
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -160,16 +157,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
 
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -179,9 +177,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,16 +195,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -217,16 +213,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -236,16 +231,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-end</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
+`calc( 32px + 16px )`
 
 </td>
 </tr>
@@ -255,16 +249,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-start-sm</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-menu-popup-item-padding-x-sm`
 
 </td>
 <td>
 
-
+`16px`
 
 </td>
 </tr>
@@ -274,16 +267,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-end-sm</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
 
 </td>
 <td>
 
-`calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
+`calc(-1 * (calc( 32px + 16px ) - 8px))`
 
 </td>
 </tr>
@@ -293,9 +285,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -312,9 +303,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +321,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,9 +339,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,9 +357,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -388,16 +375,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-bg`
 
 </td>
 <td>
 
-`map-get( $theme, hover-bg )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -407,16 +395,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -426,9 +415,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +433,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,16 +451,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -483,16 +471,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-text`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main )`
+<span class="color-preview" style="background-color: #e51a5f"></span>
+
+`#e51a5f`
 
 </td>
 </tr>
@@ -502,9 +491,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,9 +509,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -540,9 +527,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/material/docs/customization-radio.md
+++ b/packages/material/docs/customization-radio.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-radio-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-text`
 
@@ -103,16 +99,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .54 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -122,9 +119,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +137,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,9 +155,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -179,9 +173,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,16 +191,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -217,16 +211,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-checked-text`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -236,9 +231,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-border`
 
@@ -255,9 +249,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-shadow`
 
@@ -274,9 +267,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-border`
 
@@ -293,9 +285,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-shadow`
 
@@ -312,9 +303,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +321,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,16 +339,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-disabled-border`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -369,9 +359,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -388,16 +377,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-disabled-border`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -407,16 +397,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-disabled-border`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -426,9 +417,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-invalid-bg`
 
@@ -445,16 +435,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -464,16 +455,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -483,9 +475,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -502,9 +493,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -521,9 +511,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e308"`
 
@@ -540,16 +529,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3e%3ccircle cx='50%25' cy='50%25' r='4' fill='%233f51b5'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -559,16 +547,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-disabled-checked-text}'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-disabled-checked-text}'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3e%3ccircle cx='50%25' cy='50%25' r='4' fill='%23adadad'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -578,16 +565,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -597,16 +583,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -616,9 +601,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -635,16 +619,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`8px`
 
 </td>
 </tr>
@@ -654,16 +637,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -673,16 +657,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-radio-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.2`
 
 </td>
 <td>
 
-`.2`
+`0.2`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-shadows.md
+++ b/packages/material/docs/customization-shadows.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$elevation</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get( $theme, elevation )`
 
 </td>
 <td>
 
-`map-get( $theme, elevation )`
+<span class="color-preview" style="background-color: black"></span>
+
+`black`
 
 </td>
 </tr>
@@ -46,16 +47,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$box-shadow-depth-1</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )`
 
 </td>
 <td>
 
-`0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )`
+`0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -65,16 +65,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$box-shadow-depth-2</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )`
 
 </td>
 <td>
 
-`0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )`
+`0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -84,16 +83,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$box-shadow-depth-3</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )`
 
 </td>
 <td>
 
-`0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )`
+`0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -103,16 +101,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$box-shadow-depth-4</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )`
 
 </td>
 <td>
 
-`0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )`
+`0 8px 10px -5px rgba(0, 0, 0, 0.2), 0 16px 24px 2px rgba(0, 0, 0, 0.14), 0 6px 30px 5px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -122,16 +119,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$box-shadow-depth-5</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )`
 
 </td>
 <td>
 
-`0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )`
+`0 11px 15px -7px rgba(0, 0, 0, 0.2), 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-switch.md
+++ b/packages/material/docs/customization-switch.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-switch-font-family</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-track-border-width</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-thumb-border-width</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-label-text-transform</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-label-display</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `none`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: ( font-size: null, track-width: 26px, track-height:  12px, thumb-width: 16px, thumb-height: 16px, thumb-offset: -2px, label-offset: 0px ),
@@ -135,11 +129,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: ( font-size: null, track-width: 26px, track-height:  12px, thumb-width: 16px, thumb-height: 16px, thumb-offset: -2px, label-offset: 0px ),
-    md: ( font-size: null, track-width: 32px, track-height:  14px, thumb-width: 20px, thumb-height: 20px, thumb-offset: -3px, label-offset: 0px ),
-    lg: ( font-size: null, track-width: 38px, track-height:  16px, thumb-width: 24px, thumb-height: 24px, thumb-offset: -4px, label-offset: 0px )
-)`
+`(sm: (font-size: null, track-width: 26px, track-height: 12px, thumb-width: 16px, thumb-height: 16px, thumb-offset: -2px, label-offset: 0px), md: (font-size: null, track-width: 32px, track-height: 14px, thumb-width: 20px, thumb-height: 20px, thumb-offset: -3px, label-offset: 0px), lg: (font-size: null, track-width: 38px, track-height: 16px, thumb-width: 24px, thumb-height: 24px, thumb-offset: -4px, label-offset: 0px))`
 
 </td>
 </tr>
@@ -149,16 +139,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .38 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .38 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.38)"></span>
+
+`rgba(0, 0, 0, 0.38)`
 
 </td>
 </tr>
@@ -168,9 +159,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -187,9 +177,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -206,9 +195,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -225,9 +213,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -244,9 +231,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -263,9 +249,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -282,9 +267,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -301,9 +285,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -320,9 +303,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -339,9 +321,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -358,9 +339,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -377,9 +357,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-ring</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -396,9 +375,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -415,9 +393,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -434,9 +411,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -453,9 +429,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -472,16 +447,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $black, $white )`
 
 </td>
 <td>
 
-`if( $dark-theme, $black, $white )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -491,9 +467,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -510,9 +485,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -529,9 +503,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -548,9 +521,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -567,9 +539,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -586,9 +557,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -605,9 +575,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -624,16 +593,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( $primary, .54 )`
 
 </td>
 <td>
 
-`rgba( $primary, .54 )`
+<span class="color-preview" style="background-color: rgba(63, 81, 181, 0.54)"></span>
+
+`rgba(63, 81, 181, 0.54)`
 
 </td>
 </tr>
@@ -643,9 +613,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -662,9 +631,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -681,9 +649,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -700,9 +667,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -719,9 +685,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -738,9 +703,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -757,9 +721,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -776,9 +739,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -795,9 +757,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -814,9 +775,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -833,9 +793,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -852,9 +811,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-ring</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -871,9 +829,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -890,9 +847,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -909,9 +865,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -928,9 +883,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -947,16 +901,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -966,9 +921,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -985,9 +939,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1004,9 +957,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1023,9 +975,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1042,9 +993,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1061,9 +1011,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1080,9 +1029,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 

--- a/packages/material/docs/customization-table.md
+++ b/packages/material/docs/customization-table.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-table-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-vertical-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-vertical-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -65,16 +63,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-horizontal-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-horizontal-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -103,9 +99,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -122,9 +117,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -188,26 +180,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: ( 20 / 14 ),
-        cell-padding-x: map-get( $spacing, 4 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: ( 20 / 14 ),
-        cell-padding-x: map-get( $spacing, 4 ),
-        cell-padding-y: map-get( $spacing, 2 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: ( 20 / 14 ),
-        cell-padding-x: map-get( $spacing, 4 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 16px, cell-padding-y: 10px), md: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 16px, cell-padding-y: 8px), lg: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 16px, cell-padding-y: 10px))`
 
 </td>
 </tr>
@@ -217,16 +190,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -236,16 +210,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -255,16 +230,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -274,16 +250,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -293,16 +270,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
-`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -312,16 +290,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -331,16 +310,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -350,16 +330,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-text`
 
 </td>
 <td>
 
-`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -369,16 +350,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -388,16 +370,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -407,16 +390,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-text`
 
 </td>
 <td>
 
-`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -426,16 +410,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-group-row-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -445,14 +430,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-alt-bg`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -464,9 +450,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-text`
 
@@ -483,9 +468,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-alt-row-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-border`
 
@@ -502,16 +486,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-hovered-bg`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .07 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.07)"></span>
+
+`rgba(0, 0, 0, 0.07)`
 
 </td>
 </tr>
@@ -521,9 +506,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-text`
 
@@ -540,16 +524,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-hovered-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -559,9 +544,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -578,9 +562,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -597,9 +580,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -616,16 +598,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-focused-shadow`
 
 </td>
 <td>
 
-
+`null`
 
 </td>
 </tr>
@@ -635,16 +616,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-bg`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -654,9 +636,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-selected-text`
 
@@ -673,16 +654,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-table-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-tabstrip.md
+++ b/packages/material/docs/customization-tabstrip.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$tabstrip-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -46,16 +45,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
 
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -65,16 +65,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -84,9 +85,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `24px`
 
@@ -103,9 +103,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -122,9 +121,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -141,9 +139,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -160,9 +157,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-gap</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -179,9 +175,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -198,16 +193,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
 
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -217,9 +213,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -236,9 +231,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,16 +249,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`map-get( $theme, hover-bg )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -274,16 +269,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
 
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -293,9 +289,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -312,9 +307,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +325,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,16 +343,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
 
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -369,9 +363,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -388,9 +381,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -407,16 +399,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -426,16 +417,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -445,9 +435,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -464,14 +453,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -483,9 +473,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -502,9 +491,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,16 +509,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$tabstrip-content-border-focused</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-toolbar.md
+++ b/packages/material/docs/customization-toolbar.md
@@ -27,16 +27,15 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$toolbar-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$toolbar-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>

--- a/packages/material/docs/customization-treeview.md
+++ b/packages/material/docs/customization-treeview.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-treeview-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
@@ -46,16 +45,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-lg`
 
 </td>
 <td>
 
-
+`16px`
 
 </td>
 </tr>
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.25`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-indent</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `16px`
 
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -122,16 +117,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -141,9 +135,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -160,9 +153,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-radius</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -179,9 +171,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -207,26 +198,7 @@ The following table lists the available variables for customization.
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-lg,
-        line-height: 1.25,
-        item-padding-x: map-get( $spacing, 4 ),
-        item-padding-y: map-get( $spacing, 2 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-lg,
-        line-height: 1.25,
-        item-padding-x: map-get( $spacing, 4 ),
-        item-padding-y: map-get( $spacing, 2 )
-    ),
-    lg: (
-        font-size: $font-size-lg,
-        line-height: 1.25,
-        item-padding-x: map-get( $spacing, 4 ),
-        item-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 16px, line-height: 1.25, item-padding-x: 16px, item-padding-y: 6px), md: (font-size: 16px, line-height: 1.25, item-padding-x: 16px, item-padding-y: 8px), lg: (font-size: 16px, line-height: 1.25, item-padding-x: 16px, item-padding-y: 10px))`
 
 </td>
 </tr>
@@ -236,9 +208,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -255,16 +226,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -274,9 +246,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -293,16 +264,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( $kendo-treeview-text, .07 )`
 
 </td>
 <td>
 
-`rgba( $kendo-treeview-text, .07 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.07)"></span>
+
+`rgba(0, 0, 0, 0.07)`
 
 </td>
 </tr>
@@ -312,9 +284,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -331,9 +302,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -350,9 +320,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -369,9 +338,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -388,16 +356,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$secondary`
+<span class="color-preview" style="background-color: #e51a5f"></span>
+
+`#e51a5f`
 
 </td>
 </tr>
@@ -407,9 +376,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -426,9 +394,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -445,9 +412,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-item-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -464,14 +430,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -483,9 +450,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-text</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -502,9 +468,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -521,14 +486,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -540,9 +506,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-text</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -559,9 +524,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -578,14 +542,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -597,9 +562,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-text</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -616,9 +580,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -635,9 +598,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-treeview-item-focus-shadow`
 

--- a/packages/material/docs/customization-typography.md
+++ b/packages/material/docs/customization-typography.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$enable-typography</td>
-    <td></td>
+    <td>Bool</td>
 <td>
-
 
 `false`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `Roboto, "Helvetica Neue", sans-serif`
 
@@ -84,9 +81,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-family-monospace</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
 
@@ -103,16 +99,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(28 / 14)`
 
 </td>
 <td>
 
-`(28 / 14)`
+`2`
 
 </td>
 </tr>

--- a/packages/material/docs/customization.md
+++ b/packages/material/docs/customization.md
@@ -31,9 +31,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -50,16 +49,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get( $theme, base-bg )`
 
 </td>
 <td>
 
-`map-get( $theme, base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -69,16 +69,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$base-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get($theme, component-text)`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -88,16 +89,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$base-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if($theme-type == dark, white, black), .08 )`
 
 </td>
 <td>
 
-`rgba( if($theme-type == dark, white, black), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -107,9 +109,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$base-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -126,16 +127,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get( $theme, hover-bg )`
 
 </td>
 <td>
 
-`map-get( $theme, hover-bg )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -145,16 +147,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -164,16 +167,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if($theme-type == dark, white, black), .15 )`
 
 </td>
 <td>
 
-`rgba( if($theme-type == dark, white, black), .15 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.15)"></span>
+
+`rgba(0, 0, 0, 0.15)`
 
 </td>
 </tr>
@@ -183,9 +187,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -202,16 +205,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$secondary`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main )`
+<span class="color-preview" style="background-color: #e51a5f"></span>
+
+`#e51a5f`
 
 </td>
 </tr>
@@ -221,16 +225,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$secondary-contrast`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main-contrast )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -240,16 +245,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if($theme-type == dark, white, black), .1 )`
 
 </td>
 <td>
 
-`rgba( if($theme-type == dark, white, black), .1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1)"></span>
+
+`rgba(0, 0, 0, 0.1)`
 
 </td>
 </tr>
@@ -259,9 +265,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -299,9 +304,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$kendo-avatar-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -318,9 +322,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-avatar-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
@@ -337,9 +340,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-avatar-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -356,16 +358,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-avatar-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$line-height`
 
 </td>
 <td>
 
-`(28 / 14)`
+`2`
 
 </td>
 </tr>
@@ -375,9 +376,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-avatar-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 4 ),
@@ -388,11 +388,7 @@ The following table lists the available variables for customizing the Material t
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 4 ),
-    md: map-get( $spacing, 8 ),
-    lg: map-get( $spacing, 16 )
-)`
+`(sm: 16px, md: 32px, lg: 64px)`
 
 </td>
 </tr>
@@ -402,16 +398,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-avatar-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #3f51b5, "secondary": #e51a5f, "tertiary": #00695c, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #f5f5f5, "inverse": #424242)`
 
 </td>
 </tr>
@@ -442,9 +437,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$kendo-button-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -461,9 +455,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-border-radius</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -480,16 +473,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -499,16 +491,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -518,9 +509,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
@@ -537,16 +527,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -556,16 +545,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `( 20 / 14 )`
 
 </td>
 <td>
 
-`( 20 / 14 )`
+`1.4285714286`
 
 </td>
 </tr>
@@ -575,16 +563,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} + #{$kendo-button-border-width * 2} )`
+`calc( 1.4285714286em + 16px + 2px )`
 
 </td>
 </tr>
@@ -594,16 +581,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-inner-calc-size</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-button-line-height * 1em} + #{$kendo-button-padding-y * 2} )`
+`calc( 1.4285714286em + 16px )`
 
 </td>
 </tr>
@@ -613,9 +599,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `map-merge(
     $kendo-theme-colors,
@@ -625,10 +610,7 @@ The following table lists the available variables for customizing the Material t
 </td>
 <td>
 
-`map-merge(
-    $kendo-theme-colors,
-    ( "base": $base-bg )
-)`
+`("primary": #3f51b5, "secondary": #e51a5f, "tertiary": #00695c, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #f5f5f5, "inverse": #424242, "base": white)`
 
 </td>
 </tr>
@@ -638,16 +620,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-bg`
 
 </td>
 <td>
 
-`map-get( $theme, base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -657,16 +640,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$base-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -676,16 +660,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
 <td>
 
-`map-get( $theme, base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -695,9 +680,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -714,16 +698,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$box-shadow-depth-2`
 
 </td>
 <td>
 
-`0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )`
+`0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -733,9 +716,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -752,9 +734,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -771,9 +752,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -790,9 +770,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -809,9 +788,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-hover-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -828,9 +806,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-active-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -847,9 +824,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-active-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -866,9 +842,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-active-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -885,9 +860,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-active-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -904,16 +878,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-active-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$box-shadow-depth-3`
 
 </td>
 <td>
 
-`0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )`
+`0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -923,9 +896,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-selected-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-bg`
 
@@ -942,9 +914,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-text`
 
@@ -961,9 +932,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-button-active-bg`
 
@@ -980,9 +950,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -999,9 +968,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-selected-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1018,9 +986,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1037,9 +1004,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1056,9 +1022,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1075,9 +1040,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1094,9 +1058,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1113,16 +1076,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-disabled-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $body-bg, 12% )`
 
 </td>
 <td>
 
-`try-shade( $body-bg, 12% )`
+<span class="color-preview" style="background-color: #e0e0e0"></span>
+
+`#e0e0e0`
 
 </td>
 </tr>
@@ -1132,16 +1096,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-disabled-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$disabled-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.38)"></span>
 
+`rgba(0, 0, 0, 0.38)`
 
 </td>
 </tr>
@@ -1151,16 +1116,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-disabled-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-disabled-bg`
 
 </td>
 <td>
 
-`try-shade( $body-bg, 12% )`
+<span class="color-preview" style="background-color: #e0e0e0"></span>
+
+`#e0e0e0`
 
 </td>
 </tr>
@@ -1170,9 +1136,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1189,9 +1154,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-disabled-shadow</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `none`
 
@@ -1208,16 +1172,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-flat-button-hover-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.08`
 
 </td>
 <td>
 
-`.08`
+`0.08`
 
 </td>
 </tr>
@@ -1227,16 +1190,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-flat-button-focus-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.12`
 
 </td>
 <td>
 
-`.12`
+`0.12`
 
 </td>
 </tr>
@@ -1246,16 +1208,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-flat-button-active-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.16`
 
 </td>
 <td>
 
-`.16`
+`0.16`
 
 </td>
 </tr>
@@ -1265,16 +1226,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-flat-button-selected-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.22`
 
 </td>
 <td>
 
-`.22`
+`0.22`
 
 </td>
 </tr>
@@ -1284,16 +1244,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-button-transition</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `box-shadow 280ms cubic-bezier( .4, 0, .2, 1 )`
 
 </td>
 <td>
 
-`box-shadow 280ms cubic-bezier( .4, 0, .2, 1 )`
+`box-shadow 280ms cubic-bezier(0.4, 0, 0.2, 1)`
 
 </td>
 </tr>
@@ -1324,16 +1283,17 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$series-a</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( purple, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( purple, 500 )`
+<span class="color-preview" style="background-color: #9c27b0"></span>
+
+`#9c27b0`
 
 </td>
 </tr>
@@ -1343,16 +1303,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$series-b</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( blue, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( blue, 500 )`
+<span class="color-preview" style="background-color: #2196f3"></span>
+
+`#2196f3`
 
 </td>
 </tr>
@@ -1362,16 +1323,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$series-c</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( teal, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( teal, 500 )`
+<span class="color-preview" style="background-color: #009688"></span>
+
+`#009688`
 
 </td>
 </tr>
@@ -1381,16 +1343,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$series-d</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( yellow, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( yellow, 500 )`
+<span class="color-preview" style="background-color: #ffeb3b"></span>
+
+`#ffeb3b`
 
 </td>
 </tr>
@@ -1400,16 +1363,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$series-e</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( red, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( red, 500 )`
+<span class="color-preview" style="background-color: #f44336"></span>
+
+`#f44336`
 
 </td>
 </tr>
@@ -1419,16 +1383,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$series-f</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `get-base-hue( green, 500 )`
 
 </td>
 <td>
 
-`get-base-hue( green, 500 )`
+<span class="color-preview" style="background-color: #4caf50"></span>
+
+`#4caf50`
 
 </td>
 </tr>
@@ -1438,16 +1403,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$series-1</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$series-a`
 
 </td>
 <td>
 
-`get-base-hue( purple, 500 )`
+<span class="color-preview" style="background-color: #9c27b0"></span>
+
+`#9c27b0`
 
 </td>
 </tr>
@@ -1457,16 +1423,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$chart-major-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .08 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1476,16 +1443,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$chart-minor-lines</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .04 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -1516,9 +1484,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$kendo-checkbox-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -1535,9 +1502,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1554,9 +1520,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1573,16 +1538,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .54 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .54 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -1592,9 +1558,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1611,9 +1576,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1630,9 +1594,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1649,16 +1612,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -1668,16 +1632,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-checked-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -1687,16 +1652,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -1706,16 +1672,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-bg`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -1725,16 +1692,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -1744,16 +1712,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-checked-border`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -1763,9 +1732,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1782,9 +1750,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1801,9 +1768,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1820,9 +1786,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-focus-checked-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1839,9 +1804,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1858,9 +1822,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1877,16 +1840,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $component-bg, 4 )`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -1896,16 +1860,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-disabled-border`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -1915,16 +1880,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-checkbox-disabled-checked-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-checkbox-disabled-checked-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -1934,16 +1900,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-disabled-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-disabled-checked-bg`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -1953,9 +1920,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -1972,16 +1938,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -1991,16 +1958,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -2010,9 +1978,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -2029,9 +1996,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -2048,9 +2014,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e118"`
 
@@ -2067,9 +2032,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e121"`
 
@@ -2086,16 +2050,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='none' stroke='#{$kendo-checkbox-checked-text}' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3e%3cpath fill='none' stroke='white' stroke-width='3' d='M4.1,12.7 9,17.6 20.3,6.3'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -2105,16 +2068,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-indeterminate-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$kendo-checkbox-indeterminate-text}' stroke-width='3' d='M4 10h12'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='white' stroke-width='3' d='M4 10h12'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -2124,16 +2086,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2143,16 +2104,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -2162,9 +2122,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -2181,16 +2140,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`8px`
 
 </td>
 </tr>
@@ -2200,16 +2158,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -2219,16 +2178,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-checkbox-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.2`
 
 </td>
 <td>
 
-`.2`
+`0.2`
 
 </td>
 </tr>
@@ -2259,9 +2217,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$kendo-chip-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -2278,16 +2235,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2297,16 +2253,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2316,16 +2271,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -2335,16 +2289,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-md`
 
 </td>
 <td>
 
-
+`14px`
 
 </td>
 </tr>
@@ -2354,16 +2307,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(18 / 14)`
 
 </td>
 <td>
 
-`(18 / 14)`
+`1.2857142857`
 
 </td>
 </tr>
@@ -2373,9 +2325,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -2401,26 +2352,7 @@ The following table lists the available variables for customizing the Material t
 </td>
 <td>
 
-`(
-    sm: (
-        padding-x: $kendo-chip-padding-x-sm,
-        padding-y: $kendo-chip-padding-y-sm,
-        font-size: $kendo-chip-font-size-sm,
-        line-height: $kendo-chip-line-height-sm
-    ),
-    md: (
-        padding-x: $kendo-chip-padding-x-md,
-        padding-y: $kendo-chip-padding-y-md,
-        font-size: $kendo-chip-font-size-md,
-        line-height: $kendo-chip-line-height-md
-    ),
-    lg: (
-        padding-x: $kendo-chip-padding-x-lg,
-        padding-y: $kendo-chip-padding-y-lg,
-        font-size: $kendo-chip-font-size-lg,
-        line-height: $kendo-chip-line-height-lg
-    )
-)`
+`(sm: (padding-x: 4px, padding-y: 2px, font-size: 14px, line-height: 1.2857142857), md: (padding-x: 4px, padding-y: 4px, font-size: 14px, line-height: 1.2857142857), lg: (padding-x: 4px, padding-y: 6px, font-size: 14px, line-height: 1.2857142857))`
 
 </td>
 </tr>
@@ -2430,16 +2362,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-base-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $white, $kendo-button-text )`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -2449,9 +2382,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     "base": $kendo-chip-base-bg,
@@ -2464,13 +2396,7 @@ The following table lists the available variables for customizing the Material t
 </td>
 <td>
 
-`(
-    "base": $kendo-chip-base-bg,
-    "error": map-get( $kendo-theme-colors, "error" ),
-    "info": map-get( $kendo-theme-colors, "info" ),
-    "warning": map-get( $kendo-theme-colors, "warning" ),
-    "success": map-get( $kendo-theme-colors, "success" )
-)`
+`("base": rgba(0, 0, 0, 0.87), "error": #f31700, "info": #0058e9, "warning": #ffc000, "success": #37b400)`
 
 </td>
 </tr>
@@ -2480,16 +2406,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-solid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: rgba(239, 239, 239, 0.9896)"></span>
+
+`rgba(239, 239, 239, 0.9896)`
 
 </td>
 </tr>
@@ -2499,16 +2426,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-solid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -2518,16 +2446,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-solid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 70% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 70% )`
+<span class="color-preview" style="background-color: rgba(192, 192, 192, 0.961)"></span>
+
+`rgba(192, 192, 192, 0.961)`
 
 </td>
 </tr>
@@ -2537,9 +2466,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-solid-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2556,16 +2484,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 92% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 92% )`
+<span class="color-preview" style="background-color: rgba(239, 239, 239, 0.9896)"></span>
+
+`rgba(239, 239, 239, 0.9896)`
 
 </td>
 </tr>
@@ -2575,9 +2504,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-solid-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2594,16 +2522,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 84% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 84% )`
+<span class="color-preview" style="background-color: rgba(222, 222, 222, 0.9792)"></span>
+
+`rgba(222, 222, 222, 0.9792)`
 
 </td>
 </tr>
@@ -2613,9 +2542,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-solid-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2632,16 +2560,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-tint( $kendo-chip-base-bg, 76% )`
 
 </td>
 <td>
 
-`try-tint( $kendo-chip-base-bg, 76% )`
+<span class="color-preview" style="background-color: rgba(205, 205, 205, 0.9688)"></span>
+
+`rgba(205, 205, 205, 0.9688)`
 
 </td>
 </tr>
@@ -2651,9 +2580,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-solid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2670,16 +2598,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-outline-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2689,16 +2618,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-outline-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -2708,16 +2638,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-outline-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -2727,9 +2658,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-outline-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -2746,16 +2676,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-base-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -2765,16 +2696,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-outline-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $kendo-chip-base-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2784,16 +2716,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-bg`
 
 </td>
 <td>
 
-`if( $dark-theme, $white, $kendo-button-text )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -2803,16 +2736,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-outline-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-chip-outline-hover-text`
 
 </td>
 <td>
 
-`contrast-wcag( $kendo-chip-base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2822,9 +2756,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-chip-list-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: map-get( $spacing, 1 ),
@@ -2835,11 +2768,7 @@ The following table lists the available variables for customizing the Material t
 </td>
 <td>
 
-`(
-    sm: map-get( $spacing, 1 ),
-    md: map-get( $spacing, 1 ),
-    lg: map-get( $spacing, 1 )
-)`
+`(sm: 4px, md: 4px, lg: 4px)`
 
 </td>
 </tr>
@@ -2873,13 +2802,14 @@ The following table lists the available variables for customizing the Material t
     <td>Color</td>
 <td>
 
-
 `material-color( $primary-palette, main )`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -2892,13 +2822,14 @@ The following table lists the available variables for customizing the Material t
     <td>Color</td>
 <td>
 
-
 `material-color( $primary-palette, main-contrast )`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main-contrast )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2911,13 +2842,14 @@ The following table lists the available variables for customizing the Material t
     <td>Color</td>
 <td>
 
-
 `material-color( $secondary-palette, main )`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main )`
+<span class="color-preview" style="background-color: #e51a5f"></span>
+
+`#e51a5f`
 
 </td>
 </tr>
@@ -2930,13 +2862,14 @@ The following table lists the available variables for customizing the Material t
     <td>Color</td>
 <td>
 
-
 `material-color( $secondary-palette, main-contrast )`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main-contrast )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2949,13 +2882,14 @@ The following table lists the available variables for customizing the Material t
     <td>Color</td>
 <td>
 
-
 `material-color($tertiary-palette, main)`
 
 </td>
 <td>
 
-`material-color($tertiary-palette, main)`
+<span class="color-preview" style="background-color: #00695c"></span>
+
+`#00695c`
 
 </td>
 </tr>
@@ -2968,13 +2902,14 @@ The following table lists the available variables for customizing the Material t
     <td>Color</td>
 <td>
 
-
 `material-color($tertiary-palette, main-contrast)`
 
 </td>
 <td>
 
-`material-color($tertiary-palette, main-contrast)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -2986,12 +2921,15 @@ The following table lists the available variables for customizing the Material t
     <td>$info</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
 </td>
-<td><span class="color-preview" style="background-color: #0058e9"></span>
+<td>
+
+<span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
@@ -3005,12 +2943,15 @@ The following table lists the available variables for customizing the Material t
     <td>$success</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
 </td>
-<td><span class="color-preview" style="background-color: #37b400"></span>
+<td>
+
+<span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
@@ -3024,12 +2965,15 @@ The following table lists the available variables for customizing the Material t
     <td>$warning</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
 </td>
-<td><span class="color-preview" style="background-color: #ffc000"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
@@ -3043,12 +2987,15 @@ The following table lists the available variables for customizing the Material t
     <td>$error</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
 </td>
-<td><span class="color-preview" style="background-color: #f31700"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
@@ -3063,13 +3010,14 @@ The following table lists the available variables for customizing the Material t
     <td>Color</td>
 <td>
 
-
 `get-base-hue( gray, 800 )`
 
 </td>
 <td>
 
-`get-base-hue( gray, 800 )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -3082,13 +3030,14 @@ The following table lists the available variables for customizing the Material t
     <td>Color</td>
 <td>
 
-
 `get-base-hue( gray, 100 )`
 
 </td>
 <td>
 
-`get-base-hue( gray, 100 )`
+<span class="color-preview" style="background-color: #f5f5f5"></span>
+
+`#f5f5f5`
 
 </td>
 </tr>
@@ -3098,16 +3047,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$inverse</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $light, $dark )`
 
 </td>
 <td>
 
-`if( $dark-theme, $light, $dark )`
+<span class="color-preview" style="background-color: #424242"></span>
+
+`#424242`
 
 </td>
 </tr>
@@ -3138,16 +3088,17 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$component-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get($theme, component-bg)`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -3157,16 +3108,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$component-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get($theme, component-text)`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -3176,16 +3128,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$component-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get($theme, component-border)`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -3216,9 +3169,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$kendo-fab-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -3235,9 +3187,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$border-radius`
 
@@ -3254,9 +3205,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
@@ -3273,9 +3223,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size`
 
@@ -3292,16 +3241,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(20 / 14)`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>
@@ -3311,16 +3259,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$padding-x`
 
 </td>
 <td>
 
-
+`16px`
 
 </td>
 </tr>
@@ -3330,16 +3277,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-padding-x`
 
 </td>
 <td>
 
-
+`16px`
 
 </td>
 </tr>
@@ -3349,9 +3295,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -3368,9 +3313,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-icon-width`
 
@@ -3387,16 +3331,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-icon-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 ) * 1.5`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 ) * 1.5`
+`6px`
 
 </td>
 </tr>
@@ -3406,9 +3349,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -3425,16 +3367,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-items-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -3444,16 +3385,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -3463,16 +3403,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-text-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-text-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -3482,9 +3421,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -3501,9 +3439,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-text-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -3520,16 +3457,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-text-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-xs`
 
 </td>
 <td>
 
-
+`10px`
 
 </td>
 </tr>
@@ -3539,9 +3475,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-text-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.2`
 
@@ -3558,16 +3493,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -3577,16 +3511,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-padding-x`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -3596,9 +3529,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0`
 
@@ -3615,9 +3547,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -3634,9 +3565,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `20px`
 
@@ -3653,9 +3583,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-fab-item-icon-width`
 
@@ -3672,16 +3601,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-theme-colors</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `$kendo-theme-colors`
 
 </td>
 <td>
 
-
+`("primary": #3f51b5, "secondary": #e51a5f, "tertiary": #00695c, "info": #0058e9, "success": #37b400, "warning": #ffc000, "error": #f31700, "dark": #424242, "light": #f5f5f5, "inverse": #424242)`
 
 </td>
 </tr>
@@ -3691,16 +3619,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0px 3px 5px -1px rgba(0, 0, 0, .2), 0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12)`
 
 </td>
 <td>
 
-`0px 3px 5px -1px rgba(0, 0, 0, .2), 0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12)`
+`0px 3px 5px -1px rgba(0, 0, 0, 0.2), 0px 6px 10px rgba(0, 0, 0, 0.14), 0px 1px 18px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -3710,16 +3637,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0px 3px 5px -1px try-tint(rgba(0, 0, 0, .2), .5), 0px 6px 10px try-tint(rgba(0, 0, 0, .14), .5), 0px 1px 18px try-tint(rgba(0, 0, 0, .12), .5)`
 
 </td>
 <td>
 
-`0px 3px 5px -1px try-tint(rgba(0, 0, 0, .2), .5), 0px 6px 10px try-tint(rgba(0, 0, 0, .14), .5), 0px 1px 18px try-tint(rgba(0, 0, 0, .12), .5)`
+`0px 3px 5px -1px rgba(70, 70, 70, 0.232), 0px 6px 10px rgba(91, 91, 91, 0.1744), 0px 1px 18px rgba(101, 101, 101, 0.1552)`
 
 </td>
 </tr>
@@ -3729,16 +3655,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-active-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0px 5px 5px -3px rgba(0, 0, 0, .2), 0px 8px 10px 1px rgba(0, 0, 0, .14), 0px 3px 14px 2px rgba(0, 0, 0, .12)`
 
 </td>
 <td>
 
-`0px 5px 5px -3px rgba(0, 0, 0, .2), 0px 8px 10px 1px rgba(0, 0, 0, .14), 0px 3px 14px 2px rgba(0, 0, 0, .12)`
+`0px 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -3748,16 +3673,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -3767,16 +3693,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -3786,16 +3713,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -3805,16 +3733,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -3824,16 +3753,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
 <td>
 
-`map-get( $theme, base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -3843,16 +3773,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-icon-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`map-get( $theme, base-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -3862,16 +3793,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-shadow`
 
 </td>
 <td>
 
-`0px 3px 5px -1px rgba(0, 0, 0, .2), 0px 6px 10px rgba(0, 0, 0, .14), 0px 1px 18px rgba(0, 0, 0, .12)`
+`0px 3px 5px -1px rgba(0, 0, 0, 0.2), 0px 6px 10px rgba(0, 0, 0, 0.14), 0px 1px 18px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -3881,16 +3811,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-disabled-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-disabled-shadow`
 
 </td>
 <td>
 
-`0px 3px 5px -1px try-tint(rgba(0, 0, 0, .2), .5), 0px 6px 10px try-tint(rgba(0, 0, 0, .14), .5), 0px 1px 18px try-tint(rgba(0, 0, 0, .12), .5)`
+`0px 3px 5px -1px rgba(70, 70, 70, 0.232), 0px 6px 10px rgba(91, 91, 91, 0.1744), 0px 1px 18px rgba(101, 101, 101, 0.1552)`
 
 </td>
 </tr>
@@ -3900,16 +3829,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-fab-item-active-shadow</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-fab-active-shadow`
 
 </td>
 <td>
 
-`0px 5px 5px -3px rgba(0, 0, 0, .2), 0px 8px 10px 1px rgba(0, 0, 0, .14), 0px 3px 14px 2px rgba(0, 0, 0, .12)`
+`0px 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -3940,16 +3868,17 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$grid-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -3959,16 +3888,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -3978,16 +3908,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -3997,16 +3928,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -4016,16 +3948,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
 
 </td>
 <td>
 
-`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -4035,16 +3968,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -4054,9 +3988,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-header-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4073,16 +4006,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -4092,16 +4026,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
-`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -4111,16 +4046,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -4130,14 +4066,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-alt-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -4149,9 +4086,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-alt-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4168,9 +4104,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-alt-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4187,16 +4122,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( contrast-wcag( $grid-bg ), .07 )`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .07 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.07)"></span>
+
+`rgba(0, 0, 0, 0.07)`
 
 </td>
 </tr>
@@ -4206,9 +4142,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-hovered-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4225,16 +4160,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-hovered-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -4244,16 +4180,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( contrast-wcag( $grid-bg ), .04 )`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -4263,9 +4200,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4282,16 +4218,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$grid-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -4322,9 +4259,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$icon-font-url</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4362,9 +4298,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$kendo-list-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4381,9 +4316,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4400,9 +4334,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-header-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4419,9 +4352,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-header-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4438,9 +4370,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-header-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 0 1px`
 
@@ -4457,9 +4388,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-header-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4476,9 +4406,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-header-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4495,9 +4424,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-header-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4514,9 +4442,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4533,9 +4460,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4552,9 +4478,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4571,9 +4496,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4590,9 +4514,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4609,9 +4532,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-group-item-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4628,9 +4550,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-group-item-border-width</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `1px 0 0`
 
@@ -4647,9 +4568,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4666,9 +4586,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-group-item-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4685,9 +4604,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-group-item-font-weight</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4704,16 +4622,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -4723,16 +4642,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -4742,16 +4662,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -4761,9 +4682,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-header-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4780,9 +4700,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-header-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4799,9 +4718,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-header-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -4818,9 +4736,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-header-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4837,9 +4754,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4856,9 +4772,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4875,16 +4790,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`map-get( $theme, hover-bg )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -4894,16 +4810,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -4913,16 +4830,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-bg`
 
 </td>
 <td>
 
-`map-get( $theme, hover-bg )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -4932,9 +4850,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4951,9 +4868,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -4970,16 +4886,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -4989,16 +4906,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$secondary`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main )`
+<span class="color-preview" style="background-color: #e51a5f"></span>
+
+`#e51a5f`
 
 </td>
 </tr>
@@ -5008,9 +4926,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-group-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5027,9 +4944,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-group-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5046,9 +4962,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-group-item-border</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -5065,9 +4980,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-group-item-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5084,16 +4998,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-list-no-data-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
 
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -5124,9 +5039,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$kendo-menu-popup-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5143,9 +5057,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5162,16 +5075,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$popup-border-width`
 
 </td>
 <td>
 
-
+`0px`
 
 </td>
 </tr>
@@ -5181,16 +5093,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-lg`
 
 </td>
 <td>
 
-
+`16px`
 
 </td>
 </tr>
@@ -5200,9 +5111,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.25`
 
@@ -5219,16 +5129,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: white"></span>
 
+`white`
 
 </td>
 </tr>
@@ -5238,16 +5149,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
 
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -5257,16 +5169,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$popup-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
 
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -5276,9 +5189,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5295,16 +5207,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -5314,16 +5225,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -5333,16 +5243,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-padding-end</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
 
 </td>
 <td>
 
-`calc( #{$kendo-menu-popup-item-padding-x * 2} + #{$icon-size} )`
+`calc( 32px + 16px )`
 
 </td>
 </tr>
@@ -5352,16 +5261,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-start-sm</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-menu-popup-item-padding-x-sm`
 
 </td>
 <td>
 
-
+`16px`
 
 </td>
 </tr>
@@ -5371,16 +5279,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-icon-margin-end-sm</td>
-    <td></td>
+    <td>Calculation</td>
 <td>
-
 
 `calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
 
 </td>
 <td>
 
-`calc( -1 * (#{$kendo-menu-popup-item-padding-end-sm} - #{$kendo-menu-popup-item-padding-x-sm / 2}) )`
+`calc(-1 * (calc( 32px + 16px ) - 8px))`
 
 </td>
 </tr>
@@ -5390,9 +5297,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -5409,9 +5315,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5428,9 +5333,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5447,9 +5351,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5466,9 +5369,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5485,16 +5387,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-bg`
 
 </td>
 <td>
 
-`map-get( $theme, hover-bg )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -5504,16 +5407,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-hover-text`
 
 </td>
 <td>
 
-`$base-text`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -5523,9 +5427,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5542,9 +5445,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5561,16 +5463,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -5580,16 +5483,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-list-item-selected-text`
 
 </td>
 <td>
 
-`material-color( $secondary-palette, main )`
+<span class="color-preview" style="background-color: #e51a5f"></span>
+
+`#e51a5f`
 
 </td>
 </tr>
@@ -5599,9 +5503,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5618,9 +5521,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-expanded-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5637,9 +5539,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-menu-popup-item-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5677,9 +5578,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$kendo-radio-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `50%`
 
@@ -5696,9 +5596,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `2px`
 
@@ -5715,9 +5614,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-bg`
 
@@ -5734,9 +5632,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-text`
 
@@ -5753,16 +5650,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-border`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .54 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -5772,9 +5670,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5791,9 +5688,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5810,9 +5706,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5829,9 +5724,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5848,16 +5742,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -5867,16 +5762,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-checked-text`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -5886,9 +5782,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-border`
 
@@ -5905,9 +5800,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-shadow`
 
@@ -5924,9 +5818,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-border`
 
@@ -5943,9 +5836,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-focus-checked-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-focus-checked-shadow`
 
@@ -5962,9 +5854,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -5981,9 +5872,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6000,16 +5890,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-disabled-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-disabled-border`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -6019,9 +5910,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6038,16 +5928,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-disabled-border`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -6057,16 +5948,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-radio-disabled-border`
 
 </td>
 <td>
 
-`try-shade( $component-bg, 4 )`
+<span class="color-preview" style="background-color: #adadad"></span>
+
+`#adadad`
 
 </td>
 </tr>
@@ -6076,9 +5968,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-invalid-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-checkbox-invalid-bg`
 
@@ -6095,16 +5986,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-invalid-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -6114,16 +6006,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-invalid-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-checkbox-invalid-border`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #f31700"></span>
 
+`#f31700`
 
 </td>
 </tr>
@@ -6133,9 +6026,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-indicator-type</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `image`
 
@@ -6152,9 +6044,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-glyph-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `"WebComponentsIcons", monospace`
 
@@ -6171,9 +6062,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-checked-glyph</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `"\e308"`
 
@@ -6190,16 +6080,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-checked-text}'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3e%3ccircle cx='50%25' cy='50%25' r='4' fill='%233f51b5'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -6209,16 +6098,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-disabled-checked-image</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-disabled-checked-text}'/></svg>") )`
 
 </td>
 <td>
 
-`escape-svg( url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><circle cx='50%' cy='50%' r='4' fill='#{$kendo-radio-disabled-checked-text}'/></svg>") )`
+`url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3e%3ccircle cx='50%25' cy='50%25' r='4' fill='%23adadad'/%3e%3c/svg%3e")`
 
 </td>
 </tr>
@@ -6228,16 +6116,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-label-margin-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 1 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 1 )`
+`4px`
 
 </td>
 </tr>
@@ -6247,16 +6134,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-list-spacing</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -6266,9 +6152,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -6285,16 +6170,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-list-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$kendo-list-item-padding-y-md`
 
 </td>
 <td>
 
-
+`8px`
 
 </td>
 </tr>
@@ -6304,16 +6188,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-ripple-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -6323,16 +6208,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-radio-ripple-opacity</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `.2`
 
 </td>
 <td>
 
-`.2`
+`0.2`
 
 </td>
 </tr>
@@ -6363,16 +6247,17 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$elevation</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `map-get( $theme, elevation )`
 
 </td>
 <td>
 
-`map-get( $theme, elevation )`
+<span class="color-preview" style="background-color: black"></span>
+
+`black`
 
 </td>
 </tr>
@@ -6382,16 +6267,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$box-shadow-depth-1</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )`
 
 </td>
 <td>
 
-`0 2px 1px -1px rgba( $elevation, .2 ), 0 1px 1px 0 rgba( $elevation, .14 ), 0 1px 3px 0 rgba( $elevation, .12 )`
+`0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -6401,16 +6285,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$box-shadow-depth-2</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )`
 
 </td>
 <td>
 
-`0 3px 1px -2px rgba( $elevation, .2 ), 0 2px 2px 0 rgba( $elevation, .14 ), 0 1px 5px 0 rgba( $elevation, .12 )`
+`0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -6420,16 +6303,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$box-shadow-depth-3</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )`
 
 </td>
 <td>
 
-`0 5px 5px -3px rgba( $elevation, .2 ), 0 8px 10px 1px rgba( $elevation, .14 ), 0 3px 14px 2px rgba( $elevation, .12 )`
+`0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -6439,16 +6321,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$box-shadow-depth-4</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )`
 
 </td>
 <td>
 
-`0 8px 10px -5px rgba( $elevation, .2 ), 0 16px 24px 2px rgba( $elevation, .14 ), 0 6px 30px 5px rgba( $elevation, .12 )`
+`0 8px 10px -5px rgba(0, 0, 0, 0.2), 0 16px 24px 2px rgba(0, 0, 0, 0.14), 0 6px 30px 5px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -6458,16 +6339,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$box-shadow-depth-5</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )`
 
 </td>
 <td>
 
-`0 11px 15px -7px rgba( $elevation, .2 ), 0 24px 38px 3px rgba( $elevation, .14 ), 0 9px 46px 8px rgba( $elevation, .12 )`
+`0 11px 15px -7px rgba(0, 0, 0, 0.2), 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -6498,9 +6378,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$kendo-switch-font-family</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6517,9 +6396,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-track-border-width</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6536,9 +6414,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-thumb-border-width</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6555,9 +6432,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-label-text-transform</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6574,9 +6450,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-label-display</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `none`
 
@@ -6593,9 +6468,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: ( font-size: null, track-width: 26px, track-height:  12px, thumb-width: 16px, thumb-height: 16px, thumb-offset: -2px, label-offset: 0px ),
@@ -6606,11 +6480,7 @@ The following table lists the available variables for customizing the Material t
 </td>
 <td>
 
-`(
-    sm: ( font-size: null, track-width: 26px, track-height:  12px, thumb-width: 16px, thumb-height: 16px, thumb-offset: -2px, label-offset: 0px ),
-    md: ( font-size: null, track-width: 32px, track-height:  14px, thumb-width: 20px, thumb-height: 20px, thumb-offset: -3px, label-offset: 0px ),
-    lg: ( font-size: null, track-width: 38px, track-height:  16px, thumb-width: 24px, thumb-height: 24px, thumb-offset: -4px, label-offset: 0px )
-)`
+`(sm: (font-size: null, track-width: 26px, track-height: 12px, thumb-width: 16px, thumb-height: 16px, thumb-offset: -2px, label-offset: 0px), md: (font-size: null, track-width: 32px, track-height: 14px, thumb-width: 20px, thumb-height: 20px, thumb-offset: -3px, label-offset: 0px), lg: (font-size: null, track-width: 38px, track-height: 16px, thumb-width: 24px, thumb-height: 24px, thumb-offset: -4px, label-offset: 0px))`
 
 </td>
 </tr>
@@ -6620,16 +6490,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( if( $dark-theme, $white, $black ), .38 )`
 
 </td>
 <td>
 
-`rgba( if( $dark-theme, $white, $black ), .38 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.38)"></span>
+
+`rgba(0, 0, 0, 0.38)`
 
 </td>
 </tr>
@@ -6639,9 +6510,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6658,9 +6528,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6677,9 +6546,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6696,9 +6564,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6715,9 +6582,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6734,9 +6600,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6753,9 +6618,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6772,9 +6636,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6791,9 +6654,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6810,9 +6672,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6829,9 +6690,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6848,9 +6708,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-focus-ring</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6867,9 +6726,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6886,9 +6744,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6905,9 +6762,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6924,9 +6780,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6943,16 +6798,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $black, $white )`
 
 </td>
 <td>
 
-`if( $dark-theme, $black, $white )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -6962,9 +6818,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -6981,9 +6836,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7000,9 +6854,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7019,9 +6872,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7038,9 +6890,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7057,9 +6908,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7076,9 +6926,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-off-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7095,16 +6944,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( $primary, .54 )`
 
 </td>
 <td>
 
-`rgba( $primary, .54 )`
+<span class="color-preview" style="background-color: rgba(63, 81, 181, 0.54)"></span>
+
+`rgba(63, 81, 181, 0.54)`
 
 </td>
 </tr>
@@ -7114,9 +6964,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7133,9 +6982,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7152,9 +7000,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7171,9 +7018,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7190,9 +7036,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7209,9 +7054,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7228,9 +7072,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7247,9 +7090,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7266,9 +7108,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7285,9 +7126,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7304,9 +7144,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7323,9 +7162,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-focus-ring</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7342,9 +7180,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7361,9 +7198,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7380,9 +7216,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7399,9 +7234,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-track-disabled-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7418,16 +7252,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
 <td>
 
-`material-color( $primary-palette, main )`
+<span class="color-preview" style="background-color: #3f51b5"></span>
+
+`#3f51b5`
 
 </td>
 </tr>
@@ -7437,9 +7272,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7456,9 +7290,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7475,9 +7308,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7494,9 +7326,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7513,9 +7344,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7532,9 +7362,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7551,9 +7380,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-switch-on-thumb-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7591,9 +7419,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$kendo-table-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1px`
 
@@ -7610,16 +7437,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-cell-vertical-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-vertical-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -7629,16 +7455,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-cell-horizontal-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$grid-cell-horizontal-border-width`
 
 </td>
 <td>
 
-
+`1px`
 
 </td>
 </tr>
@@ -7648,9 +7473,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-font-size</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7667,9 +7491,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-line-height</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7686,9 +7509,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-x</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7705,9 +7527,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-cell-padding-y</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -7724,9 +7545,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -7752,26 +7572,7 @@ The following table lists the available variables for customizing the Material t
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-md,
-        line-height: ( 20 / 14 ),
-        cell-padding-x: map-get( $spacing, 4 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-md,
-        line-height: ( 20 / 14 ),
-        cell-padding-x: map-get( $spacing, 4 ),
-        cell-padding-y: map-get( $spacing, 2 )
-    ),
-    lg: (
-        font-size: $font-size-md,
-        line-height: ( 20 / 14 ),
-        cell-padding-x: map-get( $spacing, 4 ),
-        cell-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 16px, cell-padding-y: 10px), md: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 16px, cell-padding-y: 8px), lg: (font-size: 14px, line-height: 1.4285714286, cell-padding-x: 16px, cell-padding-y: 10px))`
 
 </td>
 </tr>
@@ -7781,16 +7582,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -7800,16 +7602,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -7819,16 +7622,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -7838,16 +7642,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-header-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -7857,16 +7662,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-header-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-text`
 
 </td>
 <td>
 
-`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -7876,16 +7682,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-header-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-header-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -7895,16 +7702,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-footer-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -7914,16 +7722,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-footer-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-text`
 
 </td>
 <td>
 
-`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -7933,16 +7742,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-footer-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-footer-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -7952,16 +7762,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-group-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-bg`
 
 </td>
 <td>
 
-`map-get($theme, component-bg)`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -7971,16 +7782,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-group-row-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-text`
 
 </td>
 <td>
 
-`if($theme-type == dark, $light-secondary-text, $dark-secondary-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
+
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -7990,16 +7802,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-group-row-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-table-header-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -8009,14 +7822,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-alt-row-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-alt-bg`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -8028,9 +7842,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-alt-row-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-text`
 
@@ -8047,9 +7860,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-alt-row-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-alt-border`
 
@@ -8066,16 +7878,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-hovered-bg`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .07 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.07)"></span>
+
+`rgba(0, 0, 0, 0.07)`
 
 </td>
 </tr>
@@ -8085,9 +7898,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-hovered-text`
 
@@ -8104,16 +7916,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-hovered-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -8123,9 +7936,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-focus-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8142,9 +7954,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-focus-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8161,9 +7972,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8180,16 +7990,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-focused-shadow`
 
 </td>
 <td>
 
-
+`null`
 
 </td>
 </tr>
@@ -8199,16 +8008,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-bg`
 
 </td>
 <td>
 
-`rgba( contrast-wcag( $grid-bg ), .04 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -8218,9 +8028,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-selected-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$grid-selected-text`
 
@@ -8237,16 +8046,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-table-selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$grid-selected-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -8277,9 +8087,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$tabstrip-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8296,16 +8105,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
 
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -8315,16 +8125,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`map-get($theme, component-border)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.12)"></span>
+
+`rgba(0, 0, 0, 0.12)`
 
 </td>
 </tr>
@@ -8334,9 +8145,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `24px`
 
@@ -8353,9 +8163,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -8372,9 +8181,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -8391,9 +8199,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-border-radius</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -8410,9 +8217,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-gap</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -8429,9 +8235,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8448,16 +8253,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$subtle-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.54)"></span>
 
+`rgba(0, 0, 0, 0.54)`
 
 </td>
 </tr>
@@ -8467,9 +8273,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8486,9 +8291,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8505,16 +8309,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$hovered-bg`
 
 </td>
 <td>
 
-`map-get( $theme, hover-bg )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.04)"></span>
+
+`rgba(0, 0, 0, 0.04)`
 
 </td>
 </tr>
@@ -8524,16 +8329,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
 
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -8543,9 +8349,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8562,9 +8367,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-hovered-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8581,9 +8385,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-selected-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8600,16 +8403,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
 
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -8619,9 +8423,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8638,9 +8441,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8657,16 +8459,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-content-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -8676,16 +8477,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-content-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -8695,9 +8495,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-content-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -8714,14 +8513,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-content-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -8733,9 +8533,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-content-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8752,9 +8551,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-content-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -8771,16 +8569,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$tabstrip-content-border-focused</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -8811,16 +8610,15 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$toolbar-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -8830,16 +8628,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$toolbar-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -8870,9 +8667,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$kendo-treeview-font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$font-family`
 
@@ -8889,16 +8685,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `$font-size-lg`
 
 </td>
 <td>
 
-
+`16px`
 
 </td>
 </tr>
@@ -8908,9 +8703,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `1.25`
 
@@ -8927,9 +8721,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-indent</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `16px`
 
@@ -8946,16 +8739,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-x</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 4 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 4 )`
+`16px`
 
 </td>
 </tr>
@@ -8965,16 +8757,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-padding-y</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `map-get( $spacing, 2 )`
 
 </td>
 <td>
 
-`map-get( $spacing, 2 )`
+`8px`
 
 </td>
 </tr>
@@ -8984,9 +8775,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-width</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `0px`
 
@@ -9003,9 +8793,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-border-radius</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9022,9 +8811,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-sizes</td>
-    <td></td>
+    <td>Map</td>
 <td>
-
 
 `(
     sm: (
@@ -9050,26 +8838,7 @@ The following table lists the available variables for customizing the Material t
 </td>
 <td>
 
-`(
-    sm: (
-        font-size: $font-size-lg,
-        line-height: 1.25,
-        item-padding-x: map-get( $spacing, 4 ),
-        item-padding-y: map-get( $spacing, 2 ) - map-get( $spacing, thin )
-    ),
-    md: (
-        font-size: $font-size-lg,
-        line-height: 1.25,
-        item-padding-x: map-get( $spacing, 4 ),
-        item-padding-y: map-get( $spacing, 2 )
-    ),
-    lg: (
-        font-size: $font-size-lg,
-        line-height: 1.25,
-        item-padding-x: map-get( $spacing, 4 ),
-        item-padding-y: map-get( $spacing, 2 ) + map-get( $spacing, thin )
-    )
-)`
+`(sm: (font-size: 16px, line-height: 1.25, item-padding-x: 16px, item-padding-y: 6px), md: (font-size: 16px, line-height: 1.25, item-padding-x: 16px, item-padding-y: 8px), lg: (font-size: 16px, line-height: 1.25, item-padding-x: 16px, item-padding-y: 10px))`
 
 </td>
 </tr>
@@ -9079,9 +8848,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9098,16 +8866,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
-`map-get($theme, component-text)`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.87)"></span>
+
+`rgba(0, 0, 0, 0.87)`
 
 </td>
 </tr>
@@ -9117,9 +8886,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9136,16 +8904,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( $kendo-treeview-text, .07 )`
 
 </td>
 <td>
 
-`rgba( $kendo-treeview-text, .07 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.07)"></span>
+
+`rgba(0, 0, 0, 0.07)`
 
 </td>
 </tr>
@@ -9155,9 +8924,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-text</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9174,9 +8942,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9193,9 +8960,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-hover-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9212,9 +8978,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-bg</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9231,16 +8996,17 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$selected-bg`
 
 </td>
 <td>
 
-`$secondary`
+<span class="color-preview" style="background-color: #e51a5f"></span>
+
+`#e51a5f`
 
 </td>
 </tr>
@@ -9250,9 +9016,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9269,9 +9034,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-selected-gradient</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9288,9 +9052,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-item-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9307,14 +9070,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9326,9 +9090,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-text</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -9345,9 +9108,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9364,14 +9126,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9383,9 +9146,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-text</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -9402,9 +9164,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-hover-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9421,14 +9182,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `transparent`
 
 </td>
 <td>
+
+<span class="color-preview" style="background-color: transparent"></span>
 
 `transparent`
 
@@ -9440,9 +9202,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-text</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -9459,9 +9220,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-border</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `null`
 
@@ -9478,9 +9238,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$kendo-treeview-loadmore-focus-shadow</td>
-    <td></td>
+    <td>Null</td>
 <td>
-
 
 `$kendo-treeview-item-focus-shadow`
 
@@ -9518,9 +9277,8 @@ The following table lists the available variables for customizing the Material t
 <tbody>
         <tr>
     <td>$enable-typography</td>
-    <td></td>
+    <td>Bool</td>
 <td>
-
 
 `false`
 
@@ -9537,9 +9295,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -9556,9 +9313,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$font-family</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `Roboto, "Helvetica Neue", sans-serif`
 
@@ -9575,9 +9331,8 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$font-family-monospace</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
 
@@ -9594,16 +9349,15 @@ The following table lists the available variables for customizing the Material t
 </tr>
 <tr>
     <td>$line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(28 / 14)`
 
 </td>
 <td>
 
-`(28 / 14)`
+`2`
 
 </td>
 </tr>
@@ -9619,6 +9373,12 @@ The following table lists the available variables for customizing the Material t
 
 ## Mixins
 
+### `exports`
+Outputs a module once, no matter how many times it is included.
+
+
+#### Parameters
+- name : `String` - The name of the exported module.
 
 
 

--- a/packages/nouvelle/docs/customization-autocomplete.md
+++ b/packages/nouvelle/docs/customization-autocomplete.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$autocomplete-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-bg`
 
 </td>
 <td>
 
-`$component-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$autocomplete-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-text`
 
 </td>
 <td>
 
-`$component-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$autocomplete-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-border`
 
 </td>
 <td>
 
-`$component-border`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$autocomplete-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-bg`
 
 </td>
 <td>
 
-`$kendo-input-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -103,16 +107,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$autocomplete-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-text`
 
 </td>
 <td>
 
-`$kendo-input-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -122,16 +127,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$autocomplete-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -141,16 +147,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$autocomplete-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-text`
 
 </td>
 <td>
 
-`$kendo-input-hover-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -160,16 +167,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$autocomplete-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-bg`
 
 </td>
 <td>
 
-`$kendo-input-hover-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -179,16 +187,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$autocomplete-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-border`
 
 </td>
 <td>
 
-`$kendo-input-hover-border`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>

--- a/packages/nouvelle/docs/customization-button.md
+++ b/packages/nouvelle/docs/customization-button.md
@@ -27,14 +27,15 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-button-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$interactive-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
@@ -46,14 +47,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$interactive-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$interactive-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -84,16 +87,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$interactive-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -103,16 +105,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, .5 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, .5 )`
+<span class="color-preview" style="background-color: #ececec"></span>
+
+`#ececec`
 
 </td>
 </tr>
@@ -122,14 +125,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -141,16 +145,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -160,16 +165,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-hover-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-button-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -179,16 +183,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-bg`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, .5 )`
+<span class="color-preview" style="background-color: #ececec"></span>
+
+`#ececec`
 
 </td>
 </tr>
@@ -198,14 +203,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -217,16 +223,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -236,16 +243,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-focus-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-button-hover-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -255,16 +261,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 1 )`
+<span class="color-preview" style="background-color: #e2e2e2"></span>
+
+`#e2e2e2`
 
 </td>
 </tr>
@@ -274,14 +281,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -293,16 +301,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -312,16 +321,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-button-active-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-button-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>

--- a/packages/nouvelle/docs/customization-color-system.md
+++ b/packages/nouvelle/docs/customization-color-system.md
@@ -29,12 +29,15 @@ The following table lists the available variables for customization.
     <td>$primary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -49,13 +52,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $primary )`
 
 </td>
 <td>
 
-`contrast-wcag( $primary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -67,12 +71,15 @@ The following table lists the available variables for customization.
     <td>$secondary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
 </td>
-<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
@@ -87,13 +94,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $secondary )`
 
 </td>
 <td>
 
-`contrast-wcag( $secondary )`
+<span class="color-preview" style="background-color: black"></span>
+
+`black`
 
 </td>
 </tr>
@@ -105,12 +113,15 @@ The following table lists the available variables for customization.
     <td>$tertiary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
 </td>
-<td><span class="color-preview" style="background-color: #03a9f4"></span>
+<td>
+
+<span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
@@ -125,13 +136,14 @@ The following table lists the available variables for customization.
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $tertiary )`
 
 </td>
 <td>
 
-`contrast-wcag( $tertiary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -143,12 +155,15 @@ The following table lists the available variables for customization.
     <td>$info</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
 </td>
-<td><span class="color-preview" style="background-color: #0058e9"></span>
+<td>
+
+<span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
@@ -162,12 +177,15 @@ The following table lists the available variables for customization.
     <td>$success</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
 </td>
-<td><span class="color-preview" style="background-color: #37b400"></span>
+<td>
+
+<span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
@@ -181,12 +199,15 @@ The following table lists the available variables for customization.
     <td>$warning</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
 </td>
-<td><span class="color-preview" style="background-color: #ffc000"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
@@ -200,12 +221,15 @@ The following table lists the available variables for customization.
     <td>$error</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
 </td>
-<td><span class="color-preview" style="background-color: #f31700"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
@@ -219,12 +243,15 @@ The following table lists the available variables for customization.
     <td>$dark</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #404040"></span>
 
 `#404040`
 
 </td>
-<td><span class="color-preview" style="background-color: #404040"></span>
+<td>
+
+<span class="color-preview" style="background-color: #404040"></span>
 
 `#404040`
 
@@ -238,12 +265,15 @@ The following table lists the available variables for customization.
     <td>$light</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
 </td>
-<td><span class="color-preview" style="background-color: #ebebeb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
@@ -255,16 +285,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$inverse</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $light, $dark )`
 
 </td>
 <td>
 
-`if( $dark-theme, $light, $dark )`
+<span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
 
 </td>
 </tr>

--- a/packages/nouvelle/docs/customization-combobox.md
+++ b/packages/nouvelle/docs/customization-combobox.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$combobox-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-bg`
 
 </td>
 <td>
 
-`$component-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$combobox-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-text`
 
 </td>
 <td>
 
-`$component-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$combobox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-border`
 
 </td>
 <td>
 
-`$component-border`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$combobox-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-bg`
 
 </td>
 <td>
 
-`$kendo-input-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -103,16 +107,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$combobox-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-text`
 
 </td>
 <td>
 
-`$kendo-input-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -122,16 +127,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$combobox-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -141,16 +147,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$combobox-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-text`
 
 </td>
 <td>
 
-`$kendo-input-hover-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -160,16 +167,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$combobox-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-bg`
 
 </td>
 <td>
 
-`$kendo-input-hover-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -179,16 +187,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$combobox-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-border`
 
 </td>
 <td>
 
-`$kendo-input-hover-border`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>

--- a/packages/nouvelle/docs/customization-common.md
+++ b/packages/nouvelle/docs/customization-common.md
@@ -27,14 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$interactive-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
 </td>
-<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
@@ -46,14 +49,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$interactive-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -65,16 +71,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$interactive-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .08 )`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -84,16 +91,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$interactive-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `rgba( black, 0 ), rgba( black, .02 )`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -103,16 +109,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `shade( $interactive-bg, .5 )`
 
 </td>
 <td>
 
-`shade( $interactive-bg, .5 )`
+<span class="color-preview" style="background-color: #ececec"></span>
+
+`#ececec`
 
 </td>
 </tr>
@@ -122,14 +129,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$interactive-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -141,16 +149,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .15 )`
 
 </td>
 <td>
 
-`rgba( black, .15 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.15)"></span>
+
+`rgba(0, 0, 0, 0.15)`
 
 </td>
 </tr>
@@ -160,16 +169,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$hover-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `rgba( black, 0 ), rgba( black, .02 )`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -179,14 +187,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -198,16 +207,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -217,16 +227,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .1 )`
 
 </td>
 <td>
 
-`rgba( black, .1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1)"></span>
+
+`rgba(0, 0, 0, 0.1)`
 
 </td>
 </tr>
@@ -236,9 +247,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$selected-gradient</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `none`
 

--- a/packages/nouvelle/docs/customization-component.md
+++ b/packages/nouvelle/docs/customization-component.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$component-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$component-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$component-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .08 )`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>

--- a/packages/nouvelle/docs/customization-dropdownlist.md
+++ b/packages/nouvelle/docs/customization-dropdownlist.md
@@ -27,14 +27,15 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$dropdownlist-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
@@ -46,14 +47,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$dropdownlist-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$dropdownlist-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$dropdownlist-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-bg`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, .5 )`
+<span class="color-preview" style="background-color: #ececec"></span>
+
+`#ececec`
 
 </td>
 </tr>
@@ -103,14 +107,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$dropdownlist-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -122,16 +127,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$dropdownlist-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -141,14 +147,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$dropdownlist-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-active-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -160,16 +167,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$dropdownlist-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-active-bg`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 1 )`
+<span class="color-preview" style="background-color: #e2e2e2"></span>
+
+`#e2e2e2`
 
 </td>
 </tr>
@@ -179,16 +187,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$dropdownlist-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-active-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>

--- a/packages/nouvelle/docs/customization-input.md
+++ b/packages/nouvelle/docs/customization-input.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-input-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-input-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-input-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-input-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -103,16 +107,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-input-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -122,16 +127,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-input-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-input-border, 1 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -141,16 +147,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-input-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -160,16 +167,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-input-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -179,16 +187,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-input-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>

--- a/packages/nouvelle/docs/customization-list.md
+++ b/packages/nouvelle/docs/customization-list.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-list-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-list-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>

--- a/packages/nouvelle/docs/customization-popup.md
+++ b/packages/nouvelle/docs/customization-popup.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$popup-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `mix( black, $component-bg, 2% )`
 
 </td>
 <td>
 
-`mix( black, $component-bg, 2% )`
+<span class="color-preview" style="background-color: #fafafa"></span>
+
+`#fafafa`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$popup-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$popup-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>

--- a/packages/nouvelle/docs/customization-textbox.md
+++ b/packages/nouvelle/docs/customization-textbox.md
@@ -27,16 +27,17 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$kendo-textbox-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -46,16 +47,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-textbox-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -65,16 +67,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-textbox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -84,16 +87,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-textbox-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -103,16 +107,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-textbox-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -122,16 +127,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-textbox-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -141,16 +147,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-textbox-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -160,16 +167,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-textbox-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -179,16 +187,17 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$kendo-textbox-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>

--- a/packages/nouvelle/docs/customization-typography.md
+++ b/packages/nouvelle/docs/customization-typography.md
@@ -27,9 +27,8 @@ The following table lists the available variables for customization.
 <tbody>
         <tr>
     <td>$font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -46,9 +45,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -65,9 +63,8 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$font-family-monospace</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
 
@@ -84,16 +81,15 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td>$line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(20 / 14)`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>

--- a/packages/nouvelle/docs/customization.md
+++ b/packages/nouvelle/docs/customization.md
@@ -31,14 +31,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tbody>
         <tr>
     <td>$interactive-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
 </td>
-<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
@@ -50,14 +53,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$interactive-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -69,16 +75,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$interactive-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .08 )`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -88,16 +95,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$interactive-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `rgba( black, 0 ), rgba( black, .02 )`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -107,16 +113,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `shade( $interactive-bg, .5 )`
 
 </td>
 <td>
 
-`shade( $interactive-bg, .5 )`
+<span class="color-preview" style="background-color: #ececec"></span>
+
+`#ececec`
 
 </td>
 </tr>
@@ -126,14 +133,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$interactive-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -145,16 +153,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .15 )`
 
 </td>
 <td>
 
-`rgba( black, .15 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.15)"></span>
+
+`rgba(0, 0, 0, 0.15)`
 
 </td>
 </tr>
@@ -164,16 +173,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$hover-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `rgba( black, 0 ), rgba( black, .02 )`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -183,14 +191,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$selected-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$primary`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -202,16 +211,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$selected-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `contrast-wcag( $selected-bg )`
 
 </td>
 <td>
 
-`contrast-wcag( $selected-bg )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -221,16 +231,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$selected-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .1 )`
 
 </td>
 <td>
 
-`rgba( black, .1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1)"></span>
+
+`rgba(0, 0, 0, 0.1)`
 
 </td>
 </tr>
@@ -240,9 +251,8 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$selected-gradient</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `none`
 
@@ -280,16 +290,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tbody>
         <tr>
     <td>$autocomplete-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-bg`
 
 </td>
 <td>
 
-`$component-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -299,16 +310,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$autocomplete-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-text`
 
 </td>
 <td>
 
-`$component-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -318,16 +330,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$autocomplete-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-border`
 
 </td>
 <td>
 
-`$component-border`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -337,16 +350,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$autocomplete-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-bg`
 
 </td>
 <td>
 
-`$kendo-input-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -356,16 +370,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$autocomplete-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-text`
 
 </td>
 <td>
 
-`$kendo-input-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -375,16 +390,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$autocomplete-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -394,16 +410,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$autocomplete-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-text`
 
 </td>
 <td>
 
-`$kendo-input-hover-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -413,16 +430,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$autocomplete-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-bg`
 
 </td>
 <td>
 
-`$kendo-input-hover-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -432,16 +450,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$autocomplete-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-border`
 
 </td>
 <td>
 
-`$kendo-input-hover-border`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -472,14 +491,15 @@ The following table lists the available variables for customizing the Nouvelle t
 <tbody>
         <tr>
     <td>$kendo-button-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$interactive-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
@@ -491,14 +511,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$interactive-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -510,16 +531,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$interactive-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -529,16 +551,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$interactive-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -548,16 +569,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, .5 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, .5 )`
+<span class="color-preview" style="background-color: #ececec"></span>
+
+`#ececec`
 
 </td>
 </tr>
@@ -567,14 +589,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -586,16 +609,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -605,16 +629,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-hover-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-button-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -624,16 +647,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-bg`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, .5 )`
+<span class="color-preview" style="background-color: #ececec"></span>
+
+`#ececec`
 
 </td>
 </tr>
@@ -643,14 +667,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -662,16 +687,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -681,16 +707,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-focus-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-button-hover-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -700,16 +725,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-active-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-button-bg, 1 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 1 )`
+<span class="color-preview" style="background-color: #e2e2e2"></span>
+
+`#e2e2e2`
 
 </td>
 </tr>
@@ -719,14 +745,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-active-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -738,16 +765,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-active-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -757,16 +785,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-button-active-gradient</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `$kendo-button-gradient`
 
 </td>
 <td>
 
-`rgba( black, 0 ), rgba( black, .02 )`
+`rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.02)`
 
 </td>
 </tr>
@@ -799,12 +826,15 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>$primary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
 </td>
-<td><span class="color-preview" style="background-color: #ff6358"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ff6358"></span>
 
 `#ff6358`
 
@@ -819,13 +849,14 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $primary )`
 
 </td>
 <td>
 
-`contrast-wcag( $primary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -837,12 +868,15 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>$secondary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
 </td>
-<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
@@ -857,13 +891,14 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $secondary )`
 
 </td>
 <td>
 
-`contrast-wcag( $secondary )`
+<span class="color-preview" style="background-color: black"></span>
+
+`black`
 
 </td>
 </tr>
@@ -875,12 +910,15 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>$tertiary</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
 </td>
-<td><span class="color-preview" style="background-color: #03a9f4"></span>
+<td>
+
+<span class="color-preview" style="background-color: #03a9f4"></span>
 
 `#03a9f4`
 
@@ -895,13 +933,14 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>Color</td>
 <td>
 
-
 `contrast-wcag( $tertiary )`
 
 </td>
 <td>
 
-`contrast-wcag( $tertiary )`
+<span class="color-preview" style="background-color: white"></span>
+
+`white`
 
 </td>
 </tr>
@@ -913,12 +952,15 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>$info</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
 </td>
-<td><span class="color-preview" style="background-color: #0058e9"></span>
+<td>
+
+<span class="color-preview" style="background-color: #0058e9"></span>
 
 `#0058e9`
 
@@ -932,12 +974,15 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>$success</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
 </td>
-<td><span class="color-preview" style="background-color: #37b400"></span>
+<td>
+
+<span class="color-preview" style="background-color: #37b400"></span>
 
 `#37b400`
 
@@ -951,12 +996,15 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>$warning</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
 </td>
-<td><span class="color-preview" style="background-color: #ffc000"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ffc000"></span>
 
 `#ffc000`
 
@@ -970,12 +1018,15 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>$error</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
 </td>
-<td><span class="color-preview" style="background-color: #f31700"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f31700"></span>
 
 `#f31700`
 
@@ -989,12 +1040,15 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>$dark</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #404040"></span>
 
 `#404040`
 
 </td>
-<td><span class="color-preview" style="background-color: #404040"></span>
+<td>
+
+<span class="color-preview" style="background-color: #404040"></span>
 
 `#404040`
 
@@ -1008,12 +1062,15 @@ The following table lists the available variables for customizing the Nouvelle t
     <td>$light</td>
     <td>Color</td>
 <td>
+
 <span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
 </td>
-<td><span class="color-preview" style="background-color: #ebebeb"></span>
+<td>
+
+<span class="color-preview" style="background-color: #ebebeb"></span>
 
 `#ebebeb`
 
@@ -1025,16 +1082,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$inverse</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `if( $dark-theme, $light, $dark )`
 
 </td>
 <td>
 
-`if( $dark-theme, $light, $dark )`
+<span class="color-preview" style="background-color: #404040"></span>
+
+`#404040`
 
 </td>
 </tr>
@@ -1065,16 +1123,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tbody>
         <tr>
     <td>$combobox-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-bg`
 
 </td>
 <td>
 
-`$component-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -1084,16 +1143,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$combobox-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-text`
 
 </td>
 <td>
 
-`$component-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -1103,16 +1163,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$combobox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-border`
 
 </td>
 <td>
 
-`$component-border`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1122,16 +1183,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$combobox-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-bg`
 
 </td>
 <td>
 
-`$kendo-input-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -1141,16 +1203,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$combobox-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-text`
 
 </td>
 <td>
 
-`$kendo-input-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -1160,16 +1223,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$combobox-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -1179,16 +1243,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$combobox-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-text`
 
 </td>
 <td>
 
-`$kendo-input-hover-text`
+<span class="color-preview" style="background-color: #656565"></span>
+
+`#656565`
 
 </td>
 </tr>
@@ -1198,16 +1263,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$combobox-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-bg`
 
 </td>
 <td>
 
-`$kendo-input-hover-bg`
+<span class="color-preview" style="background-color: #ffffff"></span>
+
+`#ffffff`
 
 </td>
 </tr>
@@ -1217,16 +1283,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$combobox-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-border`
 
 </td>
 <td>
 
-`$kendo-input-hover-border`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -1257,16 +1324,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tbody>
         <tr>
     <td>$component-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -1276,16 +1344,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$component-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$body-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -1295,16 +1364,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$component-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `rgba( black, .08 )`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1335,14 +1405,15 @@ The following table lists the available variables for customizing the Nouvelle t
 <tbody>
         <tr>
     <td>$dropdownlist-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-bg`
 
 </td>
-<td><span class="color-preview" style="background-color: #f6f6f6"></span>
+<td>
+
+<span class="color-preview" style="background-color: #f6f6f6"></span>
 
 `#f6f6f6`
 
@@ -1354,14 +1425,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$dropdownlist-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -1373,16 +1445,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$dropdownlist-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1392,16 +1465,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$dropdownlist-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-bg`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, .5 )`
+<span class="color-preview" style="background-color: #ececec"></span>
+
+`#ececec`
 
 </td>
 </tr>
@@ -1411,14 +1485,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$dropdownlist-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -1430,16 +1505,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$dropdownlist-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-hover-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1449,14 +1525,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$dropdownlist-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-active-text`
 
 </td>
-<td><span class="color-preview" style="background-color: #656565"></span>
+<td>
+
+<span class="color-preview" style="background-color: #656565"></span>
 
 `#656565`
 
@@ -1468,16 +1545,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$dropdownlist-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-active-bg`
 
 </td>
 <td>
 
-`try-shade( $kendo-button-bg, 1 )`
+<span class="color-preview" style="background-color: #e2e2e2"></span>
+
+`#e2e2e2`
 
 </td>
 </tr>
@@ -1487,16 +1565,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$dropdownlist-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-button-active-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1527,16 +1606,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tbody>
         <tr>
     <td>$kendo-input-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -1546,16 +1626,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-input-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -1565,16 +1646,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-input-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1584,16 +1666,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-input-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -1603,16 +1686,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-input-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -1622,16 +1706,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-input-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `try-shade( $kendo-input-border, 1 )`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -1641,16 +1726,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-input-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -1660,16 +1746,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-input-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -1679,16 +1766,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-input-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -1719,16 +1807,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tbody>
         <tr>
     <td>$kendo-list-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -1738,16 +1827,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-list-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -1757,16 +1847,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-list-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1797,16 +1888,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tbody>
         <tr>
     <td>$popup-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `mix( black, $component-bg, 2% )`
 
 </td>
 <td>
 
-`mix( black, $component-bg, 2% )`
+<span class="color-preview" style="background-color: #fafafa"></span>
+
+`#fafafa`
 
 </td>
 </tr>
@@ -1816,16 +1908,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$popup-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -1835,16 +1928,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$popup-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$component-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1875,16 +1969,17 @@ The following table lists the available variables for customizing the Nouvelle t
 <tbody>
         <tr>
     <td>$kendo-textbox-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -1894,16 +1989,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-textbox-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -1913,16 +2009,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-textbox-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-border`
 
 </td>
 <td>
 
-`rgba( black, .08 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.08)"></span>
+
+`rgba(0, 0, 0, 0.08)`
 
 </td>
 </tr>
@@ -1932,16 +2029,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-textbox-hover-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -1951,16 +2049,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-textbox-hover-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -1970,16 +2069,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-textbox-hover-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-hover-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -1989,16 +2089,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-textbox-focus-text</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-text`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #656565"></span>
 
+`#656565`
 
 </td>
 </tr>
@@ -2008,16 +2109,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-textbox-focus-bg</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-bg`
 
 </td>
 <td>
 
+<span class="color-preview" style="background-color: #ffffff"></span>
 
+`#ffffff`
 
 </td>
 </tr>
@@ -2027,16 +2129,17 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$kendo-textbox-focus-border</td>
-    <td></td>
+    <td>Color</td>
 <td>
-
 
 `$kendo-input-focus-border`
 
 </td>
 <td>
 
-`try-shade( $kendo-input-border, 1 )`
+<span class="color-preview" style="background-color: rgba(0, 0, 0, 0.1536)"></span>
+
+`rgba(0, 0, 0, 0.1536)`
 
 </td>
 </tr>
@@ -2067,9 +2170,8 @@ The following table lists the available variables for customizing the Nouvelle t
 <tbody>
         <tr>
     <td>$font-size</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `14px`
 
@@ -2086,9 +2188,8 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$font-family</td>
-    <td></td>
+    <td>String</td>
 <td>
-
 
 `inherit`
 
@@ -2105,9 +2206,8 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$font-family-monospace</td>
-    <td></td>
+    <td>List</td>
 <td>
-
 
 `SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace`
 
@@ -2124,16 +2224,15 @@ The following table lists the available variables for customizing the Nouvelle t
 </tr>
 <tr>
     <td>$line-height</td>
-    <td></td>
+    <td>Number</td>
 <td>
-
 
 `(20 / 14)`
 
 </td>
 <td>
 
-`(20 / 14)`
+`1.4285714286`
 
 </td>
 </tr>


### PR DESCRIPTION
This is as convoluted as things get in sass...

1) flatten all themes using baka
2) import said file using the `@use` dart-sass api
3) "compile" said file using dart-sass with custom function that processes each sass variable
4) put everything in a humongous json file
5) during the docs generation, suggest to sassdoc what the variables should be

**Important** that json generation does take some time...

* closes #1610, at least partially
* closes #1611, completely