### PR TITLE
chore: use npm ci in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,7 +18,7 @@ echo ""
 
 # install
 echo "Installing dependencies..."
-npm install
+npm ci
 
 # husky init
 echo "Initializing husky"


### PR DESCRIPTION
[Clean install](https://docs.npmjs.com/cli/v8/commands/npm-ci) in setup scripts in order to prevent package.lock update with different node versions. 