### PR TITLE
Еxplicitly download firefox in actions

### DIFF
--- a/.github/workflows/ci_visual.yml
+++ b/.github/workflows/ci_visual.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
 
-      - name: Print Firefox version
-        run: firefox --version
+      - name: Setup Firefox
+        uses: browser-actions/setup-firefox@latest
 
       - name: Download artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Related to https://github.com/actions/runner-images/issues/6399

In short: by Dec 1, `ubuntu-latest` will use `ubuntu-22.04`. That image does not have Firefox, as of yet. As a result, our builds will fail.