### PR TITLE
chore: export  form specs

### DIFF
--- a/packages/html/src/action-buttons/action-buttons.spec.tsx
+++ b/packages/html/src/action-buttons/action-buttons.spec.tsx
@@ -45,5 +45,6 @@ export const ActionButtons = (
 ActionButtons.states = states;
 ActionButtons.options = options;
 ActionButtons.className = ACTIONBUTTONS_CLASSNAME;
+ActionButtons.defaultProps = defaultProps;
 
 export default ActionButtons;

--- a/packages/html/src/action-sheet/action-sheet.spec.tsx
+++ b/packages/html/src/action-sheet/action-sheet.spec.tsx
@@ -119,5 +119,6 @@ export const ActionSheet = (
 ActionSheet.states = states;
 ActionSheet.options = options;
 ActionSheet.className = ACTIONSHEET_CLASSNAME;
+ActionSheet.defaultProps = defaultProps;
 
 export default ActionSheet;

--- a/packages/html/src/appbar/appbar.spec.tsx
+++ b/packages/html/src/appbar/appbar.spec.tsx
@@ -20,6 +20,7 @@ const options = {
         ThemeColor.inverse
     ],
 };
+const defaultProps = {};
 
 export type KendoAppbarOptions = {
   themeColor?: (typeof options.themeColor)[number] | null;
@@ -64,5 +65,6 @@ export const Appbar = (
 Appbar.states = states;
 Appbar.options = options;
 Appbar.className = APPBAR_CLASSNAME;
+Appbar.defaultProps = defaultProps;
 
 export default Appbar;

--- a/packages/html/src/autocomplete/autocomplete.spec.tsx
+++ b/packages/html/src/autocomplete/autocomplete.spec.tsx
@@ -27,6 +27,7 @@ const options = {
     rounded: [ Roundness.small, Roundness.medium, Roundness.large, Roundness.full ],
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
+const defaultProps = {};
 
 export type KendoAutocompleteOptions = {
     size?: (typeof options.size)[number] | null;
@@ -107,5 +108,6 @@ export const Autocomplete = (
 Autocomplete.states = states;
 Autocomplete.options = options;
 Autocomplete.className = AUTOCOMPLETE_CLASSNAME;
+Autocomplete.defaultProps = defaultProps;
 
 export default Autocomplete;

--- a/packages/html/src/autocomplete/autocomplete.spec.tsx
+++ b/packages/html/src/autocomplete/autocomplete.spec.tsx
@@ -27,7 +27,11 @@ const options = {
     rounded: [ Roundness.small, Roundness.medium, Roundness.large, Roundness.full ],
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
-const defaultProps = {};
+const defaultProps = {
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
+};
 
 export type KendoAutocompleteOptions = {
     size?: (typeof options.size)[number] | null;

--- a/packages/html/src/avatar/avatar.spec.tsx
+++ b/packages/html/src/avatar/avatar.spec.tsx
@@ -99,5 +99,6 @@ export const Avatar = (
 Avatar.states = states;
 Avatar.options = options;
 Avatar.className = AVATAR_CLASSNAME;
+Avatar.defaultProps = defaultProps;
 
 export default Avatar;

--- a/packages/html/src/badge/badge.spec.tsx
+++ b/packages/html/src/badge/badge.spec.tsx
@@ -85,5 +85,6 @@ export const Badge = (
 Badge.states = states;
 Badge.options = options;
 Badge.className = BADGE_CLASSNAME;
+Badge.defaultProps = defaultProps;
 
 export default Badge;

--- a/packages/html/src/button-group/button-group.spec.tsx
+++ b/packages/html/src/button-group/button-group.spec.tsx
@@ -61,5 +61,6 @@ export const ButtonGroup = (
 ButtonGroup.states = states;
 ButtonGroup.options = options;
 ButtonGroup.className = BUTTONGROUP_CLASSNAME;
+ButtonGroup.defaultProps = defaultProps;
 
 export default ButtonGroup;

--- a/packages/html/src/button/button.spec.tsx
+++ b/packages/html/src/button/button.spec.tsx
@@ -131,5 +131,6 @@ export const Button = (
 Button.states = states;
 Button.options = options;
 Button.className = BUTTON_CLASSNAME;
+Button.defaultProps = defaultProps;
 
 export default Button;

--- a/packages/html/src/calendar/calendar.spec.tsx
+++ b/packages/html/src/calendar/calendar.spec.tsx
@@ -89,5 +89,6 @@ export const Calendar = (
 Calendar.states = states;
 Calendar.options = options;
 Calendar.className = CALENDAR_CLASSNAME;
+Calendar.defaultProps = defaultProps;
 
 export default Calendar;

--- a/packages/html/src/captcha/captcha.spec.tsx
+++ b/packages/html/src/captcha/captcha.spec.tsx
@@ -12,6 +12,7 @@ const states = [
 ];
 
 const options = {};
+const defaultProps = {};
 
 export type KendoCaptchaProps = {
     value?: string;
@@ -86,5 +87,6 @@ export const Captcha = (
 Captcha.states = states;
 Captcha.options = options;
 Captcha.className = CAPTCHA_CLASSNAME;
+Captcha.defaultProps = defaultProps;
 
 export default Captcha;

--- a/packages/html/src/card/card.spec.tsx
+++ b/packages/html/src/card/card.spec.tsx
@@ -20,6 +20,8 @@ const options = {
     ],
 };
 
+const defaultProps = {};
+
 export type KendoCardOptions = {
   themeColor?: (typeof options.themeColor)[number] | null;
 };
@@ -79,5 +81,6 @@ export const Card = (
 Card.states = states;
 Card.options = options;
 Card.className = CARD_CLASSNAME;
+Card.defaultProps = defaultProps;
 
 export default Card;

--- a/packages/html/src/checkbox/checkbox.spec.tsx
+++ b/packages/html/src/checkbox/checkbox.spec.tsx
@@ -74,5 +74,6 @@ export const Checkbox = (
 Checkbox.states = states;
 Checkbox.options = options;
 Checkbox.className = CHECKBOX_CLASSNAME;
+Checkbox.defaultProps = defaultProps;
 
 export default Checkbox;

--- a/packages/html/src/chip/chip-list.spec.tsx
+++ b/packages/html/src/chip/chip-list.spec.tsx
@@ -44,5 +44,6 @@ export const ChipList = (
 ChipList.states = states;
 ChipList.options = options;
 ChipList.className = CHIPLIST_CLASSNAME;
+ChipList.defaultProps = defaultProps;
 
 export default ChipList;

--- a/packages/html/src/chip/chip.spec.tsx
+++ b/packages/html/src/chip/chip.spec.tsx
@@ -115,5 +115,6 @@ export const Chip = (
 Chip.states = states;
 Chip.options = options;
 Chip.className = CHIP_CLASSNAME;
+Chip.defaultProps = defaultProps;
 
 export default Chip;

--- a/packages/html/src/colorpalette/colorpalette.spec.tsx
+++ b/packages/html/src/colorpalette/colorpalette.spec.tsx
@@ -82,5 +82,6 @@ export const ColorPalette = (
 ColorPalette.states = states;
 ColorPalette.options = options;
 ColorPalette.className = COLORPALETTE_CLASSNAME;
+ColorPalette.defaultProps = defaultProps;
 
 export default ColorPalette;

--- a/packages/html/src/colorpicker/colorpicker.spec.tsx
+++ b/packages/html/src/colorpicker/colorpicker.spec.tsx
@@ -44,7 +44,10 @@ export type KendoColorPickerProps = KendoColorPickerOptions & {
 export type KendoColorPickerState = { [K in (typeof states)[number]]?: boolean };
 
 const defaultProps = {
-    arrowIconName: 'arrow-s'
+    arrowIconName: 'arrow-s',
+    size: Picker.defaultProps.size,
+    rounded: Picker.defaultProps.rounded,
+    fillMode: Picker.defaultProps.fillMode
 };
 
 export const ColorPicker = (

--- a/packages/html/src/colorpicker/colorpicker.spec.tsx
+++ b/packages/html/src/colorpicker/colorpicker.spec.tsx
@@ -119,5 +119,6 @@ export const ColorPicker = (
 ColorPicker.states = states;
 ColorPicker.options = options;
 ColorPicker.className = COLORPICKER_CLASSNAME;
+ColorPicker.defaultProps = defaultProps;
 
 export default ColorPicker;

--- a/packages/html/src/combobox/combobox.spec.tsx
+++ b/packages/html/src/combobox/combobox.spec.tsx
@@ -24,7 +24,11 @@ const states = [
     States.readonly
 ];
 
-const defaultProps = {};
+const defaultProps = {
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
+};
 
 const options = {
     size: [ Size.small, Size.medium, Size.large ],

--- a/packages/html/src/combobox/combobox.spec.tsx
+++ b/packages/html/src/combobox/combobox.spec.tsx
@@ -24,6 +24,8 @@ const states = [
     States.readonly
 ];
 
+const defaultProps = {};
+
 const options = {
     size: [ Size.small, Size.medium, Size.large ],
     rounded: [ Roundness.small, Roundness.medium, Roundness.large, Roundness.full ],
@@ -127,5 +129,6 @@ export const Combobox = (
 Combobox.states = states;
 Combobox.options = options;
 Combobox.className = COMBOBOX_CLASSNAME;
+Combobox.defaultProps = defaultProps;
 
 export default Combobox;

--- a/packages/html/src/dateinput/dateinput.spec.tsx
+++ b/packages/html/src/dateinput/dateinput.spec.tsx
@@ -113,5 +113,6 @@ export const DateInput = (
 DateInput.states = states;
 DateInput.options = options;
 DateInput.className = DATEINPUT_CLASSNAME;
+DateInput.defaultProps = defaultProps;
 
 export default DateInput;

--- a/packages/html/src/dateinput/dateinput.spec.tsx
+++ b/packages/html/src/dateinput/dateinput.spec.tsx
@@ -42,7 +42,10 @@ export type KendoDateInputProps = KendoDateInputOptions & {
 export type KendoDateInputState = { [K in (typeof states)[number]]?: boolean };
 
 const defaultProps = {
-    showSpinButton: true
+    showSpinButton: true,
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
 };
 
 export const DateInput = (

--- a/packages/html/src/datepicker/datepicker.spec.tsx
+++ b/packages/html/src/datepicker/datepicker.spec.tsx
@@ -31,6 +31,8 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
+const defaultProps = {};
+
 export type KendoDatePickerOptions = {
     size?: (typeof options.size)[number] | null;
     rounded?: (typeof options.rounded)[number] | null;
@@ -126,5 +128,6 @@ export const DatePicker = (
 DatePicker.states = states;
 DatePicker.options = options;
 DatePicker.className = DATEPICKER_CLASSNAME;
+DatePicker.defaultProps = defaultProps;
 
 export default DatePicker;

--- a/packages/html/src/datepicker/datepicker.spec.tsx
+++ b/packages/html/src/datepicker/datepicker.spec.tsx
@@ -31,7 +31,11 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
-const defaultProps = {};
+const defaultProps = {
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
+};
 
 export type KendoDatePickerOptions = {
     size?: (typeof options.size)[number] | null;

--- a/packages/html/src/daterangepicker/daterangepicker.spec.tsx
+++ b/packages/html/src/daterangepicker/daterangepicker.spec.tsx
@@ -17,6 +17,8 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
+const defaultProps = {};
+
 export type KendoDateRangePickerOptions = {
     size?: (typeof options.size)[number] | null;
     rounded?: (typeof options.rounded)[number] | null;
@@ -94,5 +96,6 @@ export const DateRangePicker = (
 DateRangePicker.states = states;
 DateRangePicker.options = options;
 DateRangePicker.className = DATERANGEPICKER_CLASSNAME;
+DateRangePicker.defaultProps = defaultProps;
 
 export default DateRangePicker;

--- a/packages/html/src/datetime-selector/datetime-selector.spec.tsx
+++ b/packages/html/src/datetime-selector/datetime-selector.spec.tsx
@@ -78,5 +78,6 @@ export const DateTimeSelector = (
 DateTimeSelector.states = states;
 DateTimeSelector.options = options;
 DateTimeSelector.className = DATETIMESELECTOR_CLASSNAME;
+DateTimeSelector.defaultProps = defaultProps;
 
 export default DateTimeSelector;

--- a/packages/html/src/datetimepicker/datetimepicker.spec.tsx
+++ b/packages/html/src/datetimepicker/datetimepicker.spec.tsx
@@ -132,5 +132,6 @@ export const DateTimePicker = (
 DateTimePicker.states = states;
 DateTimePicker.options = options;
 DateTimePicker.className = DATETIMEPICKER_CLASSNAME;
+DateTimePicker.defaultProps = defaultProps;
 
 export default DateTimePicker;

--- a/packages/html/src/datetimepicker/datetimepicker.spec.tsx
+++ b/packages/html/src/datetimepicker/datetimepicker.spec.tsx
@@ -49,7 +49,10 @@ export type KendoDateTimePickerProps = KendoDateTimePickerOptions & {
 export type KendoDateTimePickerState = { [K in (typeof states)[number]]?: boolean };
 
 const defaultProps = {
-    tab: 'date'
+    tab: 'date',
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
 } as const;
 
 export const DateTimePicker = (

--- a/packages/html/src/dialog/dialog.spec.tsx
+++ b/packages/html/src/dialog/dialog.spec.tsx
@@ -14,6 +14,8 @@ const options = {
     ],
 };
 
+const defaultProps = {};
+
 export type KendoDialogOptions = {
   themeColor?: (typeof options.themeColor)[number] | null;
 };
@@ -76,5 +78,6 @@ export const Dialog = (
 Dialog.states = states;
 Dialog.options = options;
 Dialog.className = DIALOG_CLASSNAME;
+Dialog.defaultProps = defaultProps;
 
 export default Dialog;

--- a/packages/html/src/dropdowngrid/dropdowngrid.spec.tsx
+++ b/packages/html/src/dropdowngrid/dropdowngrid.spec.tsx
@@ -30,7 +30,11 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
-const defaultProps = {};
+const defaultProps = {
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
+};
 
 export type KendoDropdownGridOptions = {
     size?: (typeof options.size)[number] | null;

--- a/packages/html/src/dropdowngrid/dropdowngrid.spec.tsx
+++ b/packages/html/src/dropdowngrid/dropdowngrid.spec.tsx
@@ -30,6 +30,8 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
+const defaultProps = {};
+
 export type KendoDropdownGridOptions = {
     size?: (typeof options.size)[number] | null;
     rounded?: (typeof options.rounded)[number] | null;
@@ -133,5 +135,6 @@ export const DropdownGrid = (
 DropdownGrid.states = states;
 DropdownGrid.options = options;
 DropdownGrid.className = DROPDOWNGRID_CLASSNAME;
+DropdownGrid.defaultProps = defaultProps;
 
 export default DropdownGrid;

--- a/packages/html/src/dropdownlist/dropdownlist.spec.tsx
+++ b/packages/html/src/dropdownlist/dropdownlist.spec.tsx
@@ -143,5 +143,6 @@ export const DropdownList = (
 DropdownList.states = states;
 DropdownList.options = options;
 DropdownList.className = DROPDOWNLIST_CLASSNAME;
+DropdownList.defaultProps = defaultProps;
 
 export default DropdownList;

--- a/packages/html/src/dropdownlist/dropdownlist.spec.tsx
+++ b/packages/html/src/dropdownlist/dropdownlist.spec.tsx
@@ -51,7 +51,10 @@ export type KendoDropdownListState = { [K in (typeof states)[number]]?: boolean 
 
 const defaultProps = {
     showValue: true,
-    arrowIconName: 'arrow-s'
+    arrowIconName: 'arrow-s',
+    size: Size.medium,
+    rounded: Roundness.medium,
+    fillMode: FillMode.solid,
 };
 
 export const DropdownList = (

--- a/packages/html/src/dropdowntree/dropdowntree.spec.tsx
+++ b/packages/html/src/dropdowntree/dropdowntree.spec.tsx
@@ -143,5 +143,6 @@ export const DropdownTree = (
 DropdownTree.states = states;
 DropdownTree.options = options;
 DropdownTree.className = DROPDOWNTREE_CLASSNAME;
+DropdownTree.defaultProps = defaultProps;
 
 export default DropdownTree;

--- a/packages/html/src/dropdowntree/dropdowntree.spec.tsx
+++ b/packages/html/src/dropdowntree/dropdowntree.spec.tsx
@@ -51,7 +51,10 @@ export type KendoDropdownTreeState = { [K in (typeof states)[number]]?: boolean 
 
 const defaultProps = {
     showValue: true,
-    arrowIconName: 'arrow-s'
+    arrowIconName: 'arrow-s',
+    size: Size.medium,
+    rounded: Roundness.medium,
+    fillMode: FillMode.solid,
 };
 
 export const DropdownTree = (

--- a/packages/html/src/editor/editor.spec.tsx
+++ b/packages/html/src/editor/editor.spec.tsx
@@ -8,6 +8,8 @@ const states = [
 
 const options = {};
 
+const defaultProps = {};
+
 export type KendoEditorState = { [K in (typeof states)[number]]?: boolean };
 
 export const Editor = (
@@ -37,5 +39,6 @@ export const Editor = (
 Editor.states = states;
 Editor.options = options;
 Editor.className = EDITOR_CLASSNAME;
+Editor.defaultProps = defaultProps;
 
 export default Editor;

--- a/packages/html/src/fab/fab.spec.tsx
+++ b/packages/html/src/fab/fab.spec.tsx
@@ -109,5 +109,6 @@ export const FloatingActionButton = (
 FloatingActionButton.states = states;
 FloatingActionButton.options = options;
 FloatingActionButton.className = FLOATINGACTIONBUTTON_CLASSNAME;
+FloatingActionButton.defaultProps = defaultProps;
 
 export default FloatingActionButton;

--- a/packages/html/src/floating-label/floating-label.spec.tsx
+++ b/packages/html/src/floating-label/floating-label.spec.tsx
@@ -12,6 +12,8 @@ const states = [
 
 const options = {};
 
+const defaultProps = {};
+
 export type FloatingLabelState = { [K in (typeof states)[number]]?: boolean };
 
 export type KendoFloatingLabelrProps = {
@@ -53,5 +55,6 @@ export const FloatingLabel = (
 FloatingLabel.states = states;
 FloatingLabel.options = options;
 FloatingLabel.className = FLOATINGLABEL_CLASSNAME;
+FloatingLabel.defaultProps = defaultProps;
 
 export default FloatingLabel;

--- a/packages/html/src/form/form.spec.tsx
+++ b/packages/html/src/form/form.spec.tsx
@@ -93,6 +93,7 @@ export const Form = (
 Form.states = states;
 Form.options = options;
 Form.className = FORM_CLASSNAME;
+Form.defaultProps = defaultProps;
 
 export default Form;
 

--- a/packages/html/src/icon/icon.spec.tsx
+++ b/packages/html/src/icon/icon.spec.tsx
@@ -20,6 +20,8 @@ const options = {
     ],
 };
 
+const defaultProps = {};
+
 export type IconState = { [K in (typeof states)[number]]?: boolean };
 
 export type IconOptions = {
@@ -72,5 +74,6 @@ export const Icon = (
 Icon.states = states;
 Icon.options = options;
 Icon.className = ICON_CLASSNAME;
+Icon.defaultProps = defaultProps;
 
 export default Icon;

--- a/packages/html/src/input/input.spec.tsx
+++ b/packages/html/src/input/input.spec.tsx
@@ -65,5 +65,6 @@ export const Input = (
 Input.states = states;
 Input.options = options;
 Input.className = INPUT_CLASSNAME;
+Input.defaultProps = defaultProps;
 
 export default Input;

--- a/packages/html/src/input/picker.spec.tsx
+++ b/packages/html/src/input/picker.spec.tsx
@@ -19,7 +19,6 @@ export const pickerOptions = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
-const defaultProps = {};
 
 export type PickerState = { [K in (typeof pickerStates)[number]]?: boolean };
 
@@ -29,7 +28,7 @@ export type PickerOptions = {
   fillMode?: (typeof pickerOptions.fillMode)[number] | null;
 };
 
-export const pickerDefaultProps = {
+const defaultProps = {
     size: Size.medium,
     rounded: Roundness.medium,
     fillMode: FillMode.solid,
@@ -46,9 +45,9 @@ export const Picker = (
         valid,
         loading,
         readonly,
-        size = pickerDefaultProps.size,
-        rounded = pickerDefaultProps.rounded,
-        fillMode = pickerDefaultProps.fillMode,
+        size = defaultProps.size,
+        rounded = defaultProps.rounded,
+        fillMode = defaultProps.fillMode,
         ...other
     } = props;
 

--- a/packages/html/src/input/picker.spec.tsx
+++ b/packages/html/src/input/picker.spec.tsx
@@ -19,6 +19,8 @@ export const pickerOptions = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
+const defaultProps = {};
+
 export type PickerState = { [K in (typeof pickerStates)[number]]?: boolean };
 
 export type PickerOptions = {
@@ -67,5 +69,6 @@ export const Picker = (
 Picker.states = pickerStates;
 Picker.options = pickerOptions;
 Picker.className = PICKER_CLASSNAME;
+Picker.defaultProps = defaultProps;
 
 export default Picker;

--- a/packages/html/src/list/list-angular.spec.tsx
+++ b/packages/html/src/list/list-angular.spec.tsx
@@ -110,5 +110,6 @@ export const ListAngular = (
 ListAngular.states = states;
 ListAngular.options = options;
 ListAngular.className = LISTANGULAR_CLASSNAME;
+ListAngular.defaultProps = defaultProps;
 
 export default ListAngular;

--- a/packages/html/src/list/list-item.spec.tsx
+++ b/packages/html/src/list/list-item.spec.tsx
@@ -13,6 +13,8 @@ const states = [
 
 const options = {};
 
+const defaultProps = {};
+
 export type KendoListItemProps = {
     text?: string;
     groupLabel?: string;
@@ -72,5 +74,6 @@ export const ListItem = (
 ListItem.states = states;
 ListItem.options = options;
 ListItem.className = LISTITEM_CLASSNAME;
+ListItem.defaultProps = defaultProps;
 
 export default ListItem;

--- a/packages/html/src/list/list.spec.tsx
+++ b/packages/html/src/list/list.spec.tsx
@@ -109,5 +109,6 @@ export const List = (
 List.states = states;
 List.options = options;
 List.className = LIST_CLASSNAME;
+List.defaultProps = defaultProps;
 
 export default List;

--- a/packages/html/src/listbox/listbox.spec.tsx
+++ b/packages/html/src/listbox/listbox.spec.tsx
@@ -82,5 +82,6 @@ export const ListBox = (
 ListBox.states = states;
 ListBox.options = options;
 ListBox.className = LISTBOX_CLASSNAME;
+ListBox.defaultProps = defaultProps;
 
 export default ListBox;

--- a/packages/html/src/listview/listview-item.spec.tsx
+++ b/packages/html/src/listview/listview-item.spec.tsx
@@ -9,6 +9,8 @@ const states = [
 
 const options = {};
 
+const defaultProps = {};
+
 export type KendoListViewItemState = { [K in (typeof states)[number]]?: boolean };
 
 export const ListViewItem = (
@@ -40,5 +42,6 @@ export const ListViewItem = (
 ListViewItem.states = states;
 ListViewItem.options = options;
 ListViewItem.className = LISTVIEWITEM_CLASSNAME;
+ListViewItem.defaultProps = defaultProps;
 
 export default ListViewItem;

--- a/packages/html/src/listview/listview.spec.tsx
+++ b/packages/html/src/listview/listview.spec.tsx
@@ -95,5 +95,6 @@ export const ListView = (
 ListView.states = states;
 ListView.options = options;
 ListView.className = LISTVIEW_CLASSNAME;
+ListView.defaultProps = defaultProps;
 
 export default ListView;

--- a/packages/html/src/loader/loader-container.spec.tsx
+++ b/packages/html/src/loader/loader-container.spec.tsx
@@ -90,5 +90,6 @@ export const LoaderContainer = (
 LoaderContainer.states = states;
 LoaderContainer.options = options;
 LoaderContainer.className = LOADERCONTAINER_CLASSNAME;
+LoaderContainer.defaultProps = defaultProps;
 
 export default LoaderContainer;

--- a/packages/html/src/loader/loader.spec.tsx
+++ b/packages/html/src/loader/loader.spec.tsx
@@ -103,5 +103,6 @@ export const Loader = (
 Loader.states = states;
 Loader.options = options;
 Loader.className = LOADER_CLASSNAME;
+Loader.defaultProps = defaultProps;
 
 export default Loader;

--- a/packages/html/src/maskedtextbox/maskedtextbox.spec.tsx
+++ b/packages/html/src/maskedtextbox/maskedtextbox.spec.tsx
@@ -42,7 +42,10 @@ export type KendoMaskedTextboxProps = KendoMaskedTextboxOptions & {
 export type KendoMaskedTextboxState = { [K in (typeof states)[number]]?: boolean };
 
 const defaultProps = {
-    showClearButton: true
+    showClearButton: true,
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
 };
 
 export const MaskedTextbox = (

--- a/packages/html/src/maskedtextbox/maskedtextbox.spec.tsx
+++ b/packages/html/src/maskedtextbox/maskedtextbox.spec.tsx
@@ -106,5 +106,6 @@ export const MaskedTextbox = (
 MaskedTextbox.states = states;
 MaskedTextbox.options = options;
 MaskedTextbox.className = MASKEDTEXTBOX_CLASSNAME;
+MaskedTextbox.defaultProps = defaultProps;
 
 export default MaskedTextbox;

--- a/packages/html/src/menu-button/menu-button.spec.tsx
+++ b/packages/html/src/menu-button/menu-button.spec.tsx
@@ -105,5 +105,6 @@ export const MenuButton = (
 MenuButton.states = states;
 MenuButton.options = options;
 MenuButton.className = MENUBUTTON_CLASSNAME;
+MenuButton.defaultProps = defaultProps;
 
 export default MenuButton;

--- a/packages/html/src/menu/menu-item.spec.tsx
+++ b/packages/html/src/menu/menu-item.spec.tsx
@@ -106,5 +106,6 @@ export const MenuItem = (
 MenuItem.states = states;
 MenuItem.options = options;
 MenuItem.className = MENUITEM_CLASSNAME;
+MenuItem.defaultProps = defaultProps;
 
 export default MenuItem;

--- a/packages/html/src/menu/menu-list.spec.tsx
+++ b/packages/html/src/menu/menu-list.spec.tsx
@@ -44,5 +44,6 @@ export const MenuList = (
 MenuList.states = states;
 MenuList.options = options;
 MenuList.className = MENULIST_CLASSNAME;
+MenuList.defaultProps = defaultProps;
 
 export default MenuList;

--- a/packages/html/src/multiselect/multiselect.spec.tsx
+++ b/packages/html/src/multiselect/multiselect.spec.tsx
@@ -31,7 +31,11 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
-const defaultProps = {};
+const defaultProps = {
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
+};
 
 export type KendoMultiSelectOptions = {
     size?: (typeof options.size)[number] | null;

--- a/packages/html/src/multiselect/multiselect.spec.tsx
+++ b/packages/html/src/multiselect/multiselect.spec.tsx
@@ -31,6 +31,8 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
+const defaultProps = {};
+
 export type KendoMultiSelectOptions = {
     size?: (typeof options.size)[number] | null;
     rounded?: (typeof options.rounded)[number] | null;
@@ -142,5 +144,6 @@ export const MultiSelect = (
 MultiSelect.states = states;
 MultiSelect.options = options;
 MultiSelect.className = MULTISELECT_CLASSNAME;
+MultiSelect.defaultProps = defaultProps;
 
 export default MultiSelect;

--- a/packages/html/src/multiviewcalendar/multiviewcalendar.spec.tsx
+++ b/packages/html/src/multiviewcalendar/multiviewcalendar.spec.tsx
@@ -73,5 +73,6 @@ export const MultiViewCalendar = (
 MultiViewCalendar.states = states;
 MultiViewCalendar.options = options;
 MultiViewCalendar.className = MULTIVIEWCALENDAR_CLASSNAME;
+MultiViewCalendar.defaultProps = defaultProps;
 
 export default MultiViewCalendar;

--- a/packages/html/src/notification/notification.spec.tsx
+++ b/packages/html/src/notification/notification.spec.tsx
@@ -86,5 +86,6 @@ export const Notification = (
 Notification.states = states;
 Notification.options = options;
 Notification.className = NOTIFICATION_CLASSNAME;
+Notification.defaultProps = defaultProps;
 
 export default Notification;

--- a/packages/html/src/numerictextbox/numerictextbox.spec.tsx
+++ b/packages/html/src/numerictextbox/numerictextbox.spec.tsx
@@ -45,7 +45,10 @@ export type KendoNumericTextboxState = { [K in (typeof states)[number]]?: boolea
 
 const defaultProps = {
     showSpinButton: true,
-    showClearButton: true
+    showClearButton: true,
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
 };
 
 export const NumericTextbox = (

--- a/packages/html/src/numerictextbox/numerictextbox.spec.tsx
+++ b/packages/html/src/numerictextbox/numerictextbox.spec.tsx
@@ -117,5 +117,6 @@ export const NumericTextbox = (
 NumericTextbox.states = states;
 NumericTextbox.options = options;
 NumericTextbox.className = NUMERICTEXTBOX_CLASSNAME;
+NumericTextbox.defaultProps = defaultProps;
 
 export default NumericTextbox;

--- a/packages/html/src/orgchart/orgchart.spec.tsx
+++ b/packages/html/src/orgchart/orgchart.spec.tsx
@@ -97,5 +97,6 @@ export const Orgchart = (
 Orgchart.states = states;
 Orgchart.options = options;
 Orgchart.className = ORGCHART_CLASSNAME;
+Orgchart.defaultProps = defaultProps;
 
 export default Orgchart;

--- a/packages/html/src/pager/pager.spec.tsx
+++ b/packages/html/src/pager/pager.spec.tsx
@@ -243,5 +243,6 @@ export const Pager = (
 Pager.states = states;
 Pager.options = options;
 Pager.className = PAGER_CLASSNAME;
+Pager.defaultProps = defaultProps;
 
 export default Pager;

--- a/packages/html/src/popover/popover.spec.tsx
+++ b/packages/html/src/popover/popover.spec.tsx
@@ -6,6 +6,8 @@ const states = [];
 
 const options = {};
 
+const defaultProps = {};
+
 export type KendoPopoverProps = {
     callout?: null | 'top' | 'bottom' | 'left' | 'right';
     title?: string;
@@ -51,5 +53,6 @@ export const Popover = (
 Popover.states = states;
 Popover.options = options;
 Popover.className = POPOVER_CLASSNAME;
+Popover.defaultProps = defaultProps;
 
 export default Popover;

--- a/packages/html/src/popup/popup.spec.tsx
+++ b/packages/html/src/popup/popup.spec.tsx
@@ -6,6 +6,8 @@ const states = [];
 
 const options = {};
 
+const defaultProps = {};
+
 export const Popup = (
     props: React.HTMLAttributes<HTMLDivElement>
 ) => {
@@ -24,5 +26,6 @@ export const Popup = (
 Popup.states = states;
 Popup.options = options;
 Popup.className = POPUP_CLASSNAME;
+Popup.defaultProps = defaultProps;
 
 export default Popup;

--- a/packages/html/src/progressbar/chunk-progressbar.spec.tsx
+++ b/packages/html/src/progressbar/chunk-progressbar.spec.tsx
@@ -72,5 +72,6 @@ export const ChunkProgressBar = (
 ChunkProgressBar.states = states;
 ChunkProgressBar.options = options;
 ChunkProgressBar.className = CHUNKPROGRESSBAR_CLASSNAME;
+ChunkProgressBar.defaultProps = defaultProps;
 
 export default ChunkProgressBar;

--- a/packages/html/src/progressbar/progressbar.spec.tsx
+++ b/packages/html/src/progressbar/progressbar.spec.tsx
@@ -90,5 +90,6 @@ export const ProgressBar = (
 ProgressBar.states = states;
 ProgressBar.options = options;
 ProgressBar.className = PROGRESSBAR_CLASSNAME;
+ProgressBar.defaultProps = defaultProps;
 
 export default ProgressBar;

--- a/packages/html/src/radio/radio.spec.tsx
+++ b/packages/html/src/radio/radio.spec.tsx
@@ -68,5 +68,6 @@ export const RadioButton = (
 RadioButton.states = states;
 RadioButton.options = options;
 RadioButton.className = RADIOBUTTON_CLASSNAME;
+RadioButton.defaultProps = defaultProps;
 
 export default RadioButton;

--- a/packages/html/src/searchbar/searchbar.spec.tsx
+++ b/packages/html/src/searchbar/searchbar.spec.tsx
@@ -7,6 +7,8 @@ const states = [];
 
 const options = {};
 
+const defaultProps = {};
+
 export type KendoSearchBarProps = {
     placeholder?: string;
 };
@@ -34,5 +36,6 @@ export const SearchBar = (
 SearchBar.states = states;
 SearchBar.options = options;
 SearchBar.className = SEARCHBAR_CLASSNAME;
+SearchBar.defaultProps = defaultProps;
 
 export default SearchBar;

--- a/packages/html/src/searchbox/searchbox.spec.tsx
+++ b/packages/html/src/searchbox/searchbox.spec.tsx
@@ -98,5 +98,6 @@ export const Searchbox = (
 Searchbox.states = states;
 Searchbox.options = options;
 Searchbox.className = SEARCHBOX_CLASSNAME;
+Searchbox.defaultProps = defaultProps;
 
 export default Searchbox;

--- a/packages/html/src/searchbox/searchbox.spec.tsx
+++ b/packages/html/src/searchbox/searchbox.spec.tsx
@@ -44,7 +44,10 @@ export type KendoSearchboxState = { [K in (typeof states)[number]]?: boolean };
 
 const defaultProps = {
     showIcon: true,
-    icon: "search"
+    icon: "search",
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
 };
 
 export const Searchbox = (

--- a/packages/html/src/signature/signature.spec.tsx
+++ b/packages/html/src/signature/signature.spec.tsx
@@ -132,5 +132,6 @@ export const Signature = (
 Signature.states = states;
 Signature.options = options;
 Signature.className = SIGNATURE_CLASSNAME;
+Signature.defaultProps = defaultProps;
 
 export default Signature;

--- a/packages/html/src/spinbutton/spinbutton.spec.tsx
+++ b/packages/html/src/spinbutton/spinbutton.spec.tsx
@@ -63,5 +63,6 @@ export const SpinButton = (
 SpinButton.states = states;
 SpinButton.options = options;
 SpinButton.className = SPINBUTTON_CLASSNAME;
+SpinButton.defaultProps = defaultProps;
 
 export default SpinButton;

--- a/packages/html/src/split-button/split-button.spec.tsx
+++ b/packages/html/src/split-button/split-button.spec.tsx
@@ -118,5 +118,6 @@ export const SplitButton = (
 SplitButton.states = states;
 SplitButton.options = options;
 SplitButton.className = SPLITBUTTON_CLASSNAME;
+SplitButton.defaultProps = defaultProps;
 
 export default SplitButton;

--- a/packages/html/src/switch/switch.spec.tsx
+++ b/packages/html/src/switch/switch.spec.tsx
@@ -97,5 +97,6 @@ export const Switch = (
 Switch.states = states;
 Switch.options = options;
 Switch.className = SWITCH_CLASSNAME;
+Switch.defaultProps = defaultProps;
 
 export default Switch;

--- a/packages/html/src/table/data-table.spec.tsx
+++ b/packages/html/src/table/data-table.spec.tsx
@@ -44,5 +44,6 @@ export const DataTable = (
 DataTable.states = states;
 DataTable.options = options;
 DataTable.className = DATATABLE_CLASSNAME;
+DataTable.defaultProps = defaultProps;
 
 export default DataTable;

--- a/packages/html/src/table/table-list.spec.tsx
+++ b/packages/html/src/table/table-list.spec.tsx
@@ -8,6 +8,8 @@ const options = {
     size: [ Size.small, Size.medium, Size.large ],
 };
 
+const defaultProps = {};
+
 export type KendoTableListOptions = {
   size?: (typeof options.size)[number] | null;
 };
@@ -49,5 +51,6 @@ export const TableList = (
 TableList.states = states;
 TableList.options = options;
 TableList.className = TABLELIST_CLASSNAME;
+TableList.defaultProps = defaultProps;
 
 export default TableList;

--- a/packages/html/src/table/table.spec.tsx
+++ b/packages/html/src/table/table.spec.tsx
@@ -8,6 +8,8 @@ const options = {
     size: [ Size.small, Size.medium, Size.large ],
 };
 
+const defaultProps = {};
+
 export type KendoTableOptions = {
   size?: (typeof options.size)[number] | null;
 };
@@ -40,5 +42,6 @@ export const Table = (
 Table.states = states;
 Table.options = options;
 Table.className = TABLE_CLASSNAME;
+Table.defaultProps = defaultProps;
 
 export default Table;

--- a/packages/html/src/textarea/textarea.spec.tsx
+++ b/packages/html/src/textarea/textarea.spec.tsx
@@ -22,6 +22,8 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
+const defaultProps = {};
+
 export type KendoTextareaOptions = {
     size?: (typeof options.size)[number] | null;
     rounded?: (typeof options.rounded)[number] | null;
@@ -87,5 +89,6 @@ export const Textarea = (
 Textarea.states = states;
 Textarea.options = options;
 Textarea.className = TEXTAREA_CLASSNAME;
+Textarea.defaultProps = defaultProps;
 
 export default Textarea;

--- a/packages/html/src/textarea/textarea.spec.tsx
+++ b/packages/html/src/textarea/textarea.spec.tsx
@@ -22,7 +22,11 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
-const defaultProps = {};
+const defaultProps = {
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
+};
 
 export type KendoTextareaOptions = {
     size?: (typeof options.size)[number] | null;

--- a/packages/html/src/textbox/textbox.spec.tsx
+++ b/packages/html/src/textbox/textbox.spec.tsx
@@ -115,5 +115,6 @@ export const Textbox = (
 Textbox.states = states;
 Textbox.options = options;
 Textbox.className = TEXTBOX_CLASSNAME;
+Textbox.defaultProps = defaultProps;
 
 export default Textbox;

--- a/packages/html/src/textbox/textbox.spec.tsx
+++ b/packages/html/src/textbox/textbox.spec.tsx
@@ -47,7 +47,10 @@ export type KendoTextboxProps = KendoTextboxOptions & {
 export type KendoTextboxState = { [K in (typeof states)[number]]?: boolean };
 
 const defaultProps = {
-    showClearButton: true
+    showClearButton: true,
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
 };
 
 export const Textbox = (

--- a/packages/html/src/time-selector/time-selector.spec.tsx
+++ b/packages/html/src/time-selector/time-selector.spec.tsx
@@ -85,5 +85,6 @@ export const TimeSelector = (
 TimeSelector.states = states;
 TimeSelector.options = options;
 TimeSelector.className = TIMESELECTOR_CLASSNAME;
+TimeSelector.defaultProps = defaultProps;
 
 export default TimeSelector;

--- a/packages/html/src/timedurationpicker/timedurationpicker.spec.tsx
+++ b/packages/html/src/timedurationpicker/timedurationpicker.spec.tsx
@@ -32,7 +32,11 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
-const defaultProps = {};
+const defaultProps = {
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
+};
 
 export type KendoTimeDurationPickerOptions = {
     size?: (typeof options.size)[number] | null;

--- a/packages/html/src/timedurationpicker/timedurationpicker.spec.tsx
+++ b/packages/html/src/timedurationpicker/timedurationpicker.spec.tsx
@@ -32,6 +32,8 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
+const defaultProps = {};
+
 export type KendoTimeDurationPickerOptions = {
     size?: (typeof options.size)[number] | null;
     rounded?: (typeof options.rounded)[number] | null;
@@ -131,5 +133,6 @@ export const TimeDurationPicker = (
 TimeDurationPicker.states = states;
 TimeDurationPicker.options = options;
 TimeDurationPicker.className = TIMEDURATIONPICKER_CLASSNAME;
+TimeDurationPicker.defaultProps = defaultProps;
 
 export default TimeDurationPicker;

--- a/packages/html/src/timepicker/timepicker.spec.tsx
+++ b/packages/html/src/timepicker/timepicker.spec.tsx
@@ -32,6 +32,8 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
+const defaultProps = {};
+
 export type KendoTimePickerOptions = {
     size?: (typeof options.size)[number] | null;
     rounded?: (typeof options.rounded)[number] | null;
@@ -135,5 +137,6 @@ export const TimePicker = (
 TimePicker.states = states;
 TimePicker.options = options;
 TimePicker.className = TIMEPICKER_CLASSNAME;
+TimePicker.defaultProps = defaultProps;
 
 export default TimePicker;

--- a/packages/html/src/timepicker/timepicker.spec.tsx
+++ b/packages/html/src/timepicker/timepicker.spec.tsx
@@ -32,7 +32,11 @@ const options = {
     fillMode: [ FillMode.solid, FillMode.flat, FillMode.outline ],
 };
 
-const defaultProps = {};
+const defaultProps = {
+    size: Input.defaultProps.size,
+    rounded: Input.defaultProps.rounded,
+    fillMode: Input.defaultProps.fillMode
+};
 
 export type KendoTimePickerOptions = {
     size?: (typeof options.size)[number] | null;

--- a/packages/html/src/toolbar/toolbar-angular.spec.tsx
+++ b/packages/html/src/toolbar/toolbar-angular.spec.tsx
@@ -197,5 +197,6 @@ export const ToolbarAngular = (
 ToolbarAngular.states = states;
 ToolbarAngular.options = options;
 ToolbarAngular.className = TOOLBARANGULAR_CLASSNAME;
+ToolbarAngular.defaultProps = defaultProps;
 
 export default ToolbarAngular;

--- a/packages/html/src/toolbar/toolbar-item.spec.tsx
+++ b/packages/html/src/toolbar/toolbar-item.spec.tsx
@@ -8,6 +8,8 @@ const states = [
 
 const options = {};
 
+const defaultProps = {};
+
 export type KendoToolbarItemState = { [K in (typeof states)[number]]?: boolean };
 
 export const ToolbarItem = (
@@ -37,5 +39,6 @@ export const ToolbarItem = (
 ToolbarItem.states = states;
 ToolbarItem.options = options;
 ToolbarItem.className = TOOLBARITEM_CLASSNAME;
+ToolbarItem.defaultProps = defaultProps;
 
 export default ToolbarItem;

--- a/packages/html/src/toolbar/toolbar.spec.tsx
+++ b/packages/html/src/toolbar/toolbar.spec.tsx
@@ -179,5 +179,6 @@ export const Toolbar = (
 Toolbar.states = states;
 Toolbar.options = options;
 Toolbar.className = TOOLBAR_CLASSNAME;
+Toolbar.defaultProps = defaultProps;
 
 export default Toolbar;

--- a/packages/html/src/treeview/treeview-item.spec.tsx
+++ b/packages/html/src/treeview/treeview-item.spec.tsx
@@ -14,6 +14,8 @@ const states = [
 
 const options = {};
 
+const defaultProps = {};
+
 export type KendoTreeviewItemProps = {
     leafClassName?: string;
     hasChildren?: boolean;
@@ -96,5 +98,6 @@ export const TreeviewItem = (
 TreeviewItem.states = states;
 TreeviewItem.options = options;
 TreeviewItem.className = TREEVIEWITEM_CLASSNAME;
+TreeviewItem.defaultProps = defaultProps;
 
 export default TreeviewItem;

--- a/packages/html/src/treeview/treeview.spec.tsx
+++ b/packages/html/src/treeview/treeview.spec.tsx
@@ -55,5 +55,6 @@ export const Treeview = (
 Treeview.states = states;
 Treeview.options = options;
 Treeview.className = TREEVIEW_CLASSNAME;
+Treeview.defaultProps = defaultProps;
 
 export default Treeview;

--- a/packages/html/src/upload/upload.spec.tsx
+++ b/packages/html/src/upload/upload.spec.tsx
@@ -12,6 +12,8 @@ const states = [
 
 const options = {};
 
+const defaultProps = {};
+
 export type KendoUploadProps = {
     async?: boolean;
     empty?: boolean;
@@ -69,5 +71,6 @@ export const Upload = (
 Upload.states = states;
 Upload.options = options;
 Upload.className = UPLOAD_CLASSNAME;
+Upload.defaultProps = defaultProps;
 
 export default Upload;

--- a/packages/html/src/window/window.spec.tsx
+++ b/packages/html/src/window/window.spec.tsx
@@ -14,6 +14,8 @@ const options = {
     ],
 };
 
+const defaultProps = {};
+
 export type KendoWindowOptions = {
   themeColor?: (typeof options.themeColor)[number] | null;
 };
@@ -85,5 +87,6 @@ export const Window = (
 Window.states = states;
 Window.options = options;
 Window.className = WINDOW_CLASSNAME;
+Window.defaultProps = defaultProps;
 
 export default Window;


### PR DESCRIPTION
Exporting the `defaultProps` due to different defaults per component. 

We will use them in the configurator of the Design System Docs, to populate the default values:
![image](https://user-images.githubusercontent.com/30626787/230834918-89213fad-b407-4f4b-8b53-a8deabfb7b69.png)
