### PR TITLE
Checkout package-lock.json after npm link

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -34,6 +34,7 @@ for pkg in $packages
 do
     cd $themes_dir/packages/$pkg
     npm link
+    git checkout package-lock.json
 done
 
 echo ""


### PR DESCRIPTION
It seems that on windows `npm run setup` leaves artefacts. This change should take care of them.