### PR TITLE
fix(gantt): add a stronger td selector

### DIFF
--- a/packages/default/scss/gantt/_layout.scss
+++ b/packages/default/scss/gantt/_layout.scss
@@ -17,6 +17,10 @@
         -webkit-touch-callout: none;
         -webkit-tap-highlight-color: $kendo-color-rgba-transparent;
 
+        .k-table-td {
+            white-space: nowrap;
+        }
+
         // other
         td {
             overflow: hidden;

--- a/packages/fluent/scss/gantt/_layout.scss
+++ b/packages/fluent/scss/gantt/_layout.scss
@@ -21,6 +21,10 @@
         -webkit-touch-callout: none;
         -webkit-tap-highlight-color: $kendo-color-rgba-transparent;
 
+        .k-table-td {
+            white-space: nowrap;
+        }
+
         // other
         td {
             overflow: hidden;


### PR DESCRIPTION
A stronger selector is needed so the `white-space: nowrap;` rule can be applied, which fixes the following issue:

![gantt](https://user-images.githubusercontent.com/7753940/210753855-6ddd37c5-ac65-48fd-b311-b4d50baf37b0.png)
