### PR TITLE
chore(scrollview): steamline scrollview-view styles

### DIFF
--- a/packages/default/scss/scrollview/_layout.scss
+++ b/packages/default/scss/scrollview/_layout.scss
@@ -26,19 +26,16 @@
         cursor: default;
         white-space: nowrap;
 
+        > .k-scrollview-view {
+            display: inline-block;
+            overflow: hidden;
+            flex-shrink: 0;
+        }
+
         img {
             user-select: none;
         }
 
-    }
-
-     // Can be removed once Angular are able to rely on the animations from the themes
-     kendo-scrollview.k-scrollview .k-scrollview-wrap > .k-scrollview-view {
-        display: inline-block;
-        overflow: hidden;
-        position: absolute;
-        top: 0;
-        left: 0;
     }
 
     .k-scrollview-wrap.k-scrollview-animate {

--- a/packages/fluent/scss/scrollview/_layout.scss
+++ b/packages/fluent/scss/scrollview/_layout.scss
@@ -29,19 +29,16 @@
         cursor: default;
         white-space: nowrap;
 
+        > .k-scrollview-view {
+            display: inline-block;
+            overflow: hidden;
+            flex-shrink: 0;
+        }
+
         img {
             user-select: none;
         }
 
-    }
-
-    // Can be removed once Angular are able to rely on the animations from the themes
-    kendo-scrollview.k-scrollview .k-scrollview-wrap > .k-scrollview-view {
-        display: inline-block;
-        overflow: hidden;
-        position: absolute;
-        top: 0;
-        left: 0;
     }
 
     .k-scrollview-wrap.k-scrollview-animate {


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-themes-private/issues/141

During the effort in unifying the rendering of the ScrollView and after a discussion with @pepinho24  and @Juveniel it has become apparent that some suites ( jQuery and Angular ) are unable to reuse the animations provided through the themes.

We have addressed that issue by firstly scoping the animations to the `.k-scrollview-animate` class, however additional styling was needed in order to preserve the current behavior and this PR introduces that.

> NOTE: In cases where the animation is controlled by the component and specific styles for positioning are required e.g. Virtual ScrollView in jQuery or the implementation in Angular those will need to be set inline through the component
e.g. `position: absolute; top: 0; left: 0;`