### PR TITLE
chore: add element with k-sr-only class

### DIFF
--- a/packages/html/src/scrollview/scrollview-spec.tsx
+++ b/packages/html/src/scrollview/scrollview-spec.tsx
@@ -122,6 +122,7 @@ export const ScrollView = (
                     </div>
                 }
             </div>
+            <div className="k-sr-only"></div>
         </div>
     );
 };

--- a/tests/scrollview/scrollview-rtl.html
+++ b/tests/scrollview/scrollview-rtl.html
@@ -65,6 +65,7 @@
                     </div>
                 </div>
             </div>
+            <div class="k-sr-only"></div>
         </div>
         <div class="k-scrollview k-rtl">
             <div class="k-scrollview-wrap k-scrollview-animate" style="--kendo-scrollview-views: 9; --kendo-scrollview-current: 5;">
@@ -107,6 +108,7 @@
                     </div>
                 </div>
             </div>
+            <div class="k-sr-only"></div>
         </div>
         <div class="k-scrollview k-scrollview-dark k-rtl">
             <div class="k-scrollview-wrap k-scrollview-animate" style="--kendo-scrollview-views: 9; --kendo-scrollview-current: 5;">
@@ -147,6 +149,7 @@
                     </div>
                 </div>
             </div>
+            <div class="k-sr-only"></div>
         </div>
         <span>RTL Pager disabled</span>
         <span></span>
@@ -179,6 +182,7 @@
                     </span>
                 </span>
             </div>
+            <div class="k-sr-only"></div>
         </div>
         <div class="k-scrollview k-rtl">
             <div class="k-scrollview-wrap k-scrollview-animate" style="--kendo-scrollview-views: 9; --kendo-scrollview-current: 5;">
@@ -208,6 +212,7 @@
                     </span>
                 </span>
             </div>
+            <div class="k-sr-only"></div>
         </div>
         <div class="k-scrollview k-scrollview-dark k-rtl">
             <div class="k-scrollview-wrap k-scrollview-animate" style="--kendo-scrollview-views: 9; --kendo-scrollview-current: 5;">
@@ -237,6 +242,7 @@
                     </span>
                 </span>
             </div>
+            <div class="k-sr-only"></div>
         </div>
     </div>
 </body>

--- a/tests/scrollview/scrollview.html
+++ b/tests/scrollview/scrollview.html
@@ -65,6 +65,7 @@
                     </div>
                 </div>
             </div>
+            <div class="k-sr-only"></div>
         </div>
         <div class="k-scrollview">
             <div class="k-scrollview-wrap k-scrollview-animate" style="--kendo-scrollview-views: 9; --kendo-scrollview-current: 5;">
@@ -107,6 +108,7 @@
                     </div>
                 </div>
             </div>
+            <div class="k-sr-only"></div>
         </div>
         <div class="k-scrollview k-scrollview-dark">
             <div class="k-scrollview-wrap k-scrollview-animate" style="--kendo-scrollview-views: 9; --kendo-scrollview-current: 5;">
@@ -147,6 +149,7 @@
                     </div>
                 </div>
             </div>
+            <div class="k-sr-only"></div>
         </div>
         <span>Pager disabled</span>
         <span></span>
@@ -179,6 +182,7 @@
                     </span>
                 </span>
             </div>
+            <div class="k-sr-only"></div>
         </div>
         <div class="k-scrollview">
             <div class="k-scrollview-wrap k-scrollview-animate" style="--kendo-scrollview-views: 9; --kendo-scrollview-current: 5;">
@@ -208,6 +212,7 @@
                     </span>
                 </span>
             </div>
+            <div class="k-sr-only"></div>
         </div>
         <div class="k-scrollview k-scrollview-dark">
             <div class="k-scrollview-wrap k-scrollview-animate" style="--kendo-scrollview-views: 9; --kendo-scrollview-current: 5;">
@@ -237,6 +242,7 @@
                     </span>
                 </span>
             </div>
+            <div class="k-sr-only"></div>
         </div>
     </div>
 </body>


### PR DESCRIPTION
According to the aria spec, we should render an element with class **k-sr-only** as a direct child of .**k-scrollview**: 

https://github.com/telerik/web-components-ux/blob/master/docs/components/carousel/aria.json#L45

This has been already implemented in jQuery and Angular.

@slavenai @dtopalov @PekoPPT 