### PR TITLE
fix(swatches): update default-main-dark light and dark variables

### DIFF
--- a/packages/default/lib/swatches/default-main-dark.json
+++ b/packages/default/lib/swatches/default-main-dark.json
@@ -60,12 +60,12 @@
                 "kendo-color-light": {
                     "name": "Light",
                     "type": "color",
-                    "value": "#292929"
+                    "value": "#BDBDBD"
                 },
                 "kendo-color-dark": {
                     "name": "Dark",
                     "type": "color",
-                    "value": "#BDBDBD"
+                    "value": "#292929"
                 }
             }
         },
@@ -158,7 +158,7 @@
                     "value": "#1D1D1D"
                 },
                 "kendo-button-border": {
-                    "name": "Button background",
+                    "name": "Button border",
                     "type": "color",
                     "value": "#383838"
                 }


### PR DESCRIPTION
Switched the `$kendo-color-light` and `$kendo-color-dark` variable values as it is supposed to be.
[The design](https://www.figma.com/file/3fta3SPx6nJMPTUcHTKmNI/Telerik-%26-Kendo-UI-Kit-Default-2.3-(UNPUBLISHED)?type=design&node-id=17447-393514&t=rqsB8SFOw9eAeZTd-0) is updated as well.