### PR TITLE
refactor(stepper): use clamp instead of min function for setting labe…

### DIFF
--- a/packages/default/scss/stepper/_layout.scss
+++ b/packages/default/scss/stepper/_layout.scss
@@ -68,6 +68,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            flex: none;
             position: relative;
             z-index: 1;
             overflow: visible;
@@ -101,7 +102,7 @@
 
         // Step label
         .k-step-label {
-            max-width: calc(min(100%, 10em));
+            max-width: clamp(100%, 10em, 100%);
             display: inline-flex;
             flex-wrap: wrap;
             align-items: center;


### PR DESCRIPTION
- older postcss-calc does not support min/max
- min/max breaks Kendo jQuery themes compilation

Utilizing [clamp()](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp()) resolves both of the above issues and maintains the same result.


Reported from Blazor //cc @jivanova 