### PR TITLE
chore(dock-manager): remove no longer needed chrome specific styles

### DIFF
--- a/packages/default/scss/dock-manager/_layout.scss
+++ b/packages/default/scss/dock-manager/_layout.scss
@@ -30,18 +30,6 @@
             height: 0;
             border-width: $kendo-dock-manager-border-width 0 0;
         }
-
-        // Needed because of a bug in Chrome - Issue 1473554
-        // A fix will be shipped likely in milestone 118 and then we can revisit this
-        @supports  (not (-ms-ime-mode: none)) and (not (overflow: -webkit-marquee)) and (not (-moz-appearance:none)) {
-            .k-toolbar-button {
-                padding-block: $kendo-button-padding-x;
-                padding-inline: $kendo-button-padding-y;
-            }
-            .k-toolbar-button .k-button-text {
-                writing-mode: vertical-lr;
-            }
-        }
     }
 
     // Panes

--- a/packages/fluent/scss/dock-manager/_layout.scss
+++ b/packages/fluent/scss/dock-manager/_layout.scss
@@ -32,18 +32,6 @@
             height: 0;
             border-width: var( --kendo-dock-manager-border-width, #{$kendo-dock-manager-border-width} ) 0 0;
         }
-
-        // Needed because of a bug in Chrome - Issue 1473554
-        // A fix will be shipped likely in milestone 118 and then we can revisit this
-        @supports  (not (-ms-ime-mode: none)) and (not (overflow: -webkit-marquee)) and (not (-moz-appearance:none)) {
-            .k-toolbar-button {
-                padding-block: var(--INTERNAL--kendo-button-padding-x, 0 );
-                padding-inline: var(--INTERNAL--kendo-button-padding-y, 0 );
-            }
-            .k-toolbar-button .k-button-text {
-                writing-mode: vertical-lr;
-            }
-        }
     }
 
     // Panes


### PR DESCRIPTION
Seems like the writing-mode issue with the button in Chrome has been resolved, so I am removing the workaround.