### PR TITLE
chore(prompt): use flex-start instead of start

### DIFF
--- a/packages/default/scss/prompt/_layout.scss
+++ b/packages/default/scss/prompt/_layout.scss
@@ -31,7 +31,7 @@
         display: flex;
         flex-direction: column;
         flex: 1;
-        align-items: start;
+        align-items: flex-start;
         gap: $kendo-prompt-expander-spacing;
     }
 

--- a/packages/fluent/scss/prompt/_layout.scss
+++ b/packages/fluent/scss/prompt/_layout.scss
@@ -34,7 +34,7 @@
         display: flex;
         flex-direction: column;
         flex: 1;
-        align-items: start;
+        align-items: flex-start;
         gap: var( --kendo-prompt-expander-spacing, #{$kendo-prompt-expander-spacing} );
     }
 


### PR DESCRIPTION
The usage of `start`, `end` as flex layout values produces a warning in toolings such as Vite, Nx and React Scripts.

> [vite:css] start value has mixed support, consider using flex-start instead

This is problematic for cases where warnings are considered as errors, which in turn will cause builds to fail.