### PR TITLE
fix(chip): close icon not properly aligned

### DIFF
--- a/packages/default/scss/chip/_layout.scss
+++ b/packages/default/scss/chip/_layout.scss
@@ -29,11 +29,6 @@
         .k-selected-icon-wrapper {
             display: none !important; // sass-lint:disable-line no-important
         }
-
-        // Adjustment for kendo-icon-wrapper
-        .k-icon-wrapper-host {
-            display: initial;
-        }
     }
 
 
@@ -49,6 +44,11 @@
         align-items: center;
         overflow: hidden;
         flex: 1 1 auto;
+
+        // Adjustment for kendo-icon-wrapper
+        .k-icon-wrapper-host {
+            display: initial;
+        }
     }
     .k-chip-content:first-child {
         margin-inline-start: $kendo-chip-spacing;

--- a/packages/fluent/scss/chip/_layout.scss
+++ b/packages/fluent/scss/chip/_layout.scss
@@ -34,11 +34,6 @@
             display: none !important; // sass-lint:disable-line no-important
         }
 
-        // Adjustment for kendo-icon-wrapper
-        .k-icon-wrapper-host {
-            display: initial;
-        }
-
         &:hover,
         &:focus {
             outline: 0;
@@ -70,6 +65,11 @@
         align-items: center;
         overflow: hidden;
         flex: 1 1 auto;
+
+        // Adjustment for kendo-icon-wrapper
+        .k-icon-wrapper-host {
+            display: initial;
+        }
     }
 
     .k-chip-content:first-child {

--- a/packages/nouvelle/scss/chip/_layout.scss
+++ b/packages/nouvelle/scss/chip/_layout.scss
@@ -31,11 +31,6 @@
             display: none !important; // sass-lint:disable-line no-important
         }
 
-        // Adjustment for kendo-icon-wrapper
-        .k-icon-wrapper-host {
-            display: initial;
-        }
-
         &:hover,
         &:focus {
             outline: 0;
@@ -55,6 +50,11 @@
         align-items: center;
         overflow: hidden;
         flex: 1 1 auto;
+
+        // Adjustment for kendo-icon-wrapper
+        .k-icon-wrapper-host {
+            display: initial;
+        }
     }
 
 


### PR DESCRIPTION
related to https://github.com/telerik/kendo-themes/pull/4290

The fix from the above PR breaks the Close icon alignment. It is no longer aligned in the middle.
The issue is not noticeable in the Default theme but it can be seen in the Bootstrap and the Material themes.

https://www.telerik.com/kendo-angular-ui-develop/components/buttons/chip/

![chip](https://user-images.githubusercontent.com/7753940/223429536-4c22c497-1f7a-4734-8849-cf1449b49812.png)
