### PR TITLE
chore: add type module as default for bundlers

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -12,7 +12,7 @@
   ],
   "types": "./dist/types/index.d.ts",
   "exports": {
-    "import": "./dist/esm/index.js",
+    "import": "./dist/esm/index.mjs",
     "require": "./dist/cjs/index.js",
     "types": "./dist/types/index.d.ts"
   },

--- a/packages/html/scripts/build.js
+++ b/packages/html/scripts/build.js
@@ -23,7 +23,7 @@ const commonConfig = {
     }
     await Promise.allSettled(
         [
-            { ...commonConfig, format: "esm", target: "esnext", outdir: "./dist/esm" },
+            { ...commonConfig, format: "esm", target: "esnext", outdir: "./dist/esm", outExtension: { ".js": ".mjs" } },
             {
                 ...commonConfig,
                 format: "cjs",


### PR DESCRIPTION
In a node env we need either a type: module in package.json in order to load ESM modules from js files or CJS module with mjs files using ESM syntax. 

Without that some bundlers fail to load modules and build HTML specs in node env. 