### PR TITLE
fix(html): enable callout property

### DIFF
--- a/packages/html/src/timeline/timeline-card.spec.tsx
+++ b/packages/html/src/timeline/timeline-card.spec.tsx
@@ -23,6 +23,7 @@ export const TimelineCard = (
                 props.className
             )}
             orientation="vertical"
+            callout="true"
             {...other}
         >
             { callout && <TimelineCardCallout callout={callout} />}

--- a/tests/timeline/timeline-horizontal.html
+++ b/tests/timeline/timeline-horizontal.html
@@ -68,7 +68,7 @@
                 <ul class="k-timeline-scrollable-wrap">
                     <li class="k-timeline-event">
                         <div class="k-timeline-card">
-                            <div class="k-card k-card-vertical">
+                            <div class="k-card k-card-vertical k-card-with-callout">
                                 <span class="k-timeline-card-callout k-card-callout k-callout-n"></span>
                                 <div class="k-card-inner">
                                     <div class="k-card-header">

--- a/tests/timeline/timeline-vertical-alternating.html
+++ b/tests/timeline/timeline-vertical-alternating.html
@@ -22,7 +22,7 @@
                     </div>
                     <span class="k-timeline-circle"></span>
                     <div class="k-timeline-card">
-                        <div class="k-card k-card-vertical">
+                        <div class="k-card k-card-vertical k-card-with-callout">
                             <span class="k-timeline-card-callout k-card-callout k-callout-e"></span>
                             <div class="k-card-inner">
                                 <div class="k-card-header">
@@ -44,7 +44,7 @@
                     </div>
                     <span class="k-timeline-circle"></span>
                     <div class="k-timeline-card">
-                        <div class="k-card k-card-vertical">
+                        <div class="k-card k-card-vertical k-card-with-callout">
                             <span class="k-timeline-card-callout k-card-callout k-callout-w"></span>
                             <div class="k-card-inner">
                                 <div class="k-card-header">
@@ -69,7 +69,7 @@
                     </div>
                     <span class="k-timeline-circle"></span>
                     <div class="k-timeline-card">
-                        <div class="k-card k-card-vertical">
+                        <div class="k-card k-card-vertical k-card-with-callout">
                             <span class="k-timeline-card-callout k-card-callout k-callout-e"></span>
                             <div class="k-card-inner">
                                 <div class="k-card-header">
@@ -91,7 +91,7 @@
                     </div>
                     <span class="k-timeline-circle"></span>
                     <div class="k-timeline-card">
-                        <div class="k-card k-card-vertical">
+                        <div class="k-card k-card-vertical k-card-with-callout">
                             <span class="k-timeline-card-callout k-card-callout k-callout-w"></span>
                             <div class="k-card-inner">
                                 <div class="k-card-header">

--- a/tests/timeline/timeline-vertical.html
+++ b/tests/timeline/timeline-vertical.html
@@ -28,7 +28,7 @@
                     </div>
                     <span class="k-timeline-circle"></span>
                     <div class="k-timeline-card">
-                        <div class="k-card k-card-vertical">
+                        <div class="k-card k-card-vertical k-card-with-callout">
                             <span class="k-timeline-card-callout k-card-callout k-callout-w"></span>
                             <div class="k-card-inner">
                                 <div class="k-card-header">
@@ -53,7 +53,7 @@
                     </div>
                     <span class="k-timeline-circle"></span>
                     <div class="k-timeline-card">
-                        <div class="k-card k-card-vertical">
+                        <div class="k-card k-card-vertical k-card-with-callout">
                             <span class="k-timeline-card-callout k-card-callout k-callout-w"></span>
                             <div class="k-card-inner">
                                 <div class="k-card-header">
@@ -82,7 +82,7 @@
                     </div>
                     <span class="k-timeline-circle"></span>
                     <div class="k-timeline-card">
-                        <div class="k-card k-card-vertical">
+                        <div class="k-card k-card-vertical k-card-with-callout">
                             <span class="k-timeline-card-callout k-card-callout k-callout-w"></span>
                             <div class="k-card-inner">
                                 <div class="k-card-header">
@@ -114,7 +114,7 @@
                     </div>
                     <span class="k-timeline-circle"></span>
                     <div class="k-timeline-card k-collapsed">
-                        <div class="k-card k-card-vertical">
+                        <div class="k-card k-card-vertical k-card-with-callout">
                             <span class="k-timeline-card-callout k-card-callout k-callout-w"></span>
                             <div class="k-card-inner">
                                 <div class="k-card-header">


### PR DESCRIPTION
Cards in Timeline always have callouts, therefore we should enable this prop by default. When callout property is true, `k-card-with-callout` class is set to the card - https://github.com/telerik/kendo-themes/blob/develop/packages/html/src/card/card.spec.tsx#L69. Also, this recommendation was described in the [_Unify rendering for Timeline_ issue](https://github.com/telerik/kendo-themes-private/issues/193) 