### PR TITLE
fix: make rows resizer to be visible for sticky columns

### DIFF
--- a/packages/default/scss/grid/_layout.scss
+++ b/packages/default/scss/grid/_layout.scss
@@ -1048,6 +1048,7 @@
                 position: absolute;
                 background: none;
                 cursor: row-resize;
+                z-index: 2;
             }
         }
 

--- a/packages/fluent/scss/grid/_layout.scss
+++ b/packages/fluent/scss/grid/_layout.scss
@@ -488,6 +488,7 @@
         position: absolute;
         background: none;
         cursor: row-resize;
+        z-index: 2;
     }
 
     .k-row-resizer {


### PR DESCRIPTION
fixes https://github.com/telerik/kendo-themes/issues/4496