### PR TITLE
fix(spreadsheet): file icon overlaps elements in export to pdf popup

### DIFF
--- a/packages/default/scss/spreadsheet/_layout.scss
+++ b/packages/default/scss/spreadsheet/_layout.scss
@@ -710,7 +710,7 @@
             right: 0;
             top: k-map-get( $kendo-spacing, 2 );
 
-            .k-icon {
+            .k-font-icon {
                 font-size: 6em;
             }
             .k-svg-icon {


### PR DESCRIPTION
Closes: https://github.com/telerik/kendo-themes/issues/4886