### PR TITLE
Remove highlighting of header row in detail grid

### DIFF
--- a/packages/bootstrap/scss/grid/_theme.scss
+++ b/packages/bootstrap/scss/grid/_theme.scss
@@ -18,9 +18,9 @@
         }
 
         // Hover state
-        tbody tr:not(.k-detail-row):hover,
-        tbody tr:not(.k-detail-row).k-state-hover,
-        tbody tr:not(.k-detail-row).k-hover {
+        tbody>tr:not(.k-detail-row):hover,
+        tbody>tr:not(.k-detail-row).k-state-hover,
+        tbody>tr:not(.k-detail-row).k-hover {
             color: $grid-hovered-text;
             background-color: $grid-hovered-bg;
         }

--- a/packages/default/scss/grid/_theme.scss
+++ b/packages/default/scss/grid/_theme.scss
@@ -73,9 +73,9 @@
         }
 
         // Hover state
-        tbody tr:not(.k-detail-row):hover,
-        tbody tr:not(.k-detail-row).k-state-hover,
-        tbody tr:not(.k-detail-row).k-hover {
+        tbody>tr:not(.k-detail-row):hover,
+        tbody>tr:not(.k-detail-row).k-state-hover,
+        tbody>tr:not(.k-detail-row).k-hover {
             color: $grid-hovered-text;
             background-color: $grid-hovered-bg;
         }

--- a/packages/material/scss/grid/_theme.scss
+++ b/packages/material/scss/grid/_theme.scss
@@ -21,9 +21,9 @@
 
         // Hover, Focused state
         table {
-            tr:not(.k-detail-row):hover,
-            tr:not(.k-detail-row).k-state-hover,
-            tr:not(.k-detail-row).k-hover,
+            >tr:not(.k-detail-row):hover,
+            >tr:not(.k-detail-row).k-state-hover,
+            >tr:not(.k-detail-row).k-hover,
             td.k-state-focused,
             td.k-focus,
             th.k-state-focused,


### PR DESCRIPTION
fixes: telerik/kendo-themes/issues/3604