### PR TITLE
Spec for demos

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -30,7 +30,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "node ./scripts/build.js",
+    "build": "node ./scripts/build.js && npm run typegen",
+    "typegen": "tsc --emitDeclarationOnly --declaration --declarationDir dist/",
     "build:tests": "node ./scripts/build-tests.js",
     "check-types": "npx tsc src/index.ts --noEmit --emitDeclarationOnly false --jsx react-jsx",
     "prepublishOnly": "npm run build"

--- a/packages/html/src/dropdownlist/dropdownlist.spec.tsx
+++ b/packages/html/src/dropdownlist/dropdownlist.spec.tsx
@@ -60,7 +60,7 @@ const defaultProps = {
 export const DropdownList = (
     props: KendoDropdownListProps &
         KendoDropdownListState &
-        React.HTMLAttributes<HTMLSpanElement>
+        Omit<React.HTMLAttributes<HTMLSpanElement>, 'prefix'>
 ) => {
     const {
         valueIconName,

--- a/packages/html/src/grid/tests/grid-sticky-columns.tsx
+++ b/packages/html/src/grid/tests/grid-sticky-columns.tsx
@@ -292,7 +292,7 @@ root.render(
                                                 <p className="k-reset">
                                                     <Icon icon="caret-alt-down" />
                                                     <span>Currently active projects: 5 &nbsp;</span>
-                                                    <span classicon="exclamation-circle">These people work on too many projects</span>
+                                                    <span>These people work on too many projects</span>
                                                 </p>
                                             </td>
                                         </tr>

--- a/packages/html/src/popover/popover.spec.tsx
+++ b/packages/html/src/popover/popover.spec.tsx
@@ -11,7 +11,7 @@ const defaultProps = {};
 export type KendoPopoverProps = {
     callout?: null | 'top' | 'bottom' | 'left' | 'right';
     title?: string;
-    body?: JSX.Element;
+    body?: JSX.Element | JSX.Element[];
 };
 
 

--- a/packages/html/src/popover/tests/popover.tsx
+++ b/packages/html/src/popover/tests/popover.tsx
@@ -25,7 +25,7 @@ root.render(
             <span>Empty body fixed height</span>
 
             <section>
-                <Popover callout="top" title="Title" body="Body content">
+                <Popover callout="top" title="Title" body={<>Body content</>}>
                     <ActionButtons className="k-popover-actions" alignment="stretched">
                         <Button fillMode="flat">Action</Button>
                         <Button fillMode="flat" themeColor="primary">Primary</Button>
@@ -34,7 +34,7 @@ root.render(
             </section>
 
             <section>
-                <Popover callout="right" title="Title" body="Body content">
+                <Popover callout="right" title="Title" body={<>Body content</>}>
                     <ActionButtons className="k-popover-actions" alignment="stretched">
                         <Button fillMode="flat">Action</Button>
                         <Button fillMode="flat" themeColor="primary">Primary</Button>
@@ -43,7 +43,7 @@ root.render(
             </section>
 
             <section>
-                <Popover callout="bottom" title="Title" body="Body content">
+                <Popover callout="bottom" title="Title" body={<>Body content</>}>
                     <ActionButtons className="k-popover-actions" alignment="stretched">
                         <Button fillMode="flat">Action</Button>
                         <Button fillMode="flat" themeColor="primary">Primary</Button>
@@ -52,7 +52,7 @@ root.render(
             </section>
 
             <section>
-                <Popover callout="left" title="Title" body="Body content">
+                <Popover callout="left" title="Title" body={<>Body content</>}>
                     <ActionButtons className="k-popover-actions" alignment="stretched">
                         <Button fillMode="flat">Action</Button>
                         <Button fillMode="flat" themeColor="primary">Primary</Button>
@@ -61,7 +61,7 @@ root.render(
             </section>
 
             <section>
-                <Popover callout="left" title="Title" body="" style={{ height: "150px" }}>
+                <Popover callout="left" title="Title" style={{ height: "150px" }}>
                 </Popover>
             </section>
         </div>

--- a/packages/html/src/textbox/textbox.spec.tsx
+++ b/packages/html/src/textbox/textbox.spec.tsx
@@ -56,7 +56,7 @@ const defaultProps = {
 export const Textbox = (
     props: KendoTextboxProps &
         KendoTextboxState &
-        React.HTMLAttributes<HTMLSpanElement>
+        Omit<React.HTMLAttributes<HTMLSpanElement>, 'prefix'>
 ) => {
     const {
         prefix,

--- a/packages/html/src/treeview/treeview.spec.tsx
+++ b/packages/html/src/treeview/treeview.spec.tsx
@@ -14,7 +14,7 @@ export type KendoTreeviewOptions = {
 };
 
 export type KendoTreeviewProps = KendoTreeviewOptions & {
-    children?: JSX.Element[];
+    children?: JSX.Element | JSX.Element[];
 };
 
 export type KendoTreeviewState = { [K in (typeof states)[number]]?: boolean };

--- a/tests/grid/grid-sticky-columns.html
+++ b/tests/grid/grid-sticky-columns.html
@@ -283,7 +283,7 @@
                                                     </svg>
                                                 </span>
                                                 <span>Currently active projects: 5 &nbsp;</span>
-                                                <span classicon="exclamation-circle">These people work on too many projects</span>
+                                                <span>These people work on too many projects</span>
                                             </p>
                                         </td>
                                     </tr>


### PR DESCRIPTION
Add `types` for the demos as part of the build.

Cleared up some typescript errors. One interesting one was the `prefix` property as it already exists on the native `span` elements, thus the need for `Omit<T, 'prefix'>`