### PR TITLE
fix(list): empty sticky header has a wrong height

### DIFF
--- a/packages/default/scss/list/_layout.scss
+++ b/packages/default/scss/list/_layout.scss
@@ -113,6 +113,7 @@
         }
     }
     .k-list-item-text,
+    .k-list-header-text,
     .k-list-optionlabel {
         &::before {
             content: "\200b";

--- a/packages/fluent/scss/list/_layout.scss
+++ b/packages/fluent/scss/list/_layout.scss
@@ -116,6 +116,7 @@
         }
     }
     .k-list-item-text,
+    .k-list-header-text,
     .k-list-optionlabel {
         &::before {
             content: "\200b";


### PR DESCRIPTION
related to https://github.com/telerik/kendo-themes/pull/4541 and https://github.com/telerik/kendo-themes/issues/3388