### PR TITLE
fix(dock-manager): fix toolbar buttons padding in fluent

### DIFF
--- a/packages/fluent/scss/dock-manager/_layout.scss
+++ b/packages/fluent/scss/dock-manager/_layout.scss
@@ -37,8 +37,8 @@
         // A fix will be shipped likely in milestone 118 and then we can revisit this
         @supports  (not (-ms-ime-mode: none)) and (not (overflow: -webkit-marquee)) and (not (-moz-appearance:none)) {
             .k-toolbar-button {
-                padding-block: var(--INTERNAL--kendo-button-padding-y, 0 );
-                padding-inline: var(--INTERNAL--kendo-button-padding-x, 0 );
+                padding-block: var(--INTERNAL--kendo-button-padding-x, 0 );
+                padding-inline: var(--INTERNAL--kendo-button-padding-y, 0 );
             }
             .k-toolbar-button .k-button-text {
                 writing-mode: vertical-lr;


### PR DESCRIPTION
Fixes: https://github.com/telerik/kendo-themes/issues/4753