### PR TITLE
fix(scheduler): add focus styles

### DIFF
--- a/packages/bootstrap/scss/scheduler/_variables.scss
+++ b/packages/bootstrap/scss/scheduler/_variables.scss
@@ -8,6 +8,8 @@ $scheduler-bg: $component-bg !default;
 $scheduler-text: $component-text !default;
 $scheduler-border: $component-border !default;
 
+$scheduler-shadow: 0 .5px .5px .5px rgba(0, 0, 0, .12) !default;
+
 $scheduler-toolbar-bg: $kendo-toolbar-bg !default;
 $scheduler-toolbar-text: $kendo-toolbar-text !default;
 $scheduler-toolbar-border: $kendo-toolbar-border !default;

--- a/packages/classic/scss/scheduler/_variables.scss
+++ b/packages/classic/scss/scheduler/_variables.scss
@@ -8,6 +8,8 @@ $scheduler-bg: $component-bg !default;
 $scheduler-text: $component-text !default;
 $scheduler-border: $component-border !default;
 
+$scheduler-shadow: 0 .5px .5px .5px rgba(0, 0, 0, .12) !default;
+
 $scheduler-toolbar-bg: $kendo-toolbar-bg !default;
 $scheduler-toolbar-text: $kendo-toolbar-text !default;
 $scheduler-toolbar-border: $kendo-toolbar-border !default;

--- a/packages/default/scss/scheduler/_theme.scss
+++ b/packages/default/scss/scheduler/_theme.scss
@@ -7,6 +7,10 @@
             $scheduler-bg,
             $scheduler-border
         );
+
+        &.k-focus {
+            box-shadow: $scheduler-shadow;
+        }
     }
 
     // Current time

--- a/packages/default/scss/scheduler/_variables.scss
+++ b/packages/default/scss/scheduler/_variables.scss
@@ -8,6 +8,8 @@ $scheduler-bg: $component-bg !default;
 $scheduler-text: $component-text !default;
 $scheduler-border: $component-border !default;
 
+$scheduler-shadow: 0 .5px .5px .5px rgba(0, 0, 0, .12) !default;
+
 $scheduler-toolbar-bg: $kendo-toolbar-bg !default;
 $scheduler-toolbar-text: $kendo-toolbar-text !default;
 $scheduler-toolbar-border: $kendo-toolbar-border !default;

--- a/packages/fluent/docs/customization-scheduler.md
+++ b/packages/fluent/docs/customization-scheduler.md
@@ -152,6 +152,24 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-scheduler-shadow</td>
+    <td></td>
+<td>
+
+`0 .5px .5px .5px rgba(0, 0, 0, .12)`
+
+</td>
+<td>
+
+
+
+</td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of the scheduler.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-scheduler-selected-bg</td>
     <td></td>
 <td>

--- a/packages/fluent/docs/customization.md
+++ b/packages/fluent/docs/customization.md
@@ -35976,6 +35976,24 @@ The following table lists the available variables for customizing the Fluent the
     </td>
 </tr>
 <tr>
+    <td>$kendo-scheduler-shadow</td>
+    <td></td>
+<td>
+
+`0 .5px .5px .5px rgba(0, 0, 0, .12)`
+
+</td>
+<td>
+
+
+
+</td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Box shadow of the scheduler.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-scheduler-selected-bg</td>
     <td></td>
 <td>

--- a/packages/fluent/scss/scheduler/_theme.scss
+++ b/packages/fluent/scss/scheduler/_theme.scss
@@ -9,6 +9,10 @@
             var( --kendo-scheduler-bg, #{$kendo-scheduler-bg} ),
             var( --kendo-scheduler-border, #{$kendo-scheduler-border} )
         );
+
+        &.k-focus {
+            box-shadow: var( --kendo-scheduler-shadow, #{$kendo-scheduler-shadow} );
+        }
     }
 
     // Current time

--- a/packages/fluent/scss/scheduler/_variables.scss
+++ b/packages/fluent/scss/scheduler/_variables.scss
@@ -26,6 +26,10 @@ $kendo-scheduler-text: var( --kendo-component-text, initial ) !default;
 /// @group scheduler
 $kendo-scheduler-border: var( --kendo-component-border, initial ) !default;
 
+/// Box shadow of the scheduler.
+/// @group scheduler
+$kendo-scheduler-shadow: 0 .5px .5px .5px rgba(0, 0, 0, .12) !default;
+
 /// Background color of the selected row in scheduler.
 /// @group scheduler
 $kendo-scheduler-selected-bg: get-theme-color-var( primary-20 ) !default;

--- a/packages/material/scss/scheduler/_variables.scss
+++ b/packages/material/scss/scheduler/_variables.scss
@@ -8,6 +8,8 @@ $scheduler-bg: $component-bg !default;
 $scheduler-text: $component-text !default;
 $scheduler-border: $component-border !default;
 
+$scheduler-shadow: 0 .5px .5px .5px rgba(0, 0, 0, .12) !default;
+
 $scheduler-toolbar-bg: k-try-shade( $kendo-button-bg, .5 ) !default;
 $scheduler-toolbar-text: null !default;
 $scheduler-toolbar-border: null !default;


### PR DESCRIPTION
In [Angular](https://www.telerik.com/kendo-angular-ui/components/scheduler/), [React](https://www.telerik.com/kendo-react-ui/components/scheduler/) and [Vue](https://www.telerik.com/kendo-vue-ui/components/scheduler/) the whole Scheduler is focusable and `box-shadows` is added to it when focused.
When the Scheduler is focused, in Angular the `k-focus` class is added (which has custom styles in the component), while in React and Vue inline style is added instead.

This PR adds the style in question to Kendo Themes.

NOTE 1: We should discuss if we want a different `box-shadow` value for the different themes.
NOTE 2: React and Vue should use the `k-focus` class (instead of inline styles) so they can be in sync with the changes made in the themes.
NOTE 3: Should we add the `k-focus` class to one of the visual tests (probably yes)?
NOTE 4: We need this merged and available for R1 as the styles in the Angular component are removed as part of the CSP effort.