### PR TITLE
Use child workflows for generating test assets

### DIFF
--- a/.github/workflows/ci_visual.yml
+++ b/.github/workflows/ci_visual.yml
@@ -13,70 +13,18 @@ concurrency:
 
 jobs:
 
-  prepare-artifacts:
-    name: Prepare artifacts
-    runs-on: ubuntu-latest
+  compile-themes:
+    name: Compile themes
+    uses: ./.github/workflows/compile_themes.yml
 
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v2
-
-      - name: Print Firefox version
-        run: firefox --version
-
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          cache: 'npm'
-          node-version: 14.x
-
-      - name: Install
-        run: |
-          npm ci
-          npm run bootstrap
-
-      - name: Build test assets
-        run: |
-          npm run build:scripts
-          npm run build:tests
-          npm run sass
-
-      - name: Update markup snapshots
-        env:
-          HEADLESS: 'true'
-        run: |
-          ./build/create-snapshots.mjs
-
-      - name: Pack themes
-        run: |
-          tar -cf themes.tar \
-            packages/default/dist/all.css \
-            packages/bootstrap/dist/all.css \
-            packages/classic/dist/all.css \
-            packages/fluent/dist/all.css \
-            packages/material/dist/all.css \
-            packages/nouvelle/dist/all.css \
-            packages/utils/dist/all.css
-
-      - name: Pack snapshots
-        run: tar --exclude tests/_output -cf snapshots.tar tests
-
-      - name: Upload themes
-        uses: actions/upload-artifact@v2
-        with:
-          name: themes
-          path: themes.tar
-
-      - name: Upload snapshots
-        uses: actions/upload-artifact@v2
-        with:
-          name: snapshots
-          path: snapshots.tar
+  create-snapshots:
+    name: Create snapshots
+    uses: ./.github/workflows/create_snapshots.yml
 
   run-tests:
     name: Run tests
     runs-on: ubuntu-latest
-    needs: prepare-artifacts
+    needs: [ compile-themes, create-snapshots ]
 
     strategy:
       matrix:

--- a/.github/workflows/compile_themes.yml
+++ b/.github/workflows/compile_themes.yml
@@ -1,0 +1,50 @@
+name: Compile themes
+
+on:
+  workflow_call:
+
+concurrency:
+  group: compile-themes-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  create-themes:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          cache: 'npm'
+          node-version: 14.x
+
+      - name: Install
+        run: |
+          npm ci
+          npx lerna bootstrap --ignore @progress/kendo-themes-html
+
+      - name: Build test assets
+        run: |
+          npm run sass
+
+      - name: Pack themes
+        run: |
+          tar -cf themes.tar \
+            packages/default/dist/all.css \
+            packages/bootstrap/dist/all.css \
+            packages/classic/dist/all.css \
+            packages/fluent/dist/all.css \
+            packages/material/dist/all.css \
+            packages/nouvelle/dist/all.css \
+            packages/utils/dist/all.css
+
+      - name: Upload themes
+        uses: actions/upload-artifact@v2
+        with:
+          name: themes
+          path: themes.tar

--- a/.github/workflows/create_snapshots.yml
+++ b/.github/workflows/create_snapshots.yml
@@ -1,0 +1,52 @@
+name: Create snapshots
+
+on:
+  workflow_call:
+
+concurrency:
+  group: create-snapshots-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  create-snapshots:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Print Firefox version
+        run: firefox --version
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          cache: 'npm'
+          node-version: 14.x
+
+      - name: Install
+        run: |
+          npm ci
+          npx lerna bootstrap --scope @progress/kendo-themes-html
+
+      - name: Build test assets
+        run: |
+          npm run build:scripts
+          npm run build:tests
+
+      - name: Update markup snapshots
+        env:
+          HEADLESS: 'true'
+        run: |
+          ./build/create-snapshots.mjs
+
+      - name: Pack snapshots
+        run: tar --exclude tests/_output -cf snapshots.tar tests
+
+      - name: Upload snapshots
+        uses: actions/upload-artifact@v2
+        with:
+          name: snapshots
+          path: snapshots.tar


### PR DESCRIPTION
Split `create-snapshots` and `compile-themes` into separate child workflows. that way, they can be reused if needed or optimized without touching the main workflow.