### PR TITLE
fix(fluent): forward variables in order to be configurable

### DIFF
--- a/packages/fluent/scss/core/_index.scss
+++ b/packages/fluent/scss/core/_index.scss
@@ -1,10 +1,10 @@
 @use "sass:map";
 
 // Palettes
+@forward "./color-system/palettes";
 @use "./color-system/palettes" as *;
 
 // Variables
-@use "./variables" as *;
 @forward "./variables";
 
 @forward "@progress/kendo-theme-core/scss/index.import.scss" with (


### PR DESCRIPTION
Regression of https://github.com/telerik/kendo-themes/pull/4518

Fixes the ability to configure the fluent them with the `use "" with ()` syntax