### PR TITLE
fix(signature): remove k-signature-canvas outline on focus-visible

### DIFF
--- a/packages/default/scss/signature/_layout.scss
+++ b/packages/default/scss/signature/_layout.scss
@@ -35,6 +35,7 @@
         height: 100%;
         display: block;
         z-index: 1;
+        outline: none;
     }
 
     .k-signature-line {


### PR DESCRIPTION
Related to changes implemented in: https://github.com/telerik/kendo-themes/pull/4035