### PR TITLE
Upload unified rendering improvements

### DIFF
--- a/packages/default/scss/upload/_layout.scss
+++ b/packages/default/scss/upload/_layout.scss
@@ -82,29 +82,18 @@
             border-color: inherit;
             list-style: none;
 
-            .k-file-multiple,
-            .k-file-single {
-                width: 100%;
-                display: flex;
-                justify-content: space-between;
-            }
-
-            .k-file-single {
-                align-items: center;
-            }
-
-            .k-file-multiple {
-                align-items: flex-start;
-            }
-
             .k-file {
                 padding: $kendo-upload-item-padding-y $kendo-upload-item-padding-x calc(#{$kendo-upload-item-padding-y} + #{$kendo-upload-progress-thickness});
                 border-width: 0 0 1px;
                 border-style: solid;
                 outline: none;
                 display: flex;
-                align-items: flex-start;
+                align-items: center;
                 position: relative;
+
+                &.k-file-multiple {
+                    align-items: flex-start;
+                }
             }
 
             .k-file:last-child {
@@ -177,15 +166,7 @@
         }
 
         .k-upload-files .k-file-info {
-            min-height: $kendo-upload-group-icon-size;
-            display: block;
-            overflow: hidden;
-            flex: 1 0 0;
-        }
-
-        .k-multiple-files-wrapper,
-        .k-file-single > .k-file-info {
-            margin-inline-start: $kendo-padding-md-x;
+            padding-inline-start: $kendo-padding-md-x;
             min-height: $kendo-upload-group-icon-size;
             display: block;
             overflow: hidden;
@@ -193,7 +174,12 @@
         }
 
         .k-multiple-files-wrapper {
+            padding-inline-start: $kendo-padding-md-x;
+            flex: 1 0 0;
+            overflow: hidden;
+
             .k-file-info {
+                padding-inline-start: 0;
                 margin-bottom: $kendo-upload-multiple-items-spacing;
                 display: block;
             }

--- a/packages/fluent/scss/upload/_layout.scss
+++ b/packages/fluent/scss/upload/_layout.scss
@@ -86,21 +86,6 @@
             border-color: inherit;
             list-style: none;
 
-            .k-file-multiple,
-            .k-file-single {
-                width: 100%;
-                display: flex;
-                justify-content: space-between;
-            }
-
-            .k-file-single {
-                align-items: center;
-            }
-
-            .k-file-multiple {
-                align-items: flex-start;
-            }
-
             .k-file {
                 padding-inline: var( --kendo-upload-item-padding-x, #{$kendo-upload-item-padding-x} );
                 padding-block: var( --kendo-upload-item-padding-y, #{$kendo-upload-item-padding-y} ) calc( var( --kendo-upload-item-padding-y, #{$kendo-upload-item-padding-y} ) + var( --kendo-upload-progress-thickness, #{$kendo-upload-progress-thickness} ) );
@@ -108,8 +93,12 @@
                 border-style: solid;
                 outline: none;
                 display: flex;
-                align-items: flex-start;
+                align-items: center;
                 position: relative;
+
+                &.k-file-multiple {
+                    align-items: flex-start;
+                }
             }
             .k-file:last-child {
                 border-width: 0;
@@ -185,27 +174,23 @@
         }
 
         .k-upload-files .k-file-info {
-            margin-inline-start: 0;
-            margin-inline-end: 0;
+            padding-inline-start: var( --kendo-padding-x, #{$kendo-padding-x} );
             min-height: var( --kendo-upload-group-icon-size, #{$kendo-upload-group-icon-size} );
             display: block;
             overflow: hidden;
             flex: 1 0 0;
-        }
-
-        .k-multiple-files-wrapper,
-        .k-file-single > .k-file-info {
-            margin-inline-start: var( --kendo-padding-x, #{$kendo-padding-md-x} );
-            margin-inline-end: 0;
-            min-height: var( --kendo-upload-group-icon-size, #{$kendo-upload-group-icon-size} );
-            display: block;
-            overflow: hidden;
-            flex: 1 0 0;
+            align-items: center;
         }
 
         .k-multiple-files-wrapper {
+            padding-inline-start: var( --kendo-padding-x, #{$kendo-padding-x} );
+            min-height: var( --kendo-upload-group-icon-size, #{$kendo-upload-group-icon-size} );
+            display: block;
+            overflow: hidden;
+            flex: 1 0 0;
 
             .k-file-info {
+                padding-inline-start: 0;
                 margin-block-end: var( --kendo-upload-multiple-items-spacing, #{$kendo-upload-multiple-items-spacing} );
                 display: block;
             }

--- a/packages/html-spec/src/upload/upload.json
+++ b/packages/html-spec/src/upload/upload.json
@@ -96,9 +96,120 @@
                     ],
                     "children": [
                         {
-                            "name": "file-single",
+                            "name": "file-info",
                             "selector": [
-                                ".k-file-single"
+                                ".k-file-info"
+                            ],
+                            "children": [
+                                {
+                                    "name": "file-name",
+                                    "selector": [
+                                        ".k-file-name"
+                                    ]
+                                },
+                                {
+                                    "name": "file-size",
+                                    "selector": [
+                                        ".k-file-size"
+                                    ]
+                                },
+                                {
+                                    "name": "file-validation-message",
+                                    "selector": [
+                                        ".k-file-validation-message"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "upload-progressbar",
+                            "$ref": "progressbar",
+                            "selector": [
+                                ".k-progressbar"
+                            ]
+                        },
+                        {
+                            "name": "file-icon-wrapper",
+                            "selector": [
+                                ".k-file-icon-wrapper"
+                            ],
+                            "children": [
+                                {
+                                    "name": "file-icon",
+                                    "$ref": "icon",
+                                    "selector": [
+                                        ".k-file-icon"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "upload-actions",
+                            "selector": [
+                                ".k-upload-actions"
+                            ],
+                            "children": [
+                                {
+                                    "name": "upload-percentage",
+                                    "selector": [
+                                        ".k-upload-pct"
+                                    ]
+                                },
+                                {
+                                    "name": "upload-action",
+                                    "$ref": "button",
+                                    "selector": [
+                                        ".k-upload-action"
+                                    ],
+                                    "options": [
+                                        {
+                                            "name": "fillMode",
+                                            "value": "flat"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+
+                    ]
+                },
+                {
+                    "name": "upload-file",
+                    "selector": [
+                        ".k-file",
+                        ".k-file-multiple"
+                    ],
+                    "states": [
+                        {
+                            "name": "success",
+                            "selector": [
+                                ".k-file-success"
+                            ]
+                        },
+                        {
+                            "name": "error",
+                            "selector": [
+                                ".k-file-error"
+                            ]
+                        },
+                        {
+                            "name": "invalid",
+                            "selector": [
+                                ".k-file-error.k-file-invalid"
+                            ]
+                        },
+                        {
+                            "name": "progress",
+                            "selector": [
+                                ".k-file-progress"
+                            ]
+                        }
+                    ],
+                    "children": [
+                        {
+                            "name": "multiple-files-wrapper",
+                            "selector": [
+                                ".k-multiple-files-wrapper"
                             ],
                             "children": [
                                 {
@@ -123,54 +234,6 @@
                                             "name": "file-validation-message",
                                             "selector": [
                                                 ".k-file-validation-message"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "name": "file-multiple",
-                            "selector": [
-                                ".k-file-multiple"
-                            ],
-                            "children": [
-                                {
-                                    "name": "file-multiple-wrapper",
-                                    "selector": [
-                                        ".k-multiple-files-wrapper"
-                                    ],
-                                    "children": [
-                                        {
-                                            "name": "file-info",
-                                            "selector": [
-                                                ".k-file-info"
-                                            ],
-                                            "children": [
-                                                {
-                                                    "name": "file-name",
-                                                    "selector": [
-                                                        ".k-file-name"
-                                                    ]
-                                                },
-                                                {
-                                                    "name": "file-size",
-                                                    "selector": [
-                                                        ".k-file-size"
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "name": "file-validation-message",
-                                            "selector": [
-                                                ".k-file-validation-message"
-                                            ]
-                                        },
-                                        {
-                                            "name": "file-summary",
-                                            "selector": [
-                                                ".k-file-summary"
                                             ]
                                         }
                                     ]

--- a/packages/html/src/upload/upload-file-multiple.tsx
+++ b/packages/html/src/upload/upload-file-multiple.tsx
@@ -33,42 +33,41 @@ export class UploadFileMultiple extends React.Component<UploadFileMultipleProps>
                 className={classNames(
                     className,
                     'k-file',
+                    'k-file-multiple',
                     {
                         [`k-file-${status}`]: status,
                     },
                 )}
             >
-                <div className="k-file-multiple">
-                    <ProgressBar className={classNames(
+                <ProgressBar className={classNames(
+                    {
+                        'k-hidden': status !== 'progress',
+                    }
+                )} value={progress} label={false} />
+                <span className="k-file-icon-wrapper">
+                    <Icon className="k-file-icon" name="copy"></Icon>
+                </span>
+                <div className="k-multiple-files-wrapper">
+                    {children}
+                    {fileSummary && <span className={classNames(
+                        'k-file-summary',
                         {
                             'k-hidden': status !== 'progress',
-                        }
-                    )} value={progress} label={false} />
-                    <span className="k-file-icon-wrapper">
-                        <Icon className="k-file-icon" name="copy"></Icon>
-                    </span>
-                    <div className="k-multiple-files-wrapper">
-                        {children}
-                        {fileSummary && <span className={classNames(
-                            'k-file-summary',
-                            {
-                                'k-hidden': status !== 'progress',
-                            },
-                        )}
-                        >{fileSummary}</span>}
-                        {validationMsg && <span className="k-file-validation-message">{validationMsg}</span>}
-                    </div>
-                    <div className="k-upload-actions">
-                        { status === 'progress'
-                            ?
-                            <>
-                                <span className="k-upload-pct">{progress}%</span>
-                                <Button icon="pause-sm" fillMode="flat" className="k-upload-action"></Button>
-                                <Button icon="cancel" fillMode="flat" className="k-upload-action"></Button>
-                            </>
-                            : <Button icon="close" fillMode="flat" className="k-upload-action"></Button>
-                        }
-                    </div>
+                        },
+                    )}
+                    >{fileSummary}</span>}
+                    {validationMsg && <span className="k-file-validation-message">{validationMsg}</span>}
+                </div>
+                <div className="k-upload-actions">
+                    { status === 'progress'
+                        ?
+                        <>
+                            <span className="k-upload-pct">{progress}%</span>
+                            <Button icon="pause-sm" fillMode="flat" className="k-upload-action"></Button>
+                            <Button icon="cancel" fillMode="flat" className="k-upload-action"></Button>
+                        </>
+                        : <Button icon="close" fillMode="flat" className="k-upload-action"></Button>
+                    }
                 </div>
             </li>
         );

--- a/packages/html/src/upload/upload-file.tsx
+++ b/packages/html/src/upload/upload-file.tsx
@@ -40,28 +40,26 @@ export class UploadFile extends React.Component<UploadFileProps> {
                     },
                 )}
             >
-                <div className="k-file-single">
-                    <ProgressBar className={classNames(
-                        {
-                            'k-hidden': status !== 'progress',
-                        }
-                    )} value={progress} label={false} />
-                    <span className="k-file-icon-wrapper">
-                        <Icon className="k-file-icon" name={icon}></Icon>
-                        {state && <span className="k-file-state">{state}</span>}
-                    </span>
-                    <UploadFileInfo name={name} size={size} validationMsg={validationMsg}></UploadFileInfo>
-                    <div className="k-upload-actions">
-                        { status === 'progress'
-                            ?
-                            <>
-                                <span className="k-upload-pct">{progress}%</span>
-                                <Button icon="pause-sm" fillMode="flat" className="k-upload-action"></Button>
-                                <Button icon="cancel" fillMode="flat" className="k-upload-action"></Button>
-                            </>
-                            : <Button icon="close" fillMode="flat" className="k-upload-action"></Button>
-                        }
-                    </div>
+                <ProgressBar className={classNames(
+                    {
+                        'k-hidden': status !== 'progress',
+                    }
+                )} value={progress} label={false} />
+                <span className="k-file-icon-wrapper">
+                    <Icon className="k-file-icon" name={icon}></Icon>
+                    {state && <span className="k-file-state">{state}</span>}
+                </span>
+                <UploadFileInfo name={name} size={size} validationMsg={validationMsg}></UploadFileInfo>
+                <div className="k-upload-actions">
+                    { status === 'progress'
+                        ?
+                        <>
+                            <span className="k-upload-pct">{progress}%</span>
+                            <Button icon="pause-sm" fillMode="flat" className="k-upload-action"></Button>
+                            <Button icon="cancel" fillMode="flat" className="k-upload-action"></Button>
+                        </>
+                        : <Button icon="close" fillMode="flat" className="k-upload-action"></Button>
+                    }
                 </div>
             </li>
         );

--- a/tests/form/form-field-inputs-angular-rtl.html
+++ b/tests/form/form-field-inputs-angular-rtl.html
@@ -218,25 +218,23 @@
                             </div>
                             <ul class="k-upload-files">
                                 <li class="k-file k-file-success">
-                                    <div class="k-file-single">
-                                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                    <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                        <span class="k-progress-status-wrap k-progress-start"></span>
+                                        <div class="k-progressbar-value k-selected">
                                             <span class="k-progress-status-wrap k-progress-start"></span>
-                                            <div class="k-progressbar-value k-selected">
-                                                <span class="k-progress-status-wrap k-progress-start"></span>
-                                            </div>
                                         </div>
-                                        <span class="k-file-icon-wrapper">
-                                            <span class="k-file-icon k-icon k-i-file-pdf"></span>
-                                        </span>
-                                        <div class="k-file-info">
-                                            <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
-                                            <span class="k-file-validation-message">File successfully uploaded.</span>
-                                        </div>
-                                        <div class="k-upload-actions">
-                                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                                <span class="k-button-icon k-icon k-i-close"></span>
-                                            </button>
-                                        </div>
+                                    </div>
+                                    <span class="k-file-icon-wrapper">
+                                        <span class="k-file-icon k-icon k-i-file-pdf"></span>
+                                    </span>
+                                    <div class="k-file-info">
+                                        <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
+                                        <span class="k-file-validation-message">File successfully uploaded.</span>
+                                    </div>
+                                    <div class="k-upload-actions">
+                                        <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                            <span class="k-button-icon k-icon k-i-close"></span>
+                                        </button>
                                     </div>
                                 </li>
                             </ul>
@@ -442,25 +440,23 @@
                                 </div>
                                 <ul class="k-upload-files">
                                     <li class="k-file k-file-success">
-                                        <div class="k-file-single">
-                                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                            <span class="k-progress-status-wrap k-progress-start"></span>
+                                            <div class="k-progressbar-value k-selected">
                                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                                <div class="k-progressbar-value k-selected">
-                                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                                </div>
                                             </div>
-                                            <span class="k-file-icon-wrapper">
-                                                <span class="k-file-icon k-icon k-i-file-pdf"></span>
-                                            </span>
-                                            <div class="k-file-info">
-                                                <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
-                                                <span class="k-file-validation-message">File successfully uploaded.</span>
-                                            </div>
-                                            <div class="k-upload-actions">
-                                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                                </button>
-                                            </div>
+                                        </div>
+                                        <span class="k-file-icon-wrapper">
+                                            <span class="k-file-icon k-icon k-i-file-pdf"></span>
+                                        </span>
+                                        <div class="k-file-info">
+                                            <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
+                                            <span class="k-file-validation-message">File successfully uploaded.</span>
+                                        </div>
+                                        <div class="k-upload-actions">
+                                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                                <span class="k-button-icon k-icon k-i-close"></span>
+                                            </button>
                                         </div>
                                     </li>
                                 </ul>

--- a/tests/form/form-field-inputs-angular.html
+++ b/tests/form/form-field-inputs-angular.html
@@ -218,25 +218,23 @@
                             </div>
                             <ul class="k-upload-files">
                                 <li class="k-file k-file-success">
-                                    <div class="k-file-single">
-                                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                    <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                        <span class="k-progress-status-wrap k-progress-start"></span>
+                                        <div class="k-progressbar-value k-selected">
                                             <span class="k-progress-status-wrap k-progress-start"></span>
-                                            <div class="k-progressbar-value k-selected">
-                                                <span class="k-progress-status-wrap k-progress-start"></span>
-                                            </div>
                                         </div>
-                                        <span class="k-file-icon-wrapper">
-                                            <span class="k-file-icon k-icon k-i-file-pdf"></span>
-                                        </span>
-                                        <div class="k-file-info">
-                                            <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
-                                            <span class="k-file-validation-message">File successfully uploaded.</span>
-                                        </div>
-                                        <div class="k-upload-actions">
-                                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                                <span class="k-button-icon k-icon k-i-close"></span>
-                                            </button>
-                                        </div>
+                                    </div>
+                                    <span class="k-file-icon-wrapper">
+                                        <span class="k-file-icon k-icon k-i-file-pdf"></span>
+                                    </span>
+                                    <div class="k-file-info">
+                                        <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
+                                        <span class="k-file-validation-message">File successfully uploaded.</span>
+                                    </div>
+                                    <div class="k-upload-actions">
+                                        <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                            <span class="k-button-icon k-icon k-i-close"></span>
+                                        </button>
                                     </div>
                                 </li>
                             </ul>
@@ -442,25 +440,23 @@
                                 </div>
                                 <ul class="k-upload-files">
                                     <li class="k-file k-file-success">
-                                        <div class="k-file-single">
-                                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                            <span class="k-progress-status-wrap k-progress-start"></span>
+                                            <div class="k-progressbar-value k-selected">
                                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                                <div class="k-progressbar-value k-selected">
-                                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                                </div>
                                             </div>
-                                            <span class="k-file-icon-wrapper">
-                                                <span class="k-file-icon k-icon k-i-file-pdf"></span>
-                                            </span>
-                                            <div class="k-file-info">
-                                                <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
-                                                <span class="k-file-validation-message">File successfully uploaded.</span>
-                                            </div>
-                                            <div class="k-upload-actions">
-                                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                                </button>
-                                            </div>
+                                        </div>
+                                        <span class="k-file-icon-wrapper">
+                                            <span class="k-file-icon k-icon k-i-file-pdf"></span>
+                                        </span>
+                                        <div class="k-file-info">
+                                            <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
+                                            <span class="k-file-validation-message">File successfully uploaded.</span>
+                                        </div>
+                                        <div class="k-upload-actions">
+                                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                                <span class="k-button-icon k-icon k-i-close"></span>
+                                            </button>
                                         </div>
                                     </li>
                                 </ul>

--- a/tests/form/form-field-inputs-react.html
+++ b/tests/form/form-field-inputs-react.html
@@ -195,25 +195,23 @@
                         </div>
                         <ul class="k-upload-files">
                             <li class="k-file k-file-success">
-                                <div class="k-file-single">
-                                    <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                    <span class="k-progress-status-wrap k-progress-start"></span>
+                                    <div class="k-progressbar-value k-selected">
                                         <span class="k-progress-status-wrap k-progress-start"></span>
-                                        <div class="k-progressbar-value k-selected">
-                                            <span class="k-progress-status-wrap k-progress-start"></span>
-                                        </div>
                                     </div>
-                                    <span class="k-file-icon-wrapper">
-                                        <span class="k-file-icon k-icon k-i-file-pdf"></span>
-                                    </span>
-                                    <div class="k-file-info">
-                                        <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
-                                        <span class="k-file-validation-message">File(s) successfully uploaded.</span>
-                                    </div>
-                                    <div class="k-upload-actions">
-                                        <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                            <span class="k-button-icon k-icon k-i-close"></span>
-                                        </button>
-                                    </div>
+                                </div>
+                                <span class="k-file-icon-wrapper">
+                                    <span class="k-file-icon k-icon k-i-file-pdf"></span>
+                                </span>
+                                <div class="k-file-info">
+                                    <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
+                                    <span class="k-file-validation-message">File(s) successfully uploaded.</span>
+                                </div>
+                                <div class="k-upload-actions">
+                                    <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                        <span class="k-button-icon k-icon k-i-close"></span>
+                                    </button>
                                 </div>
                             </li>
                         </ul>
@@ -421,25 +419,23 @@
                             </div>
                             <ul class="k-upload-files">
                                 <li class="k-file k-file-success">
-                                    <div class="k-file-single">
-                                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                    <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                        <span class="k-progress-status-wrap k-progress-start"></span>
+                                        <div class="k-progressbar-value k-selected">
                                             <span class="k-progress-status-wrap k-progress-start"></span>
-                                            <div class="k-progressbar-value k-selected">
-                                                <span class="k-progress-status-wrap k-progress-start"></span>
-                                            </div>
                                         </div>
-                                        <span class="k-file-icon-wrapper">
-                                            <span class="k-file-icon k-icon k-i-file-pdf"></span>
-                                        </span>
-                                        <div class="k-file-info">
-                                            <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
-                                            <span class="k-file-validation-message">File(s) successfully uploaded.</span>
-                                        </div>
-                                        <div class="k-upload-actions">
-                                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                                <span class="k-button-icon k-icon k-i-close"></span>
-                                            </button>
-                                        </div>
+                                    </div>
+                                    <span class="k-file-icon-wrapper">
+                                        <span class="k-file-icon k-icon k-i-file-pdf"></span>
+                                    </span>
+                                    <div class="k-file-info">
+                                        <span class="k-file-name">test long long long long long long long long long long long long long.pdf</span>
+                                        <span class="k-file-validation-message">File(s) successfully uploaded.</span>
+                                    </div>
+                                    <div class="k-upload-actions">
+                                        <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                            <span class="k-button-icon k-icon k-i-close"></span>
+                                        </button>
                                     </div>
                                 </li>
                             </ul>

--- a/tests/grid/grid-editing-popup.html
+++ b/tests/grid/grid-editing-popup.html
@@ -116,25 +116,23 @@
                                     </div>
                                     <ul class="k-upload-files">
                                         <li class="k-file k-file-success">
-                                            <div class="k-file-single">
-                                                <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:100;">
+                                                <span class="k-progress-status-wrap k-progress-start"></span>
+                                                <div class="k-progressbar-value k-selected">
                                                     <span class="k-progress-status-wrap k-progress-start"></span>
-                                                    <div class="k-progressbar-value k-selected">
-                                                        <span class="k-progress-status-wrap k-progress-start"></span>
-                                                    </div>
                                                 </div>
-                                                <span class="k-file-icon-wrapper">
-                                                    <span class="k-file-icon k-icon k-i-file-image"></span>
-                                                </span>
-                                                <div class="k-file-info">
-                                                    <span class="k-file-name">67409197_2322469807839836_4126207508270284800_n.png</span>
-                                                    <span class="k-file-size">24.34 KB</span>
-                                                </div>
-                                                <div class="k-upload-actions">
-                                                    <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                                        <span class="k-button-icon k-icon k-i-close"></span>
-                                                    </button>
-                                                </div>
+                                            </div>
+                                            <span class="k-file-icon-wrapper">
+                                                <span class="k-file-icon k-icon k-i-file-image"></span>
+                                            </span>
+                                            <div class="k-file-info">
+                                                <span class="k-file-name">67409197_2322469807839836_4126207508270284800_n.png</span>
+                                                <span class="k-file-size">24.34 KB</span>
+                                            </div>
+                                            <div class="k-upload-actions">
+                                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                                    <span class="k-button-icon k-icon k-i-close"></span>
+                                                </button>
                                             </div>
                                         </li>
                                     </ul>

--- a/tests/upload/upload-rtl.html
+++ b/tests/upload/upload-rtl.html
@@ -31,52 +31,48 @@
                 </div>
                 <ul class="k-upload-files">
                     <li class="k-file k-file-error">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-image"></span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.jpg</span>
-                                <span class="k-file-validation-message">File type not allowed.</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-image"></span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.jpg</span>
+                            <span class="k-file-validation-message">File type not allowed.</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                     <li class="k-file k-file-progress">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-pdf"></span>
-                                <span class="k-file-state">uploaded</span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Document.txt</span>
-                                <span class="k-file-size">225.68 KB</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <span class="k-upload-pct">60%</span>
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-pause-sm"></span>
-                                </button>
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-cancel"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-pdf"></span>
+                            <span class="k-file-state">uploaded</span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Document.txt</span>
+                            <span class="k-file-size">225.68 KB</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <span class="k-upload-pct">60%</span>
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-pause-sm"></span>
+                            </button>
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-cancel"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>
@@ -98,48 +94,44 @@
                 </div>
                 <ul class="k-upload-files">
                     <li class="k-file k-file-success">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-image"></span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Image1_With_Very_Very_Very_Very_Long_Name.png</span>
-                                <span class="k-file-validation-message">File(s) uploaded successfully.</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-image"></span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Image1_With_Very_Very_Very_Very_Long_Name.png</span>
+                            <span class="k-file-validation-message">File(s) uploaded successfully.</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                     <li class="k-file k-file-success">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-image"></span>
-                                <span class="k-file-state">uploaded</span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Image2.png</span>
-                                <span class="k-file-validation-message">File(s) uploaded successfully.</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-image"></span>
+                            <span class="k-file-state">uploaded</span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Image2.png</span>
+                            <span class="k-file-validation-message">File(s) uploaded successfully.</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>
@@ -160,42 +152,40 @@
                     </span>
                 </div>
                 <ul class="k-upload-files">
-                    <li class="k-file k-file-success">
-                        <div class="k-file-multiple">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:0;">
+                    <li class="k-file k-file-multiple k-file-success">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:0;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-copy"></span>
-                            </span>
-                            <div class="k-multiple-files-wrapper">
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.png</span>
-                                    <span class="k-file-size">19.61 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name2.png</span>
-                                    <span class="k-file-size">106.43 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video3.png</span>
-                                    <span class="k-file-size">24.34 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video4.png</span>
-                                    <span class="k-file-size">19.85 KB</span>
-                                </div>
-                                <span class="k-file-summary k-hidden">Total: 4 files, 170.22 KB</span>
-                                <span class="k-file-validation-message">4 File(s) uploaded successfully</span>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-copy"></span>
+                        </span>
+                        <div class="k-multiple-files-wrapper">
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.png</span>
+                                <span class="k-file-size">19.61 KB</span>
                             </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name2.png</span>
+                                <span class="k-file-size">106.43 KB</span>
                             </div>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video3.png</span>
+                                <span class="k-file-size">24.34 KB</span>
+                            </div>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video4.png</span>
+                                <span class="k-file-size">19.85 KB</span>
+                            </div>
+                            <span class="k-file-summary k-hidden">Total: 4 files, 170.22 KB</span>
+                            <span class="k-file-validation-message">4 File(s) uploaded successfully</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>
@@ -216,41 +206,39 @@
                     </span>
                 </div>
                 <ul class="k-upload-files">
-                    <li class="k-file k-file-progress">
-                        <div class="k-file-multiple">
-                            <div labelposition="start" class="k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:70;">
+                    <li class="k-file k-file-multiple k-file-progress">
+                        <div labelposition="start" class="k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:70;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-copy"></span>
-                            </span>
-                            <div class="k-multiple-files-wrapper">
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.png</span>
-                                    <span class="k-file-size">19.61 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name2.png</span>
-                                    <span class="k-file-size">106.43 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video4.png</span>
-                                    <span class="k-file-size">19.85 KB</span>
-                                </div>
-                                <span class="k-file-summary">Total: 4 files, 170.22 KB</span>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-copy"></span>
+                        </span>
+                        <div class="k-multiple-files-wrapper">
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.png</span>
+                                <span class="k-file-size">19.61 KB</span>
                             </div>
-                            <div class="k-upload-actions">
-                                <span class="k-upload-pct">70%</span>
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-pause-sm"></span>
-                                </button>
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-cancel"></span>
-                                </button>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name2.png</span>
+                                <span class="k-file-size">106.43 KB</span>
                             </div>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video4.png</span>
+                                <span class="k-file-size">19.85 KB</span>
+                            </div>
+                            <span class="k-file-summary">Total: 4 files, 170.22 KB</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <span class="k-upload-pct">70%</span>
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-pause-sm"></span>
+                            </button>
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-cancel"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>
@@ -271,42 +259,40 @@
                     </span>
                 </div>
                 <ul class="k-upload-files">
-                    <li class="k-file k-file-error">
-                        <div class="k-file-multiple">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:70;">
+                    <li class="k-file k-file-multiple k-file-error">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:70;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-copy"></span>
-                            </span>
-                            <div class="k-multiple-files-wrapper">
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Movie_With_Very_Very_Very_Very_Very_Long_Name1.mkv</span>
-                                    <span class="k-file-size">12.61 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Movie2.mkv</span>
-                                    <span class="k-file-size">12.36 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Image1.jpg</span>
-                                    <span class="k-file-size">1.09 MB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Image2.jpg</span>
-                                    <span class="k-file-size">1.09 MB</span>
-                                </div>
-                                <span class="k-file-summary k-hidden">Total: 4 files, 170.22 KB</span>
-                                <span class="k-file-validation-message">Invalid file(s). Please check file upload requirements.</span>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-copy"></span>
+                        </span>
+                        <div class="k-multiple-files-wrapper">
+                            <div class="k-file-info">
+                                <span class="k-file-name">Movie_With_Very_Very_Very_Very_Very_Long_Name1.mkv</span>
+                                <span class="k-file-size">12.61 KB</span>
                             </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Movie2.mkv</span>
+                                <span class="k-file-size">12.36 KB</span>
                             </div>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Image1.jpg</span>
+                                <span class="k-file-size">1.09 MB</span>
+                            </div>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Image2.jpg</span>
+                                <span class="k-file-size">1.09 MB</span>
+                            </div>
+                            <span class="k-file-summary k-hidden">Total: 4 files, 170.22 KB</span>
+                            <span class="k-file-validation-message">Invalid file(s). Please check file upload requirements.</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>
@@ -325,48 +311,44 @@
                 </div>
                 <ul class="k-upload-files">
                     <li class="k-file k-file-success">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-image"></span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Image_With_Very_Very_Very_Very_Very_Long_Name1.png</span>
-                                <span class="k-file-size">51.23 KB</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-image"></span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Image_With_Very_Very_Very_Very_Very_Long_Name1.png</span>
+                            <span class="k-file-size">51.23 KB</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                     <li class="k-file k-file-success">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-image"></span>
-                                <span class="k-file-state">uploaded</span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Image2.jpg</span>
-                                <span class="k-file-size">106.43 KB</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-image"></span>
+                            <span class="k-file-state">uploaded</span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Image2.jpg</span>
+                            <span class="k-file-size">106.43 KB</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>

--- a/tests/upload/upload.html
+++ b/tests/upload/upload.html
@@ -25,52 +25,48 @@
                 </div>
                 <ul class="k-upload-files">
                     <li class="k-file k-file-error">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-image"></span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.jpg</span>
-                                <span class="k-file-validation-message">File type not allowed.</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-image"></span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.jpg</span>
+                            <span class="k-file-validation-message">File type not allowed.</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                     <li class="k-file k-file-progress">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-pdf"></span>
-                                <span class="k-file-state">uploaded</span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Document.txt</span>
-                                <span class="k-file-size">225.68 KB</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <span class="k-upload-pct">60%</span>
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-pause-sm"></span>
-                                </button>
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-cancel"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-pdf"></span>
+                            <span class="k-file-state">uploaded</span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Document.txt</span>
+                            <span class="k-file-size">225.68 KB</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <span class="k-upload-pct">60%</span>
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-pause-sm"></span>
+                            </button>
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-cancel"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>
@@ -92,48 +88,44 @@
                 </div>
                 <ul class="k-upload-files">
                     <li class="k-file k-file-success">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-image"></span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Image1_With_Very_Very_Very_Very_Long_Name.png</span>
-                                <span class="k-file-validation-message">File(s) uploaded successfully.</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-image"></span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Image1_With_Very_Very_Very_Very_Long_Name.png</span>
+                            <span class="k-file-validation-message">File(s) uploaded successfully.</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                     <li class="k-file k-file-success">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-image"></span>
-                                <span class="k-file-state">uploaded</span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Image2.png</span>
-                                <span class="k-file-validation-message">File(s) uploaded successfully.</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-image"></span>
+                            <span class="k-file-state">uploaded</span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Image2.png</span>
+                            <span class="k-file-validation-message">File(s) uploaded successfully.</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>
@@ -154,42 +146,40 @@
                     </span>
                 </div>
                 <ul class="k-upload-files">
-                    <li class="k-file k-file-success">
-                        <div class="k-file-multiple">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:0;">
+                    <li class="k-file k-file-multiple k-file-success">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:0;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-copy"></span>
-                            </span>
-                            <div class="k-multiple-files-wrapper">
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.png</span>
-                                    <span class="k-file-size">19.61 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name2.png</span>
-                                    <span class="k-file-size">106.43 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video3.png</span>
-                                    <span class="k-file-size">24.34 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video4.png</span>
-                                    <span class="k-file-size">19.85 KB</span>
-                                </div>
-                                <span class="k-file-summary k-hidden">Total: 4 files, 170.22 KB</span>
-                                <span class="k-file-validation-message">4 File(s) uploaded successfully</span>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-copy"></span>
+                        </span>
+                        <div class="k-multiple-files-wrapper">
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.png</span>
+                                <span class="k-file-size">19.61 KB</span>
                             </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name2.png</span>
+                                <span class="k-file-size">106.43 KB</span>
                             </div>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video3.png</span>
+                                <span class="k-file-size">24.34 KB</span>
+                            </div>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video4.png</span>
+                                <span class="k-file-size">19.85 KB</span>
+                            </div>
+                            <span class="k-file-summary k-hidden">Total: 4 files, 170.22 KB</span>
+                            <span class="k-file-validation-message">4 File(s) uploaded successfully</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>
@@ -210,41 +200,39 @@
                     </span>
                 </div>
                 <ul class="k-upload-files">
-                    <li class="k-file k-file-progress">
-                        <div class="k-file-multiple">
-                            <div labelposition="start" class="k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:70;">
+                    <li class="k-file k-file-multiple k-file-progress">
+                        <div labelposition="start" class="k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:70;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-copy"></span>
-                            </span>
-                            <div class="k-multiple-files-wrapper">
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.png</span>
-                                    <span class="k-file-size">19.61 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name2.png</span>
-                                    <span class="k-file-size">106.43 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Video4.png</span>
-                                    <span class="k-file-size">19.85 KB</span>
-                                </div>
-                                <span class="k-file-summary">Total: 4 files, 170.22 KB</span>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-copy"></span>
+                        </span>
+                        <div class="k-multiple-files-wrapper">
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name.png</span>
+                                <span class="k-file-size">19.61 KB</span>
                             </div>
-                            <div class="k-upload-actions">
-                                <span class="k-upload-pct">70%</span>
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-pause-sm"></span>
-                                </button>
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-cancel"></span>
-                                </button>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video_File_with_Very_Very_Very_Very_Long_Name2.png</span>
+                                <span class="k-file-size">106.43 KB</span>
                             </div>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Video4.png</span>
+                                <span class="k-file-size">19.85 KB</span>
+                            </div>
+                            <span class="k-file-summary">Total: 4 files, 170.22 KB</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <span class="k-upload-pct">70%</span>
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-pause-sm"></span>
+                            </button>
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-cancel"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>
@@ -265,42 +253,40 @@
                     </span>
                 </div>
                 <ul class="k-upload-files">
-                    <li class="k-file k-file-error">
-                        <div class="k-file-multiple">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:70;">
+                    <li class="k-file k-file-multiple k-file-error">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:70;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-copy"></span>
-                            </span>
-                            <div class="k-multiple-files-wrapper">
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Movie_With_Very_Very_Very_Very_Very_Long_Name1.mkv</span>
-                                    <span class="k-file-size">12.61 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Movie2.mkv</span>
-                                    <span class="k-file-size">12.36 KB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Image1.jpg</span>
-                                    <span class="k-file-size">1.09 MB</span>
-                                </div>
-                                <div class="k-file-info">
-                                    <span class="k-file-name">Image2.jpg</span>
-                                    <span class="k-file-size">1.09 MB</span>
-                                </div>
-                                <span class="k-file-summary k-hidden">Total: 4 files, 170.22 KB</span>
-                                <span class="k-file-validation-message">Invalid file(s). Please check file upload requirements.</span>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-copy"></span>
+                        </span>
+                        <div class="k-multiple-files-wrapper">
+                            <div class="k-file-info">
+                                <span class="k-file-name">Movie_With_Very_Very_Very_Very_Very_Long_Name1.mkv</span>
+                                <span class="k-file-size">12.61 KB</span>
                             </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Movie2.mkv</span>
+                                <span class="k-file-size">12.36 KB</span>
                             </div>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Image1.jpg</span>
+                                <span class="k-file-size">1.09 MB</span>
+                            </div>
+                            <div class="k-file-info">
+                                <span class="k-file-name">Image2.jpg</span>
+                                <span class="k-file-size">1.09 MB</span>
+                            </div>
+                            <span class="k-file-summary k-hidden">Total: 4 files, 170.22 KB</span>
+                            <span class="k-file-validation-message">Invalid file(s). Please check file upload requirements.</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>
@@ -319,48 +305,44 @@
                 </div>
                 <ul class="k-upload-files">
                     <li class="k-file k-file-success">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-image"></span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Image_With_Very_Very_Very_Very_Very_Long_Name1.png</span>
-                                <span class="k-file-size">51.23 KB</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-image"></span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Image_With_Very_Very_Very_Very_Very_Long_Name1.png</span>
+                            <span class="k-file-size">51.23 KB</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                     <li class="k-file k-file-success">
-                        <div class="k-file-single">
-                            <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                        <div labelposition="start" class="k-hidden k-progressbar k-progressbar-horizontal" style="--kendo-progressbar-value:60;">
+                            <span class="k-progress-status-wrap k-progress-start"></span>
+                            <div class="k-progressbar-value k-selected">
                                 <span class="k-progress-status-wrap k-progress-start"></span>
-                                <div class="k-progressbar-value k-selected">
-                                    <span class="k-progress-status-wrap k-progress-start"></span>
-                                </div>
                             </div>
-                            <span class="k-file-icon-wrapper">
-                                <span class="k-file-icon k-icon k-i-file-image"></span>
-                                <span class="k-file-state">uploaded</span>
-                            </span>
-                            <div class="k-file-info">
-                                <span class="k-file-name">Image2.jpg</span>
-                                <span class="k-file-size">106.43 KB</span>
-                            </div>
-                            <div class="k-upload-actions">
-                                <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
-                                    <span class="k-button-icon k-icon k-i-close"></span>
-                                </button>
-                            </div>
+                        </div>
+                        <span class="k-file-icon-wrapper">
+                            <span class="k-file-icon k-icon k-i-file-image"></span>
+                            <span class="k-file-state">uploaded</span>
+                        </span>
+                        <div class="k-file-info">
+                            <span class="k-file-name">Image2.jpg</span>
+                            <span class="k-file-size">106.43 KB</span>
+                        </div>
+                        <div class="k-upload-actions">
+                            <button class="k-upload-action k-button k-button-md k-button-flat k-button-flat-base k-rounded-md k-icon-button">
+                                <span class="k-button-icon k-icon k-i-close"></span>
+                            </button>
                         </div>
                     </li>
                 </ul>


### PR DESCRIPTION
related https://github.com/telerik/kendo-themes/pull/4076/commits

Simplify the new Upload rendering as the following:
- remove `.k-file-single` and `.k-file-multiple` wrappers
- add the `.k-file-multiple` class to the `.k-file` element