### PR TITLE
Fix dark swatch input colors in Bootstrap

### DIFF
--- a/packages/bootstrap/docs/customization-input.md
+++ b/packages/bootstrap/docs/customization-input.md
@@ -266,7 +266,7 @@ The following table lists the available variables for customization.
     <td>$kendo-input-bg</td>
     <td>Color</td>
     <td><code>$input-bg</code></td>
-    <td><span class="color-preview" style="background-color: #fff"></span><code>#fff</code></td>
+    <td><span class="color-preview" style="background-color: #ffffff"></span><code>#ffffff</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of the Input components.</div></div>
@@ -346,7 +346,7 @@ The following table lists the available variables for customization.
     <td>$kendo-input-focus-bg</td>
     <td>Color</td>
     <td><code>$input-focus-bg</code></td>
-    <td><span class="color-preview" style="background-color: #fff"></span><code>#fff</code></td>
+    <td><span class="color-preview" style="background-color: #ffffff"></span><code>#ffffff</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of the focused Input components.</div></div>

--- a/packages/bootstrap/docs/customization.md
+++ b/packages/bootstrap/docs/customization.md
@@ -8729,7 +8729,7 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>$kendo-input-bg</td>
     <td>Color</td>
     <td><code>$input-bg</code></td>
-    <td><span class="color-preview" style="background-color: #fff"></span><code>#fff</code></td>
+    <td><span class="color-preview" style="background-color: #ffffff"></span><code>#ffffff</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of the Input components.</div></div>
@@ -8809,7 +8809,7 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>$kendo-input-focus-bg</td>
     <td>Color</td>
     <td><code>$input-focus-bg</code></td>
-    <td><span class="color-preview" style="background-color: #fff"></span><code>#fff</code></td>
+    <td><span class="color-preview" style="background-color: #ffffff"></span><code>#ffffff</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The background color of the focused Input components.</div></div>

--- a/packages/bootstrap/scss/_bootstrap-overrides.scss
+++ b/packages/bootstrap/scss/_bootstrap-overrides.scss
@@ -1,0 +1,20 @@
+$gray-100: #f8f9fa !default;
+$gray-200: #e9ecef !default;
+$gray-300: #dee2e6 !default;
+$gray-400: #ced4da !default;
+$gray-500: #adb5bd !default;
+$gray-600: #6c757d !default;
+$gray-700: #495057 !default;
+$gray-800: #343a40 !default;
+$gray-900: #212529 !default;
+
+$kendo-body-bg: #ffffff !default;
+
+$kendo-component-bg: $kendo-body-bg !default;
+$kendo-component-text: k-contrast-color( $kendo-component-bg, $gray-900, $gray-100 ) !default;
+$kendo-component-border: if( k-is-light( $kendo-component-bg ), $gray-300, $gray-700 ) !default;
+
+$input-bg: $kendo-component-bg !default;
+$input-color: k-contrast-color( $input-bg, $gray-900, $gray-300 ) !default;
+$input-border-color: if( k-is-light( $input-bg ), $gray-400, $gray-600 ) !default;
+$input-placeholder-color: k-contrast-color( $input-bg, $gray-600, $gray-400 ) !default;

--- a/packages/bootstrap/scss/core/color-system/_swatch.scss
+++ b/packages/bootstrap/scss/core/color-system/_swatch.scss
@@ -1,5 +1,6 @@
 @import "@progress/kendo-theme-core/scss/functions/index.import.scss";
 @import "@progress/kendo-theme-core/scss/color-system/_constants.scss";
+@import "../../_bootstrap-overrides.scss";
 @import "bootstrap/scss/_functions.scss";
 @import "bootstrap/scss/_variables.scss";
 @import "./_palettes.scss";
@@ -183,28 +184,6 @@ $kendo-colors: $_default-colors !default;
 // Legacy
 
 $kendo-is-dark-theme: false !default;
-
-$gray-100: #f8f9fa !default;
-$gray-200: #e9ecef !default;
-$gray-300: #dee2e6 !default;
-$gray-400: #ced4da !default;
-$gray-500: #adb5bd !default;
-$gray-600: #6c757d !default;
-$gray-700: #495057 !default;
-$gray-800: #343a40 !default;
-$gray-900: #212529 !default;
-
-$kendo-body-bg: #ffffff !default;
-
-$kendo-component-bg: $kendo-body-bg !default;
-$kendo-component-text: k-contrast-color( $kendo-component-bg, $gray-900, $gray-100 ) !default;
-$kendo-component-border: if( k-is-light( $kendo-component-bg ), $gray-300, $gray-700 ) !default;
-
-$input-bg: $kendo-component-bg !default;
-$input-color: k-contrast-color( $input-bg, $gray-900, $gray-300 ) !default;
-$input-border-color: if( k-is-light( $input-bg ), $gray-400, $gray-600 ) !default;
-$input-placeholder-color: k-contrast-color( $input-bg, $gray-600, $gray-400 ) !default;
-
 
 // Theme colors
 /// The color that focuses the user attention.


### PR DESCRIPTION
With the implementation of the color system in Bootstrap we were no longer relying on the styles from `_bootstrap-overrides` ( at least not in the same way as before )  -- these styles were never applied and the value of `input-bg` always defaulted to `#fff`, which causes issues in the Dark swatches.