### PR TITLE
fix(common): incorrectly set current time marker width

### DIFF
--- a/packages/default/scss/common/_indicators.scss
+++ b/packages/default/scss/common/_indicators.scss
@@ -1,11 +1,9 @@
 @include exports( "common/indicators/current-time" ) {
 
-    $kendo-current-time-width: 1px !default;
     $kendo-current-time-color: #ff0000 !default;
 
     // Layout
     .k-current-time {
-        width: $kendo-current-time-width;
         position: absolute;
 
         &.k-current-time-arrow-left,

--- a/packages/fluent/scss/core/helpers/_indicators.scss
+++ b/packages/fluent/scss/core/helpers/_indicators.scss
@@ -1,9 +1,7 @@
-$kendo-current-time-width: 1px !default;
 $kendo-current-time-color: #ff0000 !default;
 
 // Layout
 .k-current-time {
-    width: var( --kendo-current-time-width, #{$kendo-current-time-width} );
     position: absolute;
 
     &.k-current-time-arrow-left,

--- a/packages/html/src/gantt/tests/gantt.tsx
+++ b/packages/html/src/gantt/tests/gantt.tsx
@@ -758,7 +758,7 @@ export default () =>(
                                     <div className="k-gantt-line k-gantt-line-v" style={{ left: "621px", top: "197px", height: "72px" }}></div>
                                     <div className="k-gantt-line k-gantt-line-h" style={{ left: "621px", top: "269px", width: "191px" }}><span className="k-arrow-e"></span></div>
                                 </div>
-                                <div className="k-current-time" style={{ left: "243px", top: "0px", height: "828px" }}></div>
+                                <div className="k-current-time" style={{ left: "243px", top: "0px", width: "1px", height: "828px" }}></div>
                             </div>
                         </div>
                     </div>

--- a/tests/gantt/gantt.html
+++ b/tests/gantt/gantt.html
@@ -1283,7 +1283,7 @@
                                     <span class="k-arrow-e"></span>
                                 </div>
                             </div>
-                            <div class="k-current-time" style="left: 243px; top: 0px; height: 828px;"></div>
+                            <div class="k-current-time" style="left: 243px; top: 0px; width: 1px; height: 828px;"></div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The current time marker should not have a `width` property set because it is supposed to be used as both a horizontal and a vertical line.
The components (Scheduler and Gantt) should add the required property inline (either `width` or `height`), as they currently do.