### PR TITLE
chore(html): tweak distribution

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -13,6 +13,7 @@
   "main": "dist/index.js",
   "files": [
     "dist/**/*.js",
+    "dist/**/*.d.ts",
     "dist/**/*.js.map",
     "src/**/**.ts",
     "src/**/**.tsx"

--- a/packages/html/scripts/build.js
+++ b/packages/html/scripts/build.js
@@ -6,10 +6,13 @@ components.push('./src/index.ts');
 
 esbuild.buildSync({
     logLevel: 'error',
+    format: 'esm',
+    target: 'esnext',
     entryPoints: components,
     outdir: './dist',
+    jsx: 'automatic',
     bundle: true,
     minify: false,
-    sourcemap: true,
+    sourcemap: false,
     external: [ 'react', 'react-dom' ]
 });


### PR DESCRIPTION
Tweak the distribution of the `html` package to enable more flexibility when consuming the package. Additionally, adding `d.ts` files to the dist through the `files` collection, as they do not seems to be published to npm, regardless of being generated after https://github.com/telerik/kendo-themes/pull/4453