### PR TITLE
chore: use <span> element for collapse icon button

### DIFF
--- a/packages/html/src/timeline/timeline-card-title.tsx
+++ b/packages/html/src/timeline/timeline-card-title.tsx
@@ -1,5 +1,5 @@
 import { classNames } from '../misc';
-import { IconButton } from '../button';
+import { Icon } from '../icon';
 
 export const TIMELINECARDTITLE_CLASSNAME = `k-card-title`;
 
@@ -30,7 +30,7 @@ export const TimelineCardTitle = (
             {...other}
         >
             <span className="k-event-title">{children}</span>
-            {collapsible && <IconButton fillMode="flat" icon="chevron-right" className="k-event-collapse"></IconButton>}
+            {collapsible && <span className="k-event-collapse k-button k-button-md k-rounded-md k-button-flat k-button-flat-base k-icon-button"><Icon icon="chevron-right" className="k-button-icon"/></span>}
         </div>
     );
 };


### PR DESCRIPTION
Using `<button>` element for the collapse icon leads to AXE errors. After a discussion, we decided to change this element to `<span>`. Related to https://github.com/telerik/kendo-themes-private/issues/193
