### PR TITLE
ci(dev): switch to lerna conventional prerelease

### DIFF
--- a/.github/workflows/publish_npm_dev.yml
+++ b/.github/workflows/publish_npm_dev.yml
@@ -60,7 +60,6 @@ jobs:
           npm run docs
 
       - name: Lerna publish
-        run: |
-          npx lerna publish --canary --preid dev --dist-tag dev --allow-branch develop --force-publish --exact --yes
+        run: npx lerna publish --conventional-commits --conventional-prerelease --create-release github --preid dev --dist-tag dev --allow-branch develop --force-publish --exact --yes
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Lerna [canary releases](https://github.com/lerna/lerna/tree/main/libs/commands/publish#--canary) always bump minor version only. This is not ideal, especially for major versions where we have breaking changes.

To solve this, we can switch to [conventional-prerelease](https://github.com/lerna/lerna/tree/main/libs/commands/version#--conventional-prerelease), which will bump versions as follows:

```
- major: 1.0.0-dev.0 => 2.0.0-dev.0 
- minor: 1.0.0-dev.0 => 1.1.0-dev.0 
- patch: 1.0.0-dev.0 => 1.0.1-dev.0
``` 

/cc @radkostanev, @jivanova 