### PR TITLE
Speedup a11y tests

### DIFF
--- a/.github/workflows/_compile-themes.yml
+++ b/.github/workflows/_compile-themes.yml
@@ -43,10 +43,16 @@ jobs:
         run: |
           npm run sass
 
+      - name: Build swatch for a11y tests
+        run: |
+          npm run dist:swatches
+          npx sass-build build --file packages/default/dist/default-ocean-blue-a11y.scss --outFile packages/default/dist/default-ocean-blue-a11y.css
+
       - name: Pack themes
         run: |
           tar -cf themes.tar \
             packages/default/dist/all.css \
+            packages/default/dist/default-ocean-blue-a11y.css \
             packages/bootstrap/dist/all.css \
             packages/classic/dist/all.css \
             packages/fluent/dist/all.css \

--- a/.github/workflows/_test-contrast.yml
+++ b/.github/workflows/_test-contrast.yml
@@ -2,17 +2,41 @@ name: CI | A11y
 
 on:
   workflow_call:
+    inputs:
+      max-chunks:
+        required: false
+        type: number
+        default: 1
 
-concurrency:
-  group: test-contrast-${{ github.ref }}
-  cancel-in-progress: true
+# concurrency:
+#   group: test-contrast-${{ github.ref }}
+#   cancel-in-progress: true
 
 jobs:
 
-  run-checks:
-    name: Run checks
-
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      chunk-var: ${{ steps.generate-matrix.outputs.MATRIX }}
+
+    steps:
+
+      - id: generate-matrix
+        run: |
+          MATRIX=$(echo $(seq ${{ inputs.max-chunks }}) | sed 's/ /, /g')
+          MATRIX="[ $MATRIX ]"
+
+          echo $MATRIX
+          echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
+
+  run-checks:
+    runs-on: ubuntu-latest
+    needs: [ prepare ]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: ${{ fromJson(needs.prepare.outputs.chunk-var) }}
 
     steps:
 
@@ -26,7 +50,7 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16
 
       - name: Use cache for root node_modules
         id: cache-root-node_modules
@@ -40,20 +64,19 @@ jobs:
         run: |
           npm ci --no-optional --no-audit --no-fund
 
-      - name: Bootstrap
-        run: |
-          npm run bootstrap
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: .tmp
 
-      - name: Build test pages
-        run: |
-          npm run build:tests
+      - name: Unpack artifacts
+        run: find .tmp -name "*.tar" -type f -exec tar -xf {} \;
 
-      - name: Build swatches
-        run: |
-          npm run sass:swatches
-
-      - name: Test contrast
+      - name: Test contrast (${{ matrix.chunk }} of ${{ matrix.max-chunks }})
         run: xvfb-run --auto-servernum --server-args="-screen 0, 1366x768x24" npm run test-contrast
+        env:
+          MAX_CHUNKS: ${{ inputs.max-chunks }}
+          CURRENT_CHUNK: ${{ matrix.chunk }}
 
       - name: Done
         run: echo "Done!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,10 @@ jobs:
 
   ci-a11y:
     name: Status check > A11y
+    needs: [ compile-themes, render-test-pages ]
     uses: ./.github/workflows/_test-contrast.yml
+    with:
+      max-chunks: 4
 
   # placeholder
   # replace placeholder with ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "nunjucks": "^3.2.3",
         "pastshots": "^1.6.2",
         "sass": "^1.54.9",
-        "sass-build": "^1.1.2",
+        "sass-build": "^1.1.5",
         "sass-embedded": "^1.54.9",
         "sass-lint": "^1.13.1",
         "sassdoc": "^2.7.4",
@@ -4312,71 +4312,6 @@
         "sass-embedded": "^1.56.1"
       }
     },
-    "node_modules/@progress/kendo-theme-tasks/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@progress/kendo-theme-tasks/node_modules/are-we-there-yet": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-4.0.0.tgz",
-      "integrity": "sha512-nSXlV+u3vtVjRgihdTzbfWYzxPWGo424zPgQbHD0ZqIla3jqYAewDcvee0Ua2hjS5IfTAmjGlx1Jf0PKwjZDEw==",
-      "dev": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^4.1.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@progress/kendo-theme-tasks/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/@progress/kendo-theme-tasks/node_modules/gauge": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-5.0.0.tgz",
-      "integrity": "sha512-0s5T5eciEG7Q3ugkxAkFtaDhrrhXsCRivA5y8C9WMHWuI8UlMOJg7+Iwf7Mccii+Dfs3H5jHepU0joPVyQU0Lw==",
-      "dev": true,
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/@progress/kendo-theme-tasks/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4384,45 +4319,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@progress/kendo-theme-tasks/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@progress/kendo-theme-tasks/node_modules/npmlog": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-7.0.1.tgz",
-      "integrity": "sha512-uJ0YFk/mCQpLBt+bxN88AKd+gyqZvZDbtiNxk6Waqcj2aPRyfVx8ITawkyQynxUagInjdYT1+qj4NfA5KJJUxg==",
-      "dev": true,
-      "dependencies": {
-        "are-we-there-yet": "^4.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^5.0.0",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@progress/kendo-theme-tasks/node_modules/readable-stream": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
-      "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
-      "dev": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@progress/kendo-theme-tasks/node_modules/sass": {
@@ -4440,29 +4336,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@progress/kendo-theme-tasks/node_modules/sass-build": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sass-build/-/sass-build-1.1.3.tgz",
-      "integrity": "sha512-E3BvgJa4fi1ea7qUcO8OtURQf4X8h9Z0RThhHf3tNj5w8yCNxevyBHWIhFA1Qkj1cm5YlJXJwh5lbQo+mxgEtQ==",
-      "dev": true,
-      "dependencies": {
-        "@joneff/baka": "^2.1.0",
-        "autoprefixer": "^10.0.0",
-        "glob": "^7.0.0 || ^8.0.0",
-        "lodash": "^4.17.21",
-        "mime-types": "^2.1.35",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-        "npmlog": "^7.0.1",
-        "postcss": "^8.0.0",
-        "postcss-calc": "^8.0.0",
-        "sass": "^1.50.0",
-        "sass-embedded": "^1.50.0",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "sass-build": "bin/sass-build.js"
       }
     },
     "node_modules/@progress/kendo-theme-tasks/node_modules/sass-embedded": {
@@ -4619,32 +4492,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@progress/kendo-theme-tasks/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@progress/kendo-theme-tasks/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@progress/kendo-theme-tasks/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -4658,15 +4505,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@progress/kendo-theme-tasks/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@sidvind/better-ajv-errors": {
@@ -22796,38 +22634,26 @@
       }
     },
     "node_modules/sass-build": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sass-build/-/sass-build-1.1.2.tgz",
-      "integrity": "sha512-beN+NpZyRrOTmDlxMWXXIfYy3npRdpF8LVF15f9nWuhIhrBLVPJ79kB7y4sHk27+Jruyhjb0Wu7scidpZ9NkTA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/sass-build/-/sass-build-1.1.5.tgz",
+      "integrity": "sha512-nGTtmfASFt+/jwJ8oVs+o63YdG9rQPd/jzF8h/BMU3Q8qvVr2UiViD3u4TCIsN9vrwV/6gt5lXAZ7ZRSKnGjiQ==",
       "dev": true,
       "dependencies": {
         "@joneff/baka": "^2.1.0",
+        "autoprefixer": "^10.0.0",
+        "glob": "^7.0.0 || ^8.0.0",
         "lodash": "^4.17.21",
         "mime-types": "^2.1.35",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "npmlog": "^7.0.1",
+        "postcss": "^8.0.0",
+        "postcss-calc": "^8.0.0",
+        "sass": "^1.50.0",
+        "sass-embedded": "^1.50.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
         "sass-build": "bin/sass-build.js"
-      },
-      "peerDependencies": {
-        "autoprefixer": "^10.0.0",
-        "glob": "^7.0.0 || ^8.0.0",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-        "postcss": "^8.0.0",
-        "postcss-calc": "^8.0.0",
-        "sass": "^1.50.0",
-        "sass-embedded": "^1.50.0"
-      }
-    },
-    "node_modules/sass-build/node_modules/@joneff/baka": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@joneff/baka/-/baka-2.1.0.tgz",
-      "integrity": "sha512-wIoV4emrSXHhiGZLxid/9h6gPvoxeMdJTti+bjcAlC4LK6mMGGbsm9oLMa1eKFx460QqJlu5cwS+kNOyftrw0Q==",
-      "dev": true,
-      "dependencies": {
-        "@joneff/sass-import-resolver": "^1.0.0",
-        "glob": "^8.0.3"
       }
     },
     "node_modules/sass-build/node_modules/ansi-regex": {
@@ -31241,83 +31067,11 @@
         "sass-embedded": "^1.56.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "are-we-there-yet": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-4.0.0.tgz",
-          "integrity": "sha512-nSXlV+u3vtVjRgihdTzbfWYzxPWGo424zPgQbHD0ZqIla3jqYAewDcvee0Ua2hjS5IfTAmjGlx1Jf0PKwjZDEw==",
-          "dev": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^4.1.0"
-          }
-        },
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "gauge": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-5.0.0.tgz",
-          "integrity": "sha512-0s5T5eciEG7Q3ugkxAkFtaDhrrhXsCRivA5y8C9WMHWuI8UlMOJg7+Iwf7Mccii+Dfs3H5jHepU0joPVyQU0Lw==",
-          "dev": true,
-          "requires": {
-            "aproba": "^1.0.3 || ^2.0.0",
-            "color-support": "^1.1.3",
-            "console-control-strings": "^1.1.0",
-            "has-unicode": "^2.0.1",
-            "signal-exit": "^3.0.7",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "wide-align": "^1.1.5"
-          }
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "npmlog": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-7.0.1.tgz",
-          "integrity": "sha512-uJ0YFk/mCQpLBt+bxN88AKd+gyqZvZDbtiNxk6Waqcj2aPRyfVx8ITawkyQynxUagInjdYT1+qj4NfA5KJJUxg==",
-          "dev": true,
-          "requires": {
-            "are-we-there-yet": "^4.0.0",
-            "console-control-strings": "^1.1.0",
-            "gauge": "^5.0.0",
-            "set-blocking": "^2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
-          "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10"
-          }
         },
         "sass": {
           "version": "1.57.1",
@@ -31328,26 +31082,6 @@
             "chokidar": ">=3.0.0 <4.0.0",
             "immutable": "^4.0.0",
             "source-map-js": ">=0.6.2 <2.0.0"
-          }
-        },
-        "sass-build": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/sass-build/-/sass-build-1.1.3.tgz",
-          "integrity": "sha512-E3BvgJa4fi1ea7qUcO8OtURQf4X8h9Z0RThhHf3tNj5w8yCNxevyBHWIhFA1Qkj1cm5YlJXJwh5lbQo+mxgEtQ==",
-          "dev": true,
-          "requires": {
-            "@joneff/baka": "^2.1.0",
-            "autoprefixer": "^10.0.0",
-            "glob": "^7.0.0 || ^8.0.0",
-            "lodash": "^4.17.21",
-            "mime-types": "^2.1.35",
-            "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-            "npmlog": "^7.0.1",
-            "postcss": "^8.0.0",
-            "postcss-calc": "^8.0.0",
-            "sass": "^1.50.0",
-            "sass-embedded": "^1.50.0",
-            "yargs-parser": "^21.1.1"
           }
         },
         "sass-embedded": {
@@ -31427,26 +31161,6 @@
           "dev": true,
           "optional": true
         },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -31455,12 +31169,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-          "dev": true
         }
       }
     },
@@ -45545,28 +45253,25 @@
       }
     },
     "sass-build": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sass-build/-/sass-build-1.1.2.tgz",
-      "integrity": "sha512-beN+NpZyRrOTmDlxMWXXIfYy3npRdpF8LVF15f9nWuhIhrBLVPJ79kB7y4sHk27+Jruyhjb0Wu7scidpZ9NkTA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/sass-build/-/sass-build-1.1.5.tgz",
+      "integrity": "sha512-nGTtmfASFt+/jwJ8oVs+o63YdG9rQPd/jzF8h/BMU3Q8qvVr2UiViD3u4TCIsN9vrwV/6gt5lXAZ7ZRSKnGjiQ==",
       "dev": true,
       "requires": {
         "@joneff/baka": "^2.1.0",
+        "autoprefixer": "^10.0.0",
+        "glob": "^7.0.0 || ^8.0.0",
         "lodash": "^4.17.21",
         "mime-types": "^2.1.35",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "npmlog": "^7.0.1",
+        "postcss": "^8.0.0",
+        "postcss-calc": "^8.0.0",
+        "sass": "^1.50.0",
+        "sass-embedded": "^1.50.0",
         "yargs-parser": "^21.1.1"
       },
       "dependencies": {
-        "@joneff/baka": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@joneff/baka/-/baka-2.1.0.tgz",
-          "integrity": "sha512-wIoV4emrSXHhiGZLxid/9h6gPvoxeMdJTti+bjcAlC4LK6mMGGbsm9oLMa1eKFx460QqJlu5cwS+kNOyftrw0Q==",
-          "dev": true,
-          "requires": {
-            "@joneff/sass-import-resolver": "^1.0.0",
-            "glob": "^8.0.3"
-          }
-        },
         "ansi-regex": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "nunjucks": "^3.2.3",
     "pastshots": "^1.6.2",
     "sass": "^1.54.9",
-    "sass-build": "^1.1.2",
+    "sass-build": "^1.1.5",
     "sass-embedded": "^1.54.9",
     "sass-lint": "^1.13.1",
     "sassdoc": "^2.7.4",


### PR DESCRIPTION
What's changed:

* wait for themes and test assets to be compiled before running tests
* run against rendered html files instead of the react alternative
* reduce await usage
* run in parallel via max-chunks input