### PR TITLE
chore(deps): update kendo-theme-tasks to v1.17.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@commitlint/core": "^17.0.0",
         "@progress/kendo-e2e": "^1.0.0",
         "@progress/kendo-font-icons": "0.3.0",
-        "@progress/kendo-theme-tasks": "^1.17.1",
+        "@progress/kendo-theme-tasks": "^1.17.3",
         "@typescript-eslint/eslint-plugin": "^5.27.0",
         "@typescript-eslint/parser": "^5.27.0",
         "chai": "^4.3.6",
@@ -984,9 +984,9 @@
       }
     },
     "node_modules/@joneff/baka": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@joneff/baka/-/baka-2.0.0.tgz",
-      "integrity": "sha512-hfMQYpMMp2E6SP9+qAXpG1n9q+5ayyTWODlYS6aLTsO6hVDn/LCShM65a5THc+CCn1354Jv3G81NyiplgoSNiQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@joneff/baka/-/baka-2.0.1.tgz",
+      "integrity": "sha512-FXJdVI+lvbQ0r7AcyjkOnyOIW+fvGoqSrvKS9ML3XwP2itYmU9EfgMQhCa8mHzW1bHQtUbeC0I4L2EdnrdmtZA==",
       "dev": true,
       "dependencies": {
         "@joneff/sass-import-resolver": "^1.0.0",
@@ -3480,12 +3480,12 @@
       "dev": true
     },
     "node_modules/@progress/kendo-theme-tasks": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-tasks/-/kendo-theme-tasks-1.17.2.tgz",
-      "integrity": "sha512-7iwfFAicE+PFY/FYMjev6IqtEUYg+/bXfGujBppwHBMOVAk1nHRYQJEk2r7oQdoCcV/ggFvHBfE3eUPZCql4oQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-tasks/-/kendo-theme-tasks-1.17.3.tgz",
+      "integrity": "sha512-zIUth9X8GS6dfVCIAAxXSV+FoCLJu98KiGl5nY/awtab1i4Hr+siSJ7aXlAgzhAv9e3alwfeR8rvr64bWWS9UQ==",
       "dev": true,
       "dependencies": {
-        "@joneff/baka": "^2.0.0",
+        "@joneff/baka": "^2.0.1",
         "@progress/dss": "^1.0.1",
         "autoprefixer": "^10.4.8",
         "glob": "^7.1.6",
@@ -23920,9 +23920,9 @@
       "dev": true
     },
     "@joneff/baka": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@joneff/baka/-/baka-2.0.0.tgz",
-      "integrity": "sha512-hfMQYpMMp2E6SP9+qAXpG1n9q+5ayyTWODlYS6aLTsO6hVDn/LCShM65a5THc+CCn1354Jv3G81NyiplgoSNiQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@joneff/baka/-/baka-2.0.1.tgz",
+      "integrity": "sha512-FXJdVI+lvbQ0r7AcyjkOnyOIW+fvGoqSrvKS9ML3XwP2itYmU9EfgMQhCa8mHzW1bHQtUbeC0I4L2EdnrdmtZA==",
       "dev": true,
       "requires": {
         "@joneff/sass-import-resolver": "^1.0.0",
@@ -25927,12 +25927,12 @@
       "dev": true
     },
     "@progress/kendo-theme-tasks": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-tasks/-/kendo-theme-tasks-1.17.2.tgz",
-      "integrity": "sha512-7iwfFAicE+PFY/FYMjev6IqtEUYg+/bXfGujBppwHBMOVAk1nHRYQJEk2r7oQdoCcV/ggFvHBfE3eUPZCql4oQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-tasks/-/kendo-theme-tasks-1.17.3.tgz",
+      "integrity": "sha512-zIUth9X8GS6dfVCIAAxXSV+FoCLJu98KiGl5nY/awtab1i4Hr+siSJ7aXlAgzhAv9e3alwfeR8rvr64bWWS9UQ==",
       "dev": true,
       "requires": {
-        "@joneff/baka": "^2.0.0",
+        "@joneff/baka": "^2.0.1",
         "@progress/dss": "^1.0.1",
         "autoprefixer": "^10.4.8",
         "glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@commitlint/core": "^17.0.0",
     "@progress/kendo-e2e": "^1.0.0",
     "@progress/kendo-font-icons": "0.3.0",
-    "@progress/kendo-theme-tasks": "^1.17.1",
+    "@progress/kendo-theme-tasks": "^1.17.3",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",
     "chai": "^4.3.6",


### PR DESCRIPTION
Fixes issue with `@joneff/baka` file import paths on windows machines.