### PR TITLE
fix: bootstrap swatches do not override inherited primary color

### DIFF
--- a/packages/bootstrap/lib/swatches/bootstrap-3-dark.json
+++ b/packages/bootstrap/lib/swatches/bootstrap-3-dark.json
@@ -196,6 +196,11 @@
         {
             "hidden": true,
             "variables": {
+                "primary": {
+                    "name": "Override bootstrap primary",
+                    "type": "variable",
+                    "value": "$kendo-color-primary"
+                },
                 "gray-100": {
                     "name": "Gray 100",
                     "type": "color",

--- a/packages/bootstrap/lib/swatches/bootstrap-3.json
+++ b/packages/bootstrap/lib/swatches/bootstrap-3.json
@@ -196,6 +196,11 @@
         {
             "hidden": true,
             "variables": {
+                "primary": {
+                    "name": "Override bootstrap primary",
+                    "type": "variable",
+                    "value": "$kendo-color-primary"
+                },
                 "gray-100": {
                     "name": "Gray 100",
                     "type": "color",

--- a/packages/bootstrap/lib/swatches/bootstrap-4-dark.json
+++ b/packages/bootstrap/lib/swatches/bootstrap-4-dark.json
@@ -187,6 +187,16 @@
                     "value": "#d9534f"
                 }
             }
+        },
+        {
+            "hidden": true,
+            "variables": {
+                "primary": {
+                    "name": "Override bootstrap primary",
+                    "type": "variable",
+                    "value": "$kendo-color-primary"
+                }
+            }
         }
     ]
 }

--- a/packages/bootstrap/lib/swatches/bootstrap-4.json
+++ b/packages/bootstrap/lib/swatches/bootstrap-4.json
@@ -187,6 +187,16 @@
                     "value": "#d9534f"
                 }
             }
+        },
+        {
+            "hidden": true,
+            "variables": {
+                "primary": {
+                    "name": "Override bootstrap primary",
+                    "type": "variable",
+                    "value": "$kendo-color-primary"
+                }
+            }
         }
     ]
 }

--- a/packages/bootstrap/lib/swatches/bootstrap-main-dark.json
+++ b/packages/bootstrap/lib/swatches/bootstrap-main-dark.json
@@ -187,6 +187,16 @@
                     "value": "#dc3545"
                 }
             }
+        },
+        {
+            "hidden": true,
+            "variables": {
+                "primary": {
+                    "name": "Override bootstrap primary",
+                    "type": "variable",
+                    "value": "$kendo-color-primary"
+                }
+            }
         }
     ]
 }

--- a/packages/bootstrap/lib/swatches/bootstrap-nordic.json
+++ b/packages/bootstrap/lib/swatches/bootstrap-nordic.json
@@ -187,6 +187,16 @@
                     "value": "#c09e2f"
                 }
             }
+        },
+        {
+            "hidden": true,
+            "variables": {
+                "primary": {
+                    "name": "Override bootstrap primary",
+                    "type": "variable",
+                    "value": "$kendo-color-primary"
+                }
+            }
         }
     ]
 }

--- a/packages/bootstrap/lib/swatches/bootstrap-turquoise-dark.json
+++ b/packages/bootstrap/lib/swatches/bootstrap-turquoise-dark.json
@@ -187,6 +187,16 @@
                     "value": "#aa46be"
                 }
             }
+        },
+        {
+            "hidden": true,
+            "variables": {
+                "primary": {
+                    "name": "Override bootstrap primary",
+                    "type": "variable",
+                    "value": "$kendo-color-primary"
+                }
+            }
         }
     ]
 }

--- a/packages/bootstrap/lib/swatches/bootstrap-turquoise.json
+++ b/packages/bootstrap/lib/swatches/bootstrap-turquoise.json
@@ -187,6 +187,16 @@
                     "value": "#aa46be"
                 }
             }
+        },
+        {
+            "hidden": true,
+            "variables": {
+                "primary": {
+                    "name": "Override bootstrap primary",
+                    "type": "variable",
+                    "value": "$kendo-color-primary"
+                }
+            }
         }
     ]
 }

--- a/packages/bootstrap/lib/swatches/bootstrap-urban.json
+++ b/packages/bootstrap/lib/swatches/bootstrap-urban.json
@@ -187,6 +187,16 @@
                     "value": "#355261"
                 }
             }
+        },
+        {
+            "hidden": true,
+            "variables": {
+                "primary": {
+                    "name": "Override bootstrap primary",
+                    "type": "variable",
+                    "value": "$kendo-color-primary"
+                }
+            }
         }
     ]
 }

--- a/packages/bootstrap/lib/swatches/bootstrap-vintage.json
+++ b/packages/bootstrap/lib/swatches/bootstrap-vintage.json
@@ -187,6 +187,16 @@
                     "value": "#b38400"
                 }
             }
+        },
+        {
+            "hidden": true,
+            "variables": {
+                "primary": {
+                    "name": "Override bootstrap primary",
+                    "type": "variable",
+                    "value": "$kendo-color-primary"
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
fixes: https://github.com/telerik/kendo-themes/issues/4314