### PR TITLE
fix(grid): increase sticky content selector specificity

### DIFF
--- a/packages/default/scss/grid/_theme.scss
+++ b/packages/default/scss/grid/_theme.scss
@@ -260,10 +260,10 @@
         }
 
         // Selected state
-        &.k-selected .k-grid-content-sticky,
-        &.k-selected .k-grid-row-sticky,
-        td.k-grid-content-sticky.k-selected,
-        .k-table-td.k-grid-content-sticky.k-selected {
+        &.k-table-row.k-selected .k-grid-content-sticky,
+        &.k-table-row.k-selected .k-grid-row-sticky,
+        &.k-table-row td.k-grid-content-sticky.k-selected,
+        &.k-table-row .k-table-td.k-grid-content-sticky.k-selected {
             @include fill( $bg: $kendo-grid-sticky-selected-bg );
         }
 


### PR DESCRIPTION
Closes: https://github.com/telerik/kendo-themes/issues/4309