### PR TITLE
Expose $kendo-daterange-picker-input-width variable

### DIFF
--- a/packages/bootstrap/scss/daterangepicker/_variables.scss
+++ b/packages/bootstrap/scss/daterangepicker/_variables.scss
@@ -1,2 +1,2 @@
 // Daterangepicker
-$kendo-daterange-picker-input-width: 10em;
+$kendo-daterange-picker-input-width: 10em !default;

--- a/packages/classic/scss/daterangepicker/_variables.scss
+++ b/packages/classic/scss/daterangepicker/_variables.scss
@@ -1,2 +1,2 @@
 // Daterangepicker
-$kendo-daterange-picker-input-width: 10em;
+$kendo-daterange-picker-input-width: 10em !default;

--- a/packages/default/scss/daterangepicker/_variables.scss
+++ b/packages/default/scss/daterangepicker/_variables.scss
@@ -1,2 +1,2 @@
 // Daterangepicker
-$kendo-daterange-picker-input-width: 10em;
+$kendo-daterange-picker-input-width: 10em !default;

--- a/packages/material/scss/daterangepicker/_variables.scss
+++ b/packages/material/scss/daterangepicker/_variables.scss
@@ -1,2 +1,2 @@
 // Daterangepicker
-$kendo-daterange-picker-input-width: 10em;
+$kendo-daterange-picker-input-width: 10em !default;


### PR DESCRIPTION
The  `$kendo-daterange-picker-input-width` variable was missing a `!default` flag and could not have been customized.