### PR TITLE
fix(floating-label): set correct vertical position for all sizes

### DIFF
--- a/packages/bootstrap/scss/floating-label/_variables.scss
+++ b/packages/bootstrap/scss/floating-label/_variables.scss
@@ -4,7 +4,7 @@ $floating-label-font-size: $kendo-input-font-size !default;
 $floating-label-line-height: $kendo-input-line-height !default;
 $floating-label-height: calc( #{$floating-label-line-height} * #{$floating-label-font-size} ) !default;
 $floating-label-offset-x: calc( #{$kendo-input-padding-x} + #{$kendo-input-border-width} ) !default;
-$floating-label-offset-y: calc( #{$floating-label-height} + #{$kendo-input-border-width} + #{$kendo-input-padding-y} ) !default;
+$floating-label-offset-y: 50% !default;
 
 $floating-label-focus-scale: 1 !default;
 $floating-label-focus-offset-x: 0 !default;

--- a/packages/classic/scss/floating-label/_variables.scss
+++ b/packages/classic/scss/floating-label/_variables.scss
@@ -4,7 +4,7 @@ $floating-label-font-size: $kendo-input-font-size !default;
 $floating-label-line-height: $kendo-input-line-height !default;
 $floating-label-height: calc( #{$floating-label-line-height} * #{$floating-label-font-size} ) !default;
 $floating-label-offset-x: calc( #{$kendo-input-padding-x} + #{$kendo-input-border-width} ) !default;
-$floating-label-offset-y: calc( #{$floating-label-height} + #{$kendo-input-border-width} + #{$kendo-input-padding-y} ) !default;
+$floating-label-offset-y: 50% !default;
 
 $floating-label-focus-scale: 1 !default;
 $floating-label-focus-offset-x: 0 !default;

--- a/packages/default/scss/floating-label/_variables.scss
+++ b/packages/default/scss/floating-label/_variables.scss
@@ -4,7 +4,7 @@ $floating-label-font-size: $kendo-input-font-size !default;
 $floating-label-line-height: $kendo-input-line-height !default;
 $floating-label-height: calc( #{$floating-label-line-height} * #{$floating-label-font-size} ) !default;
 $floating-label-offset-x: calc( #{$kendo-input-padding-x} + #{$kendo-input-border-width} ) !default;
-$floating-label-offset-y: calc( #{$floating-label-height} + #{$kendo-input-border-width} + #{$kendo-input-padding-y} ) !default;
+$floating-label-offset-y: 50% !default;
 
 $floating-label-focus-scale: 1 !default;
 $floating-label-focus-offset-x: 0 !default;

--- a/packages/material/scss/floating-label/_variables.scss
+++ b/packages/material/scss/floating-label/_variables.scss
@@ -4,7 +4,7 @@ $floating-label-font-size: $kendo-input-font-size !default;
 $floating-label-line-height: $kendo-input-line-height !default;
 $floating-label-height: calc( #{$floating-label-line-height} * #{$floating-label-font-size} ) !default;
 $floating-label-offset-x: calc( #{$kendo-input-padding-x} + #{$kendo-input-border-width} ) !default;
-$floating-label-offset-y: calc( #{$floating-label-height} + #{$kendo-input-border-width} + #{$kendo-input-padding-y} ) !default;
+$floating-label-offset-y: 50% !default;
 
 $floating-label-focus-scale: .75 !default;
 $floating-label-focus-offset-x: 0px !default;


### PR DESCRIPTION
The vertical position of the floating label was calculated according to the input's padding-y in size medium and it was not correctly centered for the other sizes.