### PR TITLE
Button icon svg

### DIFF
--- a/packages/default/scss/button/_layout.scss
+++ b/packages/default/scss/button/_layout.scss
@@ -88,6 +88,45 @@
             > .k-button-icon {
                 min-width: calc( #{$_font-size} * #{$_line-height} );
                 min-height: calc( #{$_font-size} * #{$_line-height} );
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+
+                &.k-svg-icon > svg,
+                &.k-icon-md > svg {
+                    width: $kendo-icon-size-md;
+                    height: $kendo-icon-size-md;
+                }
+
+                &.k-icon-xs > svg {
+                    width: $kendo-icon-size-xs;
+                    height: $kendo-icon-size-xs;
+                }
+
+                &.k-icon-sm > svg {
+                    width: $kendo-icon-size-sm;
+                    height: $kendo-icon-size-sm;
+                }
+
+                &.k-icon-lg > svg {
+                    width: $kendo-icon-size-lg;
+                    height: $kendo-icon-size-lg;
+                }
+
+                &.k-icon-xl > svg {
+                    width: $kendo-icon-size-xl;
+                    height: $kendo-icon-size-xl;
+                }
+
+                &.k-icon-xxl > svg {
+                    width: $kendo-icon-size-xxl;
+                    height: $kendo-icon-size-xxl;
+                }
+
+                &.k-icon-xxxl > svg {
+                    width: $kendo-icon-size-xxxl;
+                    height: $kendo-icon-size-xxxl;
+                }
             }
         }
     }

--- a/packages/fluent/scss/button/_layout.scss
+++ b/packages/fluent/scss/button/_layout.scss
@@ -94,6 +94,45 @@
             > .k-button-icon {
                 min-width: calc( #{$_font-size} * #{$_line-height} );
                 min-height: calc( #{$_font-size} * #{$_line-height} );
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+
+                &.k-svg-icon > svg,
+                &.k-icon-md > svg {
+                    width: var( --kendo-icon-size-md, 1rem );
+                    height: var( --kendo-icon-size-md, 1rem );
+                }
+
+                &.k-icon-xs > svg {
+                    width: var( --kendo-icon-size-sm, 0.75rem );
+                    height: var( --kendo-icon-size-sm, 0.75rem )s;
+                }
+
+                &.k-icon-sm > svg {
+                    width: var( --kendo-icon-size-sm, 0.875rem );
+                    height: var( --kendo-icon-size-sm, 0.875rem );
+                }
+
+                &.k-icon-lg > svg {
+                    width: var( --kendo-icon-size-lg, 1.25rem );
+                    height: var( --kendo-icon-size-lg, 1.25rem );
+                }
+
+                &.k-icon-xl > svg {
+                    width: var( --kendo-icon-size-xl, 1.5rem );
+                    height: var( --kendo-icon-size-xl, 1.5rem );
+                }
+
+                &.k-icon-xxl > svg {
+                    width: var( --kendo-icon-size-xxl, 2rem );
+                    height: var( --kendo-icon-size-xxl, 2rem );
+                }
+
+                &.k-icon-xxxl > svg {
+                    width: var( --kendo-icon-size-xxl, 3rem );
+                    height: var( --kendo-icon-size-xxl, 3rem );
+                }
             }
         }
     }


### PR DESCRIPTION
If a SVG icon is used insed icon button, due to the min-widht and height that we set to the .k-button-icon element, the SVG icon gets resized as well.