### PR TITLE
Snapshot chunks

### DIFF
--- a/build/create-snapshots.mjs
+++ b/build/create-snapshots.mjs
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 import { Browser, snapshotMarkup } from '@progress/kendo-e2e';
 import { createServer } from 'http-server';
-import { promisify } from 'util';
-import { default as cbGlob } from 'glob';
-import { mkdir } from 'fs/promises';
+import glob from 'glob';
+import fs from 'fs';
 import path from 'path';
-const glob = promisify(cbGlob);
 
 const PORT = 18111;
 const HOST = 'localhost';
@@ -13,48 +11,68 @@ const TESTS_PATH = './packages/html/src';
 const OUTPUT_PATH = './tests';
 const COMPONENT_PAGE_EXT = '.html';
 
-const browser = new Browser();
-const server = createServer({
-    root: './',
-    port: PORT
-});
+function pathUrl(path) {
+    return `http://${HOST}:${PORT}/${path.replace('./', '')}`;
+}
 
-const pathUrl = path => `http://${HOST}:${PORT}/${path.replace('./', '')}`;
+const files = glob.sync(`${TESTS_PATH}/**/*${COMPONENT_PAGE_EXT}`);
+const pages = files.map(path => [ path, pathUrl(path) ]);
 
-server.listen(PORT, HOST, async() => {
-    const files = await glob(`${TESTS_PATH}/**/*${COMPONENT_PAGE_EXT}`);
-    const pages = files.map(path => [ path, pathUrl(path) ]);
+function arrayChunks( array, chunkCount ) {
+    const result = [];
+    const chunkSize = Math.ceil(array.length / chunkCount);
 
-    for (let i = 0; i < pages.length; i++) {
-        const [ filePath, url ] = pages[i];
-
-        await browser.navigateTo(url);
-
-        const fileName = path.basename(filePath);
-        const folderName = path.basename(path.dirname(path.dirname(filePath)));
-        const outputPath = `${OUTPUT_PATH}/${folderName}/${fileName}`;
-
-        await mkdir(path.dirname(outputPath), { recursive: true });
-
-        await snapshotMarkup(browser.driver, 'html', outputPath, {
-            template: (output) => `<!doctype html>${output}`,
-            preserveAttributes: true,
-            preserveCommentNodes: true,
-            beautifyOptions: {
-                /* eslint-disable camelcase */
-                newline_between_rules: false,
-                brace_style: 'collapse',
-                indent_size: 4,
-                inline: [],
-                extra_liners: [],
-                preserve_newlines: false,
-                end_with_newline: true
-                /* eslint-enable */
-            }
-        });
+    for (let i = 0; i < array.length; i += chunkSize) {
+        result.push(array.slice(i, i + chunkSize));
     }
 
-    await browser.close();
-    server.close();
-});
+    return result;
+}
 
+const chunks = arrayChunks(pages, 8);
+
+Promise.all(chunks.map(async( chunk, index ) => {
+    let port = PORT + index;
+
+    const browser = new Browser();
+    const server = createServer({
+        root: './',
+        port: port
+    });
+
+    server.listen(port, HOST, async() => {
+
+        for (let i = 0; i < chunk.length; i++) {
+            const [ filePath, url ] = chunk[i];
+
+            await browser.navigateTo(url);
+
+            const fileName = path.basename(filePath);
+            const folderName = path.basename(path.dirname(path.dirname(filePath)));
+            const outputPath = `${OUTPUT_PATH}/${folderName}/${fileName}`;
+
+            fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+
+            await snapshotMarkup(browser.driver, 'html', outputPath, {
+                template: (output) => `<!doctype html>${output}`,
+                preserveAttributes: true,
+                preserveCommentNodes: true,
+                beautifyOptions: {
+                    /* eslint-disable camelcase */
+                    newline_between_rules: false,
+                    brace_style: 'collapse',
+                    indent_size: 4,
+                    inline: [],
+                    extra_liners: [],
+                    preserve_newlines: false,
+                    end_with_newline: true
+                    /* eslint-enable */
+                }
+            });
+        }
+
+        await browser.close();
+        server.close();
+    });
+
+}));

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "build:tests": "npm run build:tests --prefix packages/html",
     "watch:tests": "npm run watch:tests --prefix packages/html",
     "serve": "npm run sass && npm run build:scripts && npm run build:tests && npm run serve-tests",
-    "eslint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
+    "eslint": "eslint \"**/*.{js,jsx,ts,tsx,mjs}\"",
     "check-types": "npm run check-types --prefix packages/html",
     "sasslint": "sass-lint -v -q ",
     "stylelint": "stylelint \"**/*.scss\"",
@@ -69,7 +69,7 @@
     "update": "npx npm-check-updates --upgrade"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": "eslint"
+    "*.{js,jsx,ts,tsx,mjs}": "eslint"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Speed up snapshot by splitting the list into 8 chunks and executing in asynchronously.

On a local M1 Pro machine cuts the time from 36s to 10s which is about x4 improvement.

/cc @tsvetomir @dtopuzov 