### PR TITLE
fix(pivotgrid): add outline none to focus cells

### DIFF
--- a/packages/default/scss/pivotgrid/_layout.scss
+++ b/packages/default/scss/pivotgrid/_layout.scss
@@ -60,6 +60,10 @@
         border-right-width: $pivotgrid-cell-border-width;
         border-bottom-style: solid;
         border-bottom-width: $pivotgrid-cell-border-width;
+
+        &:focus {
+            outline: none;
+        }
     }
 
 
@@ -130,6 +134,10 @@
         white-space: nowrap;
         vertical-align: top;
         overflow: hidden;
+
+        &:focus {
+            outline: none;
+        }
     }
 
     .k-pivotgrid-cell .k-icon {


### PR DESCRIPTION
related to: https://github.com/telerik/kendo-themes/issues/3804