### PR TITLE
Cache root node_modules to speedup builds

### DIFF
--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -28,12 +28,20 @@ jobs:
           ref: develop
 
       - name: Setup node
+        id: setup-node
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: ${{ matrix.node-version }}
 
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit --no-fund
 
       - name: Bootstrap

--- a/.github/workflows/ci_next.yml
+++ b/.github/workflows/ci_next.yml
@@ -28,12 +28,20 @@ jobs:
           ref: v5-dev
 
       - name: Setup node
+        id: setup-node
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: ${{ matrix.node-version }}
 
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit --no-fund
 
       - name: Bootstrap

--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -6,8 +6,10 @@ defaults:
 
 on:
   push:
-    branches:
-      - '**'
+    branches-ignore:
+      - 'master'
+      - 'develop'
+      - 'v4-dev'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,12 +28,20 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup node
+        id: setup-node
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: 14.x
 
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit --no-fund
 
       - name: Bootstrap

--- a/.github/workflows/ci_visual.yml
+++ b/.github/workflows/ci_visual.yml
@@ -31,11 +31,31 @@ jobs:
         theme: [default, bootstrap, material, classic, nouvelle, fluent]
 
     steps:
+
+      - name: Print Firefox version
+        run: firefox --version
+
       - name: Checkout branch
         uses: actions/checkout@v3
 
-      - name: Setup Firefox
-        uses: browser-actions/setup-firefox@latest
+      - name: Setup node
+        id: setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v3
+        env:
+          cache-name: root-node_modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-14-${{ env.cache-name }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
+        run: npm ci --no-audit --no-fund
 
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/compile_themes.yml
+++ b/.github/workflows/compile_themes.yml
@@ -18,12 +18,20 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup node
+        id: setup-node
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: 14.x
 
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit --no-fund
 
       - name: Bootstrap

--- a/.github/workflows/create_snapshots.yml
+++ b/.github/workflows/create_snapshots.yml
@@ -14,19 +14,27 @@ jobs:
 
     steps:
 
-      - name: Checkout branch
-        uses: actions/checkout@v3
-
       - name: Print Firefox version
         run: firefox --version
 
+      - name: Checkout branch
+        uses: actions/checkout@v3
+
       - name: Setup node
+        id: setup-node
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: 14.x
 
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit --no-fund
 
       - name: Bootstrap

--- a/.github/workflows/nuget_publish.yml
+++ b/.github/workflows/nuget_publish.yml
@@ -24,20 +24,28 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: develop
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        id: setup-node
+        uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: 14.x
 
       - name: Setup nuget
         uses: nuget/setup-nuget@v1
 
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit --no-fund
 
       - name: Bootstrap

--- a/.github/workflows/publish_swatches.yml
+++ b/.github/workflows/publish_swatches.yml
@@ -28,12 +28,20 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
 
       - name: Setup node
+        id: setup-node
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: 14.x
 
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit --no-fund
 
       - name: Bootstrap

--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -32,15 +32,23 @@ jobs:
           git config user.email "kendouiteam@progress.com"
 
       - name: Setup node
+        id: setup-node
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: 14.x
           registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit --no-fund
 
       - name: Bootstrap

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -32,15 +32,23 @@ jobs:
           git config user.email "kendouiteam@progress.com"
 
       - name: Setup node
+        id: setup-node
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: 14.x
           registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit --no-fund
 
       - name: Bootstrap

--- a/.github/workflows/release_stable.yml
+++ b/.github/workflows/release_stable.yml
@@ -33,15 +33,23 @@ jobs:
           git merge --ff-only --quiet origin/develop
 
       - name: Setup node
+        id: setup-node
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: 14.x
           registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit --no-fund
 
       - name: Bootstrap

--- a/.github/workflows/tag_stable.yml
+++ b/.github/workflows/tag_stable.yml
@@ -20,9 +20,9 @@ jobs:
           ref: master
 
       - name: Setup node
+        id: setup-node
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: 14.x
           registry-url: 'https://registry.npmjs.org'
         env:


### PR DESCRIPTION
By caching `node_modules` and skipping `npm ci` we should save some time.

@tsvetomir the way I am reading the docs, without specifying a restore key, only a full match will result in cache hit. Correct?