### PR TITLE
fix(button): remove forced aspect ratio

### DIFF
--- a/packages/default/scss/button/_layout.scss
+++ b/packages/default/scss/button/_layout.scss
@@ -51,7 +51,6 @@
 
     // Icon Button
     .k-icon-button {
-        aspect-ratio: 1;
         gap: 0;
 
         .k-icon {


### PR DESCRIPTION
Fixes issues where the icon button is stretched in flex containers.