### PR TITLE
fix(pivotgrid): fix vertical alignment of pivotgrid cells

### DIFF
--- a/packages/default/scss/pivotgrid/_layout.scss
+++ b/packages/default/scss/pivotgrid/_layout.scss
@@ -524,6 +524,7 @@
     }
 
     .k-pivot-layout > tbody,
+    .k-pivot .k-table-td,
     .k-pivot td {
         vertical-align: top;
     }

--- a/packages/fluent/scss/pivotgrid/_layout.scss
+++ b/packages/fluent/scss/pivotgrid/_layout.scss
@@ -504,6 +504,7 @@
     }
 
     .k-pivot-layout > tbody,
+    .k-pivot .k-table-td,
     .k-pivot td {
         vertical-align: top;
     }


### PR DESCRIPTION
fixes: https://github.com/telerik/kendo/issues/17251