### PR TITLE
Update checkout and setup-node actions to v3

### DIFF
--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -23,12 +23,12 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: develop
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'npm'
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/ci_next.yml
+++ b/.github/workflows/ci_next.yml
@@ -23,12 +23,12 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: v5-dev
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'npm'
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'npm'
           node-version: 14.x

--- a/.github/workflows/ci_visual.yml
+++ b/.github/workflows/ci_visual.yml
@@ -32,13 +32,13 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Print Firefox version
         run: firefox --version
 
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: .tmp
 
@@ -52,7 +52,7 @@ jobs:
         run: tar -cf screenshots-${{ matrix.theme }}.tar tests/_output/${{ matrix.theme }}
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: screenshots-${{ matrix.theme }}
           path: screenshots-${{ matrix.theme }}.tar
@@ -66,10 +66,10 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: .tmp
 

--- a/.github/workflows/compile_themes.yml
+++ b/.github/workflows/compile_themes.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'npm'
           node-version: 14.x
@@ -44,7 +44,7 @@ jobs:
             packages/utils/dist/all.css
 
       - name: Upload themes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: themes
           path: themes.tar

--- a/.github/workflows/create_snapshots.yml
+++ b/.github/workflows/create_snapshots.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Print Firefox version
         run: firefox --version
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'npm'
           node-version: 14.x
@@ -46,7 +46,7 @@ jobs:
         run: tar --exclude tests/_output -cf snapshots.tar tests
 
       - name: Upload snapshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: snapshots
           path: snapshots.tar

--- a/.github/workflows/merge_develop.yml
+++ b/.github/workflows/merge_develop.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish_swatches.yml
+++ b/.github/workflows/publish_swatches.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref }}
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'npm'
           node-version: 14.x
@@ -42,7 +42,7 @@ jobs:
         run: npm run sass:swatches
 
       - name: Checkout artifact repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: telerik/themes-cdn
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: develop
           token: ${{ secrets.GH_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
           git config user.email "kendouiteam@progress.com"
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'npm'
           node-version: 14.x

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: v5-dev
           token: ${{ secrets.GH_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
           git config user.email "kendouiteam@progress.com"
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'npm'
           node-version: 14.x

--- a/.github/workflows/release_stable.yml
+++ b/.github/workflows/release_stable.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
           fetch-depth: '0'
@@ -33,7 +33,7 @@ jobs:
           git merge --ff-only --quiet origin/develop
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'npm'
           node-version: 14.x

--- a/.github/workflows/tag_stable.yml
+++ b/.github/workflows/tag_stable.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'npm'
           node-version: 14.x


### PR DESCRIPTION
Targeting a recent warning:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-node, actions/setup-node, actions/checkout