### PR TITLE
fix(list): empty items have a wrong height

### DIFF
--- a/packages/default/scss/list/_layout.scss
+++ b/packages/default/scss/list/_layout.scss
@@ -99,6 +99,14 @@
             right: 0;
         }
     }
+    .k-list-item-text,
+    .k-list-optionlabel {
+        &::before {
+            content: "\200b";
+            width: 0px;
+            overflow: hidden;
+        }
+    }
     .k-list-optionlabel {
         @extend .k-list-item;
     }


### PR DESCRIPTION
fixes https://github.com/telerik/kendo-themes/issues/3388