### PR TITLE
fix(material): remove deprecated tilde import

### DIFF
--- a/packages/material/scss/core/functions/_index.scss
+++ b/packages/material/scss/core/functions/_index.scss
@@ -1,4 +1,4 @@
 $wcag-min-contrast-ratio: 4.5 !default;
 
-@import "~@progress/kendo-theme-core/scss/functions/index.import.scss";
-@import "~@progress/kendo-theme-default/scss/core/functions/_index.scss";
+@import "@progress/kendo-theme-core/scss/functions/index.import.scss";
+@import "@progress/kendo-theme-default/scss/core/functions/_index.scss";


### PR DESCRIPTION
@angular-devkit/build-angular has removed support for deprecated tilde import in v15 which cause the build of an application consuming `@progress/kendo-theme-material/scss/variables` to fail.