### PR TITLE
Remove styles for fab shape property

### DIFF
--- a/docs/components/floatingactionbutton/index.md
+++ b/docs/components/floatingactionbutton/index.md
@@ -65,31 +65,6 @@ The FloatingActionButton specifies the primary or the most common actions in an 
 </button>
 ```
 
-## Shapes
-To create different shapes, the FloatingActionButton utilizes two classes, one for the base structure and one for rounding.
-
-### Rectangle
-
-```html
-<div class="k-d-flex k-gap-2">
-    <button type="button" class="k-fab k-fab-rectangle k-fab-sm k-fab-solid k-fab-solid-primary">
-        <span class="k-fab-text">Rectangle</span>
-    </button>
-    <button type="button" class="k-fab k-fab-rectangle k-rounded-sm k-fab-sm k-fab-solid k-fab-solid-primary">
-        <span class="k-fab-text">Rectangle Rounded SM</span>
-    </button>
-    <button type="button" class="k-fab k-fab-rectangle k-rounded-md k-fab-sm k-fab-solid k-fab-solid-primary">
-        <span class="k-fab-text">Rectangle Rounded MD</span>
-    </button>
-    <button type="button" class="k-fab k-fab-rectangle k-rounded-lg k-fab-sm k-fab-solid k-fab-solid-primary">
-        <span class="k-fab-text">Rectangle Rounded LG</span>
-    </button>
-    <button type="button" class="k-fab k-fab-rectangle k-rounded-full k-fab-sm k-fab-solid k-fab-solid-primary">
-        <span class="k-fab-text">Rectangle Rounded Full</span>
-    </button>
-</div>
-```
-
 ### Square
 
 ```html

--- a/packages/default/scss/fab/_layout.scss
+++ b/packages/default/scss/fab/_layout.scss
@@ -57,14 +57,6 @@
         padding: $kendo-fab-padding-y-lg $kendo-fab-padding-x-lg;
     }
 
-    // Shapes
-    .k-fab-rectangle { }
-
-    .k-fab-square {
-        aspect-ratio: 1;
-    }
-
-
     // Items
     .k-fab-items {
         margin: 0;

--- a/packages/fluent/scss/fab/_layout.scss
+++ b/packages/fluent/scss/fab/_layout.scss
@@ -75,11 +75,6 @@
         }
     }
 
-    // Shapes
-    .k-fab-square {
-        aspect-ratio: 1;
-    }
-
 
     // Items
     .k-fab-items {

--- a/packages/html/src/fab/fab.tsx
+++ b/packages/html/src/fab/fab.tsx
@@ -10,7 +10,6 @@ export interface FloatingActionButtonProps {
     type?: 'button' | 'submit' | 'reset';
     size?: null | 'small' | 'medium' | 'large';
     rounded: null | 'small' | 'medium' | 'large' | 'full';
-    shape?: null | 'rectangle' | 'square';
     fillMode?: null | 'solid';
     themeColor?: null | 'primary' | 'secondary' | 'tertiary' | 'info' | 'success' | 'warning' | 'error' | 'dark' | 'light' | 'inverse';
     position?: null | 'top-start' | 'top-center' | 'top-end' | 'middle-start' | 'middle-end' | 'bottom-start' | 'bottom-center' | 'bottom-end';
@@ -26,7 +25,6 @@ export class FloatingActionButton extends React.Component<FloatingActionButtonPr
     static defaultProps = {
         type: 'button',
         size: 'medium',
-        shape: 'rectangle',
         rounded: 'full',
         fillMode: 'solid',
         themeColor: 'primary'
@@ -40,7 +38,6 @@ export class FloatingActionButton extends React.Component<FloatingActionButtonPr
             icon,
             type,
             size,
-            shape,
             rounded,
             fillMode,
             themeColor,
@@ -62,7 +59,6 @@ export class FloatingActionButton extends React.Component<FloatingActionButtonPr
                     'k-fab',
                     {
                         [`k-fab-${kendoThemeMaps.sizeMap[size!] || size}`]: size,
-                        [`k-fab-${shape}`]: shape,
                         [`k-fab-${fillMode}`]: fillMode,
                         [`k-fab-${fillMode}-${themeColor}`]: Boolean(fillMode && themeColor),
                         [`k-rounded-${kendoThemeMaps.roundedMap[rounded!] || rounded}`]: rounded,

--- a/tests/fab/fab-items.html
+++ b/tests/fab/fab-items.html
@@ -26,7 +26,7 @@
         <span>Large</span>
         <span>Downward - Left Labels</span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-end" style="top: 16px; right: 16px;">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-end" style="top: 16px; right: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; top: calc(52px); right: calc(16px);">
@@ -55,7 +55,7 @@
             </div>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-end" style="top: 16px; right: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-end" style="top: 16px; right: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; top: calc(68px); right: calc(24px);">
@@ -80,7 +80,7 @@
             </div>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-end" style="top: 16px; right: 16px;">
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-end" style="top: 16px; right: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; top: calc(84px); right: calc(32px);">
@@ -106,7 +106,7 @@
         </span>
         <span>Downward - Right Labels</span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-start" style="top: 16px; left: 16px;">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-start" style="top: 16px; left: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; top: calc(52px); left: calc(16px);">
@@ -127,7 +127,7 @@
             </div>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-start" style="top: 16px; left: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-start" style="top: 16px; left: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; top: calc(68px); left: calc(24px);">
@@ -148,7 +148,7 @@
             </div>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-start" style="top: 16px; left: 16px;">
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-start" style="top: 16px; left: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; top: calc(84px); left: calc(32px);">
@@ -170,7 +170,7 @@
         </span>
         <span>Upward - Left Labels</span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-end" style="bottom: 16px; right: 16px;">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-end" style="bottom: 16px; right: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; bottom: calc(52px); right: calc(16px);">
@@ -191,7 +191,7 @@
             </div>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-end" style="bottom: 16px; right: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-end" style="bottom: 16px; right: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; bottom: calc(68px); right: calc(24px);">
@@ -212,7 +212,7 @@
             </div>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-end" style="bottom: 16px; right: 16px;">
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-end" style="bottom: 16px; right: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; bottom: calc(84px); right: calc(32px);">
@@ -234,7 +234,7 @@
         </span>
         <span>Upward - Right Labels</span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-start" style="bottom: 16px; left: 16px;">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-start" style="bottom: 16px; left: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; bottom: calc(52px); left: calc(16px);">
@@ -255,7 +255,7 @@
             </div>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-start" style="bottom: 16px; left: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-start" style="bottom: 16px; left: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; bottom: calc(68px); left: calc(24px);">
@@ -276,7 +276,7 @@
             </div>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-start" style="bottom: 16px; left: 16px;">
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-start" style="bottom: 16px; left: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
             <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; bottom: calc(84px); left: calc(32px);">
@@ -299,7 +299,7 @@
         <span>Angular rendering</span>
         <span class="relative-container">
             <span class="k-pos-absolute k-bottom-start" style="bottom: 16px; left: 16px;">
-                <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+                <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-full">
                     <span class="k-fab-icon k-icon k-i-plus"></span>
                 </button>
                 <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; bottom: 36px; left: calc(0px);">
@@ -322,7 +322,7 @@
         </span>
         <span class="relative-container">
             <span class="k-pos-absolute k-bottom-start" style="bottom: 16px; left: 16px;">
-                <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+                <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full">
                     <span class="k-fab-icon k-icon k-i-plus"></span>
                 </button>
                 <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; bottom: 52px; left: calc(8px);">
@@ -345,7 +345,7 @@
         </span>
         <span class="relative-container">
             <span class="k-pos-absolute k-bottom-start" style="bottom: 16px; left: 16px;">
-                <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+                <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-full">
                     <span class="k-fab-icon k-icon k-i-plus"></span>
                 </button>
                 <div class="k-fab-popup k-popup k-popup-transparent" style="position: absolute; bottom: 68px; left: calc(16px);">

--- a/tests/fab/fab-position.html
+++ b/tests/fab/fab-position.html
@@ -26,45 +26,45 @@
         <span>End</span>
         <span>Top</span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-start" style="top: 16px; left: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-start" style="top: 16px; left: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-center" style="top: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-center" style="top: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-end" style="top: 16px; right: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-top-end" style="top: 16px; right: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>Middle</span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-middle-start" style="left: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-middle-start" style="left: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span class="relative-container">NO CENTER POSITION</span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-middle-end" style="right: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-middle-end" style="right: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>Bottom</span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-start" style="bottom: 16px; left: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-start" style="bottom: 16px; left: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-center" style="bottom: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-center" style="bottom: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span class="relative-container">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-end" style="bottom: 16px; right: 16px;">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full !k-pos-absolute k-bottom-end" style="bottom: 16px; right: 16px;">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>

--- a/tests/fab/fab-size.html
+++ b/tests/fab/fab-size.html
@@ -25,186 +25,186 @@
         <span>large</span>
         <span>null</span>
         <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary">
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary">
-                <span class="k-fab-icon k-icon k-i-plus"></span>
-            </button>
-        </span>
-        <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary">
-                <span class="k-fab-text">Create</span>
-            </button>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary">
-                <span class="k-fab-icon k-icon k-i-plus"></span>
-                <span class="k-fab-text">Create</span>
-            </button>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary">
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary">
+                <span class="k-fab-icon k-icon k-i-plus"></span>
+            </button>
+        </span>
+        <span class="k-d-flex k-gap-1">
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary">
+                <span class="k-fab-text">Create</span>
+            </button>
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary">
+                <span class="k-fab-icon k-icon k-i-plus"></span>
+                <span class="k-fab-text">Create</span>
+            </button>
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>small</span>
         <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-sm">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-sm">
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-sm">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-sm">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-sm">
-                <span class="k-fab-icon k-icon k-i-plus"></span>
-            </button>
-        </span>
-        <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-sm">
-                <span class="k-fab-text">Create</span>
-            </button>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-sm">
-                <span class="k-fab-icon k-icon k-i-plus"></span>
-                <span class="k-fab-text">Create</span>
-            </button>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-sm">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-sm">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-sm">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-sm">
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-sm">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-sm">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-sm">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-sm">
+                <span class="k-fab-icon k-icon k-i-plus"></span>
+            </button>
+        </span>
+        <span class="k-d-flex k-gap-1">
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-sm">
+                <span class="k-fab-text">Create</span>
+            </button>
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-sm">
+                <span class="k-fab-icon k-icon k-i-plus"></span>
+                <span class="k-fab-text">Create</span>
+            </button>
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-sm">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>medium</span>
         <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-md">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-md">
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-md">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-md">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-md">
-                <span class="k-fab-icon k-icon k-i-plus"></span>
-            </button>
-        </span>
-        <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-md">
-                <span class="k-fab-text">Create</span>
-            </button>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-md">
-                <span class="k-fab-icon k-icon k-i-plus"></span>
-                <span class="k-fab-text">Create</span>
-            </button>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-md">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-md">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-md">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-md">
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-md">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-md">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-md">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-md">
+                <span class="k-fab-icon k-icon k-i-plus"></span>
+            </button>
+        </span>
+        <span class="k-d-flex k-gap-1">
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-md">
+                <span class="k-fab-text">Create</span>
+            </button>
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-md">
+                <span class="k-fab-icon k-icon k-i-plus"></span>
+                <span class="k-fab-text">Create</span>
+            </button>
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-md">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>large</span>
         <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-lg">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-lg">
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-lg">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-lg">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-lg">
-                <span class="k-fab-icon k-icon k-i-plus"></span>
-            </button>
-        </span>
-        <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-lg">
-                <span class="k-fab-text">Create</span>
-            </button>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-lg">
-                <span class="k-fab-icon k-icon k-i-plus"></span>
-                <span class="k-fab-text">Create</span>
-            </button>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-lg">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-lg">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-lg">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-lg">
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-lg">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-lg">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-lg">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-lg">
+                <span class="k-fab-icon k-icon k-i-plus"></span>
+            </button>
+        </span>
+        <span class="k-d-flex k-gap-1">
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-lg">
+                <span class="k-fab-text">Create</span>
+            </button>
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-lg">
+                <span class="k-fab-icon k-icon k-i-plus"></span>
+                <span class="k-fab-text">Create</span>
+            </button>
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-lg">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>full</span>
         <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-sm k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
-                <span class="k-fab-icon k-icon k-i-plus"></span>
-            </button>
-        </span>
-        <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
-                <span class="k-fab-text">Create</span>
-            </button>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
-                <span class="k-fab-icon k-icon k-i-plus"></span>
-                <span class="k-fab-text">Create</span>
-            </button>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+            <button type="button" class="k-fab k-fab-sm k-fab-solid k-fab-solid-primary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span class="k-d-flex k-gap-1">
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
-            <button type="button" class="k-fab k-fab-lg k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full">
+                <span class="k-fab-icon k-icon k-i-plus"></span>
+            </button>
+        </span>
+        <span class="k-d-flex k-gap-1">
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-full">
+                <span class="k-fab-text">Create</span>
+            </button>
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-full">
+                <span class="k-fab-icon k-icon k-i-plus"></span>
+                <span class="k-fab-text">Create</span>
+            </button>
+            <button type="button" class="k-fab k-fab-lg k-fab-solid k-fab-solid-primary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>

--- a/tests/fab/fab-states.html
+++ b/tests/fab/fab-states.html
@@ -17,261 +17,261 @@
         <span>Disabled</span>
         <span>primary</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full k-hover">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full k-hover">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full k-focus">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full k-focus">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full k-active">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full k-active">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full k-disabled">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full k-disabled">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>secondary</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-secondary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-secondary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-secondary k-rounded-full k-hover">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-secondary k-rounded-full k-hover">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-secondary k-rounded-full k-focus">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-secondary k-rounded-full k-focus">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-secondary k-rounded-full k-active">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-secondary k-rounded-full k-active">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-secondary k-rounded-full k-disabled">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-secondary k-rounded-full k-disabled">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>tertiary</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-tertiary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-tertiary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-tertiary k-rounded-full k-hover">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-tertiary k-rounded-full k-hover">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-tertiary k-rounded-full k-focus">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-tertiary k-rounded-full k-focus">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-tertiary k-rounded-full k-active">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-tertiary k-rounded-full k-active">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-tertiary k-rounded-full k-disabled">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-tertiary k-rounded-full k-disabled">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>info</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-info k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-info k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-info k-rounded-full k-hover">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-info k-rounded-full k-hover">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-info k-rounded-full k-focus">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-info k-rounded-full k-focus">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-info k-rounded-full k-active">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-info k-rounded-full k-active">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-info k-rounded-full k-disabled">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-info k-rounded-full k-disabled">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>success</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-success k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-success k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-success k-rounded-full k-hover">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-success k-rounded-full k-hover">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-success k-rounded-full k-focus">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-success k-rounded-full k-focus">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-success k-rounded-full k-active">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-success k-rounded-full k-active">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-success k-rounded-full k-disabled">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-success k-rounded-full k-disabled">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>warning</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-warning k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-warning k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-warning k-rounded-full k-hover">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-warning k-rounded-full k-hover">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-warning k-rounded-full k-focus">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-warning k-rounded-full k-focus">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-warning k-rounded-full k-active">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-warning k-rounded-full k-active">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-warning k-rounded-full k-disabled">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-warning k-rounded-full k-disabled">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>error</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-error k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-error k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-error k-rounded-full k-hover">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-error k-rounded-full k-hover">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-error k-rounded-full k-focus">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-error k-rounded-full k-focus">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-error k-rounded-full k-active">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-error k-rounded-full k-active">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-error k-rounded-full k-disabled">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-error k-rounded-full k-disabled">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>dark</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-dark k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-dark k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-dark k-rounded-full k-hover">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-dark k-rounded-full k-hover">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-dark k-rounded-full k-focus">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-dark k-rounded-full k-focus">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-dark k-rounded-full k-active">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-dark k-rounded-full k-active">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-dark k-rounded-full k-disabled">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-dark k-rounded-full k-disabled">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>light</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-light k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-light k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-light k-rounded-full k-hover">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-light k-rounded-full k-hover">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-light k-rounded-full k-focus">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-light k-rounded-full k-focus">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-light k-rounded-full k-active">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-light k-rounded-full k-active">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-light k-rounded-full k-disabled">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-light k-rounded-full k-disabled">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>inverse</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-inverse k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-inverse k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-inverse k-rounded-full k-hover">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-inverse k-rounded-full k-hover">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-inverse k-rounded-full k-focus">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-inverse k-rounded-full k-focus">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-inverse k-rounded-full k-active">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-inverse k-rounded-full k-active">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-inverse k-rounded-full k-disabled">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-inverse k-rounded-full k-disabled">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>

--- a/tests/fab/fab.html
+++ b/tests/fab/fab.html
@@ -21,171 +21,171 @@
         <span>Icon</span>
         <span>primary</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-primary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-primary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>secondary</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-secondary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-secondary k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-secondary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-secondary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-secondary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-secondary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>tertiary</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-tertiary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-tertiary k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-tertiary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-tertiary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-tertiary k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-tertiary k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>info</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-info k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-info k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-info k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-info k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-info k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-info k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>success</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-success k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-success k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-success k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-success k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-success k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-success k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>warning</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-warning k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-warning k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-warning k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-warning k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-warning k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-warning k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>error</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-error k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-error k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-error k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-error k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-error k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-error k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>dark</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-dark k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-dark k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-dark k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-dark k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-dark k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-dark k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>light</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-light k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-light k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-light k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-light k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-light k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-light k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>
         <span>inverse</span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-inverse k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-inverse k-rounded-full">
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-inverse k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-inverse k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
                 <span class="k-fab-text">Create</span>
             </button>
         </span>
         <span>
-            <button type="button" class="k-fab k-fab-md k-fab-rectangle k-fab-solid k-fab-solid-inverse k-rounded-full">
+            <button type="button" class="k-fab k-fab-md k-fab-solid k-fab-solid-inverse k-rounded-full">
                 <span class="k-fab-icon k-icon k-i-plus"></span>
             </button>
         </span>


### PR DESCRIPTION
The FAB shape property is obsolete and needs to be removed from the component and the demos (as it was removed from the Button).

- [ ] Kendo jQuery @telerik/kendo-jquery 
- [ ] Kendo React @telerik/kendo-react-admins 
- [ ] Kendo Vue @telerik/kendo-vue-team 
- [x] Kendo Angular 