### PR TITLE
chore(treelist): use content box for toggle icon to prevent shrinking

### DIFF
--- a/packages/default/scss/treelist/_layout.scss
+++ b/packages/default/scss/treelist/_layout.scss
@@ -103,6 +103,7 @@
     .k-treelist-toggle {
         margin-block: -$kendo-icon-padding;
         padding: $kendo-icon-padding;
+        box-sizing: content-box;
         cursor: pointer;
     }
 

--- a/packages/fluent/scss/treelist/_layout.scss
+++ b/packages/fluent/scss/treelist/_layout.scss
@@ -99,6 +99,7 @@
     .k-treelist-toggle {
         margin-block: calc( var( --kendo-icon-padding ) * -1 );
         padding: var( --kendo-icon-padding, .25rem );
+        box-sizing: content-box;
         cursor: pointer;
     }
 


### PR DESCRIPTION
part of: https://github.com/telerik/kendo-themes-private/issues/40