### PR TITLE
fix(grid): locked columns header misalignment

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -49,6 +49,7 @@
 
         .k-grid-header,
         .k-grid-content,
+        .k-grid-content-locked,
         .k-grid-footer {
             .k-table {
                 table-layout: fixed;


### PR DESCRIPTION
fixes https://github.com/telerik/kendo-angular/issues/3952

NOTE: The code that this PR adds has been mistakenly deleted in [this commit](https://github.com/telerik/kendo-themes/commit/9c197f34b822727041a8ea3a94c96698e3f86302#diff-cbf07e8554d09a3c79d40aa21eb7dc2c0a81ec74645defd9cb90fcce62fc99d4) (screenshot below):

![deleted](https://user-images.githubusercontent.com/7753940/233682416-c756667b-b285-4a45-8d7b-2d3e8ea72720.png)
