### PR TITLE
fix(pivotgrid): chip menu not properly positioned

### DIFF
--- a/packages/default/scss/chip/_layout.scss
+++ b/packages/default/scss/chip/_layout.scss
@@ -29,6 +29,11 @@
         .k-selected-icon-wrapper {
             display: none !important; // sass-lint:disable-line no-important
         }
+
+        // Adjustment for kendo-icon-wrapper
+        .k-icon-wrapper-host {
+            display: initial;
+        }
     }
 
 

--- a/packages/fluent/scss/chip/_layout.scss
+++ b/packages/fluent/scss/chip/_layout.scss
@@ -34,6 +34,11 @@
             display: none !important; // sass-lint:disable-line no-important
         }
 
+        // Adjustment for kendo-icon-wrapper
+        .k-icon-wrapper-host {
+            display: initial;
+        }
+
         &:hover,
         &:focus {
             outline: 0;

--- a/packages/nouvelle/scss/chip/_layout.scss
+++ b/packages/nouvelle/scss/chip/_layout.scss
@@ -31,6 +31,11 @@
             display: none !important; // sass-lint:disable-line no-important
         }
 
+        // Adjustment for kendo-icon-wrapper
+        .k-icon-wrapper-host {
+            display: initial;
+        }
+
         &:hover,
         &:focus {
             outline: 0;


### PR DESCRIPTION
related to https://github.com/telerik/kendo-angular-private/issues/354