### PR TITLE
fix(icon): wrong icon size when svg is used with k-icon-modifier

### DIFF
--- a/packages/default/scss/icons/_layout.scss
+++ b/packages/default/scss/icons/_layout.scss
@@ -45,6 +45,10 @@ $ki-icon-size: $kendo-icon-size;
         right: 0;
         margin: 0 -.5em -.5em 0;
     }
+    .k-svg-icon.k-icon-modifier {
+        width: 1em;
+        height: 1em;
+    }
 
     .k-i-none::before {
         content: "";

--- a/packages/fluent/scss/icon/_layout.scss
+++ b/packages/fluent/scss/icon/_layout.scss
@@ -26,6 +26,10 @@
         right: 0;
         margin: 0 -.5em -.5em 0;
     }
+    .k-svg-icon.k-icon-modifier {
+        width: 1em;
+        height: 1em;
+    }
 
     // RTL icons
     .k-rtl,


### PR DESCRIPTION
The icon has a wrong size when svg is used with `k-icon-modifier`:

![wrong html](https://github.com/telerik/kendo-themes/assets/7753940/2fca69de-ceae-44f6-98ab-f32205f5b731)


The icon should look like this:

![correct html](https://github.com/telerik/kendo-themes/assets/7753940/60fe63d1-5134-418c-bca7-12545f59060d)
