### PR TITLE
Resolve module system warnings

### DIFF
--- a/packages/fluent/scss/action-buttons/index.scss
+++ b/packages/fluent/scss/action-buttons/index.scss
@@ -3,7 +3,7 @@ $_kendo-module-meta: (
     name: "action-buttons",
     dependencies: (
         "button",
-        "icons"
+        "icon"
     )
 );
 
@@ -14,7 +14,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/button/index.scss
+++ b/packages/fluent/scss/button/index.scss
@@ -13,7 +13,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/calendar/index.scss
+++ b/packages/fluent/scss/calendar/index.scss
@@ -13,7 +13,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/card/index.scss
+++ b/packages/fluent/scss/card/index.scss
@@ -1,6 +1,6 @@
 // Module meta
 $_kendo-module-meta: (
-    name: "button",
+    name: "card",
     dependencies: (
         "action-buttons",
         "icon",
@@ -15,7 +15,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/core/module-system/index.scss
+++ b/packages/fluent/scss/core/module-system/index.scss
@@ -1,23 +1,38 @@
+@use "sass:list";
+@use "sass:map";
 @use "_components.scss" as _;
 
 $components: _.$components !default;
+$_deps: ();
 $_imported: ();
 
 @mixin register( $name: null, $dependencies: null ) {
-    @if $dependencies {
-        @each $dep in $dependencies {
-            @if ( index( $components, $dep) == null) {
-                @warn "The module \"#{$name}\" depends on module \"#{$dep}\", but the styles will not be loaded!";
-            }
-            @if ( index( $_imported, $dep) == null) {
-                @warn "The module \"#{$name}\" depends on module \"#{$dep}\", but the styles have not been loaded yet!";
+    @if (list.index( $components, $name) != null) {
+        $_deps: map.set( $_deps, $name, $dependencies );
+
+        @if $dependencies {
+            @each $dep in $dependencies {
+                @if ( list.index( $components, $dep ) == null ) {
+                    @warn "The module \"#{$name}\" depends on module \"#{$dep}\", but the styles will not be loaded!";
+                }
             }
         }
     }
 }
+
 @mixin render( $name: null ) {
-    @if ( index( $components, $name ) != null ) and ( index( $_imported, $name ) == null)  {
-        $_imported: append( $_imported, $name );
+    $dependencies: map.get( $_deps, $name );
+
+    @if $dependencies {
+        @each $dep in $dependencies {
+            @if ( list.index( $_imported, $dep ) == null ) {
+                @warn "The module \"#{$name}\" depends on module \"#{$dep}\", but the styles have not been loaded yet!";
+            }
+        }
+    }
+
+    @if ( list.index( $components, $name ) != null ) and ( list.index( $_imported, $name ) == null )  {
+        $_imported: list.append( $_imported, $name );
         @content;
     }
 }

--- a/packages/fluent/scss/dialog/index.scss
+++ b/packages/fluent/scss/dialog/index.scss
@@ -13,7 +13,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/forms/index.scss
+++ b/packages/fluent/scss/forms/index.scss
@@ -18,7 +18,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/icon/index.scss
+++ b/packages/fluent/scss/icon/index.scss
@@ -11,7 +11,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/input/index.scss
+++ b/packages/fluent/scss/input/index.scss
@@ -14,7 +14,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/list/index.scss
+++ b/packages/fluent/scss/list/index.scss
@@ -14,7 +14,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/listbox/index.scss
+++ b/packages/fluent/scss/listbox/index.scss
@@ -16,7 +16,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/listgroup/index.scss
+++ b/packages/fluent/scss/listgroup/index.scss
@@ -13,7 +13,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/maskedtextbox/index.scss
+++ b/packages/fluent/scss/maskedtextbox/index.scss
@@ -15,7 +15,7 @@ $_kendo-module-meta: (
 
 // Register
 @use "../core/module-system/" as module;
-@include module.register( $_kendo-module-meta );
+@include module.register( $_kendo-module-meta... );
 
 // Expose
 @mixin styles() {

--- a/packages/fluent/scss/messagebox/index.scss
+++ b/packages/fluent/scss/messagebox/index.scss
@@ -11,7 +11,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/multiselect/index.scss
+++ b/packages/fluent/scss/multiselect/index.scss
@@ -20,7 +20,7 @@ $_kendo-module-meta: (
 
 // Register
 @use "../core/module-system/" as module;
-@include module.register( $_kendo-module-meta );
+@include module.register( $_kendo-module-meta... );
 
 // Expose
 @mixin styles() {

--- a/packages/fluent/scss/notification/index.scss
+++ b/packages/fluent/scss/notification/index.scss
@@ -14,7 +14,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/numerictextbox/index.scss
+++ b/packages/fluent/scss/numerictextbox/index.scss
@@ -16,7 +16,7 @@ $_kendo-module-meta: (
 
 // Register
 @use "../core/module-system/" as module;
-@include module.register( $_kendo-module-meta );
+@include module.register( $_kendo-module-meta... );
 
 // Expose
 @mixin styles() {

--- a/packages/fluent/scss/overlay/index.scss
+++ b/packages/fluent/scss/overlay/index.scss
@@ -11,7 +11,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/popup/index.scss
+++ b/packages/fluent/scss/popup/index.scss
@@ -11,7 +11,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/rating/index.scss
+++ b/packages/fluent/scss/rating/index.scss
@@ -13,7 +13,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/searchbox/index.scss
+++ b/packages/fluent/scss/searchbox/index.scss
@@ -15,7 +15,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/split-button/index.scss
+++ b/packages/fluent/scss/split-button/index.scss
@@ -14,7 +14,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/textarea/index.scss
+++ b/packages/fluent/scss/textarea/index.scss
@@ -14,7 +14,7 @@ $_kendo-module-meta: (
 
 // Register
 @use "../core/module-system/" as module;
-@include module.register( $_kendo-module-meta );
+@include module.register( $_kendo-module-meta... );
 
 // Expose
 @mixin styles() {

--- a/packages/fluent/scss/textbox/index.scss
+++ b/packages/fluent/scss/textbox/index.scss
@@ -14,7 +14,7 @@ $_kendo-module-meta: (
 
 // Register
 @use "../core/module-system/" as module;
-@include module.register( $_kendo-module-meta );
+@include module.register( $_kendo-module-meta... );
 
 // Expose
 @mixin styles() {

--- a/packages/fluent/scss/timepicker/index.scss
+++ b/packages/fluent/scss/timepicker/index.scss
@@ -17,7 +17,7 @@ $_kendo-module-meta: (
 
 // Register
 @use "../core/module-system/" as module;
-@include module.register( $_kendo-module-meta );
+@include module.register( $_kendo-module-meta... );
 
 // Expose
 @mixin styles() {

--- a/packages/fluent/scss/typography/index.scss
+++ b/packages/fluent/scss/typography/index.scss
@@ -11,7 +11,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/utils/index.scss
+++ b/packages/fluent/scss/utils/index.scss
@@ -11,7 +11,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose

--- a/packages/fluent/scss/window/index.scss
+++ b/packages/fluent/scss/window/index.scss
@@ -6,7 +6,7 @@ $_kendo-module-meta: (
         "forms",
         "button",
         "action-buttons",
-        "icons"
+        "icon"
     )
 );
 
@@ -16,7 +16,7 @@ $_kendo-module-meta: (
 @use "_theme.scss" as *;
 
 // Register
-@use "../core/module-system" as module;
+@use "../core/module-system/" as module;
 @include module.register( $_kendo-module-meta... );
 
 // Expose


### PR DESCRIPTION
* require `icon` instead of `icons`, because that's the correct module name
* use spread operator for module meta in `module.register` because it expects two params
* minor tweaks in the module system to correctly report / warn about missing styles dependencies

This should resolve all warnings, as of now.