### PR TITLE
Make kendo-popup 'pos: fixed' inside inputs and pickers so it's not clipped by overflow hidden

### DIFF
--- a/packages/default/scss/input/_layout.scss
+++ b/packages/default/scss/input/_layout.scss
@@ -421,6 +421,14 @@
         }
     }
 
+
+    // Angular specific
+    .k-input > kendo-popup,
+    .k-picker > kendo-popup {
+        position: fixed;
+    }
+
+
 }
 
 


### PR DESCRIPTION
Needed for accessibility

Addresses https://github.com/telerik/k2/issues/694