### PR TITLE
fix(bootstrap); dark theme input colors

### DIFF
--- a/packages/bootstrap/scss/_bootstrap-overrides.scss
+++ b/packages/bootstrap/scss/_bootstrap-overrides.scss
@@ -10,13 +10,13 @@ $gray-700: #495057 !default;
 $gray-800: #343a40 !default;
 $gray-900: #212529 !default;
 
-$kendo-body-bg: $kendo-color-white !default;
+$kendo-body-bg: #ffffff !default;
 
 $kendo-component-bg: $kendo-body-bg !default;
 $kendo-component-text: k-contrast-color( $kendo-component-bg, $gray-900, $gray-100 ) !default;
 $kendo-component-border: if( k-is-light( $kendo-component-bg ), $gray-300, $gray-700 ) !default;
 
 $input-bg: $kendo-component-bg !default;
-$input-color: k-contrast-color( $input-bg, $gray-700, $gray-300 ) !default;
+$input-color: k-contrast-color( $input-bg, $gray-900, $gray-300 ) !default;
 $input-border-color: if( k-is-light( $input-bg ), $gray-400, $gray-600 ) !default;
 $input-placeholder-color: k-contrast-color( $input-bg, $gray-600, $gray-400 ) !default;

--- a/packages/bootstrap/scss/_variables.scss
+++ b/packages/bootstrap/scss/_variables.scss
@@ -1,4 +1,5 @@
 @import "./core/functions/index.import.scss";
+@import "./_bootstrap-overrides.scss";
 @import "bootstrap/scss/_functions.scss";
 @import "bootstrap/scss/_variables.scss";
 

--- a/packages/bootstrap/scss/core/_index.scss
+++ b/packages/bootstrap/scss/core/_index.scss
@@ -2,7 +2,6 @@ $wcag-min-contrast-ratio: 4.5 !default;
 
 // Variables
 @import "../_variables.scss";
-@import "../_bootstrap-overrides.scss";
 
 @import "@progress/kendo-theme-core/scss/index.import.scss";
 


### PR DESCRIPTION
regression introduced in https://github.com/telerik/kendo-themes/pull/4518

This PR fixes variable's import order which results in incorrect bootstrap dark theme in v6.5.0.