### PR TITLE
fix: hide scrollbars when are not needed #2954

### DIFF
--- a/packages/default/scss/pivotgrid/_layout.scss
+++ b/packages/default/scss/pivotgrid/_layout.scss
@@ -110,7 +110,7 @@
     // Values
     .k-pivotgrid-values {
         border-color: inherit;
-        overflow: scroll;
+        overflow: auto;
     }
 
     .k-pivotgrid-values .k-pivotgrid-cell {


### PR DESCRIPTION
related https://github.com/telerik/kendo-themes/issues/2954