### PR TITLE
Kendo HTML spec export all components

### DIFF
--- a/packages/html-spec/package.json
+++ b/packages/html-spec/package.json
@@ -12,6 +12,7 @@
   ],
   "main": "src/index.js",
   "files": [
+    "dist/**/*.json",
     "src/**/*.js",
     "src/**/*.json"
   ],
@@ -27,5 +28,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {}
+  "scripts": {
+    "build": "node ./scripts/build.js",
+    "prepublishOnly": "npm run build"
+  }
 }

--- a/packages/html-spec/scripts/build.js
+++ b/packages/html-spec/scripts/build.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const componentsHtmlSpecs = require('../src/index.js');
+
+const dist = "./dist";
+
+if (!fs.existsSync(dist)) {
+    fs.mkdirSync(dist);
+}
+
+fs.writeFileSync(`${dist}/components.json`, JSON.stringify(componentsHtmlSpecs, null, 4));

--- a/packages/html-spec/src/button/index.js
+++ b/packages/html-spec/src/button/index.js
@@ -1,3 +1,3 @@
-import componentJson from './button.json';
+const componentJson = require('./button.json');
 
-export const [ button ] = componentJson;
+exports.button = componentJson;

--- a/packages/html-spec/src/checkbox/index.js
+++ b/packages/html-spec/src/checkbox/index.js
@@ -1,3 +1,3 @@
-import componentJson from './checkbox.json';
+const componentJson = require('./checkbox.json');
 
-export const [ checkbox ] = componentJson;
+exports.checkbox = componentJson;

--- a/packages/html-spec/src/combobox/index.js
+++ b/packages/html-spec/src/combobox/index.js
@@ -1,3 +1,3 @@
-import componentJson from './combobox.json';
+const componentJson = require('./combobox.json');
 
-export const [ combobox, comboboxPopup ] = componentJson;
+exports.combobox = componentJson;

--- a/packages/html-spec/src/icon/index.js
+++ b/packages/html-spec/src/icon/index.js
@@ -1,3 +1,3 @@
-import componentJson from './icon.json';
+const componentJson = require('./icon.json');
 
-export const [ icon ] = componentJson;
+exports.icon = componentJson;

--- a/packages/html-spec/src/index.js
+++ b/packages/html-spec/src/index.js
@@ -1,6 +1,8 @@
-export * from './button';
-export * from './checkbox';
-export * from './combobox';
-export * from './icon';
-export * from './list';
-export * from './popup';
+module.exports = {
+    ...require('./button'),
+    ...require('./checkbox'),
+    ...require('./combobox'),
+    ...require('./icon'),
+    ...require('./list'),
+    ...require('./popup')
+};

--- a/packages/html-spec/src/list/index.js
+++ b/packages/html-spec/src/list/index.js
@@ -1,3 +1,3 @@
-import componentJson from './list.json';
+const componentJson = require('./list.json');
 
-export const [ list, listItem ] = componentJson;
+exports.list = componentJson;

--- a/packages/html-spec/src/popup/index.js
+++ b/packages/html-spec/src/popup/index.js
@@ -1,3 +1,3 @@
-import componentJson from './popup.json';
+const componentJson = require('./popup.json');
 
-export const [ popup ] = componentJson;
+exports.popup = componentJson;


### PR DESCRIPTION
In this PR:

* As [import assertions](https://github.com/tc39/proposal-import-assertions) are still level 3, this causes eslint parse errors when importing JSON files. Thus, switching to require.
* Export `components.json` in dist folder.