### PR TITLE
fix(gantt): gantt-timeline children should have correct box-sizing

### DIFF
--- a/packages/default/scss/gantt/_layout.scss
+++ b/packages/default/scss/gantt/_layout.scss
@@ -297,6 +297,14 @@
             height: 100%;
             border-width: 0;
             display: flex;
+
+            *,
+            *::before,
+            *::after,
+            &::before,
+            &::after {
+                box-sizing: border-box;
+            }
         }
         .k-grid-header {}
         .k-grid-content {

--- a/packages/fluent/scss/gantt/_layout.scss
+++ b/packages/fluent/scss/gantt/_layout.scss
@@ -294,6 +294,14 @@
             height: 100%;
             border-width: 0;
             display: flex;
+
+            *,
+            *::before,
+            *::after,
+            &::before,
+            &::after {
+                box-sizing: border-box;
+            }
         }
         .k-grid-header {}
         .k-grid-content {


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-themes/pull/4839

With switching from `k-timeline` to `k-gantt-timeline` in the rendering and styles of the Gantt component we missed to consider that there might be styles related to `k-timeline` on which we may rely on.

Namely the styles for box-sizing [here](https://github.com/telerik/kendo-themes/blob/4a6a0cb7085a4b032405585e25da25fd4383d7d7/packages/default/scss/timeline/_layout.scss#L14), without which there is an issue with setting a specific row height - reported in jQuery.