### PR TITLE
Inner dropzone should not be clickable

### DIFF
--- a/packages/default/scss/dropzone/_layout.scss
+++ b/packages/default/scss/dropzone/_layout.scss
@@ -23,7 +23,6 @@
         align-items: center;
         justify-content: center;
         position: relative;
-        cursor: pointer;
 
         .k-icon,
         .k-dropzone-icon {

--- a/packages/fluent/scss/dropzone/_layout.scss
+++ b/packages/fluent/scss/dropzone/_layout.scss
@@ -25,7 +25,6 @@
         align-items: center;
         justify-content: center;
         position: relative;
-        cursor: pointer;
 
         .k-icon,
         .k-dropzone-icon {


### PR DESCRIPTION
`.k-dropzone-inner` is not clickable so the `cursor: pointer` style should be removed