### PR TITLE
Minor improvements

### DIFF
--- a/packages/core/docs/customization.md
+++ b/packages/core/docs/customization.md
@@ -227,7 +227,7 @@ k-color-tint($color, $level) // => Color
 #### Source
 
 ```scss
-// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L32-L34
+// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L37-L39
 @function k-color-tint($color, $level) {
     @return k-color-level( $color, -$level );
 }
@@ -265,7 +265,7 @@ k-color-shade($color, $level) // => Color
 #### Source
 
 ```scss
-// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L45-L47
+// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L50-L52
 @function k-color-shade($color, $level) {
     @return k-color-level( $color, $level );
 }
@@ -297,7 +297,7 @@ k-try-shade($color, $level) // => Color
 #### Source
 
 ```scss
-// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L55-L63
+// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L60-L68
 @function k-try-shade($color, $level) {
     $_dark-theme: if( k-meta-variable-exists( kendo-is-dark-theme ), $kendo-is-dark-theme, false );
 
@@ -335,7 +335,7 @@ k-try-tint($color, $level) // => Color
 #### Source
 
 ```scss
-// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L71-L79
+// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L76-L84
 @function k-try-tint($color, $level) {
     $_dark-theme: if( k-meta-variable-exists( kendo-is-dark-theme ), $kendo-is-dark-theme, false );
 
@@ -373,7 +373,7 @@ k-try-darken($color, $level) // => Color
 #### Source
 
 ```scss
-// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L87-L94
+// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L92-L99
 @function k-try-darken($color, $level) {
     $_dark-theme: if( k-meta-variable-exists( kendo-is-dark-theme ), $kendo-is-dark-theme, false );
 
@@ -410,7 +410,7 @@ k-try-lighten($color, $level) // => Color
 #### Source
 
 ```scss
-// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L102-L109
+// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L107-L114
 @function k-try-lighten($color, $level) {
     $_dark-theme: if( k-meta-variable-exists( kendo-is-dark-theme ), $kendo-is-dark-theme, false );
 
@@ -453,7 +453,7 @@ k-rgba-to-mix($color, $bg) // => Color
 #### Source
 
 ```scss
-// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L120-L124
+// Location https://github.com/telerik/kendo-themes/blob/develop/packages//scss/functions/_color-manipulation.import.scss#L125-L129
 @function k-rgba-to-mix($color, $bg) {
     $percent: k-color-alpha( $color ) * 100%;
 

--- a/packages/core/scss/functions/_color-manipulation.import.scss
+++ b/packages/core/scss/functions/_color-manipulation.import.scss
@@ -1,9 +1,14 @@
+$kendo-light-color-level-step: 8% !default;
+$kendo-dark-color-level-step: 16% !default;
+
 /// Set a specific jump point for requesting color jumps
 /// @group color-system
 /// @access private
 $kendo-color-level-step: 8% !default;
 
 @function k-color-level( $color, $level: 0 ) {
+    $_dark-theme: if( k-meta-variable-exists( kendo-is-dark-theme ), $kendo-is-dark-theme, false );
+    $_color-level-step: if( $_dark-theme, $kendo-dark-color-level-step, $kendo-light-color-level-step );
 
     @if ( $level == 0 ) or ( $level == 0% ) {
         @return $color;
@@ -17,7 +22,7 @@ $kendo-color-level-step: 8% !default;
         @return k-color-mix( $base, $color, $level );
     }
 
-    @return k-color-mix( $base, $color, $level * $kendo-color-level-step );
+    @return k-color-mix( $base, $color, k-math-clamp( $level * $_color-level-step, 0%, 100% ) );
 }
 
 /// Makes a color lighter by mixing it with white

--- a/packages/utils/docs/customization.md
+++ b/packages/utils/docs/customization.md
@@ -778,15 +778,6 @@ This class could be assigned to elements which should be visually hidden, but re
 
 
 
-### `.#{$kendo-prefix}text-ellipsis`
-
-This is equivalent to `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;`.
-    @name .k-text-ellipsis
-    @group text
-
-
-
-
 ### `.k-user-select-none`
 
 This is equivalent to `user-select: none;`. The text of the element and its sub-elements is not selectable. Note that the Selection object can contain these elements.

--- a/packages/utils/scss/_variables.scss
+++ b/packages/utils/scss/_variables.scss
@@ -628,7 +628,10 @@ $kendo-utils: (
         capitalize: capitalize,
         normal-case: none
     ),
-    "text-overflow": (),
+    "text-overflow": (
+        clip: clip,
+        ellipsis: ellipsis
+    ),
     "text-indent": (),
     "vertical-align": (),
     "white-space": (

--- a/packages/utils/scss/typography/_text-overflow.scss
+++ b/packages/utils/scss/typography/_text-overflow.scss
@@ -1,0 +1,24 @@
+@mixin kendo-utils--typography--text-overflow() {
+
+    // Text overflow utility classes
+    $kendo-utils-text-overflow: k-map-get( $kendo-utils, "text-overflow" ) !default;
+    @include generate-utils( text, text-overflow, $kendo-utils-text-overflow );
+
+
+    // Text truncate utility classes
+    .#{$kendo-prefix}text-truncate {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    .\!#{$kendo-prefix}text-truncate {
+        white-space: nowrap !important; // sass-lint:disable-line no-important
+        overflow: hidden !important; // sass-lint:disable-line no-important
+        text-overflow: ellipsis !important; // sass-lint:disable-line no-important
+    }
+
+    // Legacy aliases
+    .#{$kendo-prefix}text-ellipsis { @extend .#{$kendo-prefix}text-truncate !optional; }
+    .\!#{$kendo-prefix}text-ellipsis { @extend .\!#{$kendo-prefix}text-truncate !optional; }
+
+}

--- a/packages/utils/scss/typography/index.import.scss
+++ b/packages/utils/scss/typography/index.import.scss
@@ -10,24 +10,20 @@
 @import "./_text-align.scss";
 @import "./_text-color.scss";
 // text decoration
+@import "./_text-overflow.scss";
 @import "./_text-transform.scss";
-// text overflow
 // text indent
 // vertical align
 @import "./_white-space.scss";
 
 
 @mixin kendo-utils--typography() {
-    /// This is equivalent to `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;`.
-    /// @name .k-text-ellipsis
-    /// @group text
-    .#{$kendo-prefix}text-ellipsis { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; } // sass-lint:disable-line one-declaration-per-line
-
     @include kendo-utils--typography--font-size();
     @include kendo-utils--typography--font-style();
     @include kendo-utils--typography--font-weight();
     @include kendo-utils--typography--text-align();
     @include kendo-utils--typography--text-color();
+    @include kendo-utils--typography--text-overflow();
     @include kendo-utils--typography--text-transform();
     @include kendo-utils--typography--white-space();
 }


### PR DESCRIPTION
* streamline typography styles for text overflow and text tuncate;
* use two steps for color manipulation depending on light or dark theme.

I think the latter one can be slightly improved to take into consideration the current theme and to always use `$kendo-color-level-stop`.

I had to patch the few places where the old `k-text-ellipsis` was used, but thankfully, those fall only within kendo-jquery domain, so we can fix them.