### PR TITLE
fix(html): appbar should not have fillMode

### DIFF
--- a/packages/html/src/appbar/tests/appbar-rtl.tsx
+++ b/packages/html/src/appbar/tests/appbar-rtl.tsx
@@ -72,7 +72,7 @@ export default () =>(
                 <>
                     <span>RTL Appbar - {themeColor} theme color</span>
                     <section>
-                        <AppbarNormal fillMode="solid" themeColor={themeColor} dir="rtl">
+                        <AppbarNormal themeColor={themeColor} dir="rtl">
                             <AppbarSection>
                                 <Icon icon="menu" />
                             </AppbarSection>

--- a/packages/html/src/appbar/tests/appbar.tsx
+++ b/packages/html/src/appbar/tests/appbar.tsx
@@ -72,7 +72,7 @@ export default () =>(
                 <>
                     <span>Appbar {themeColor} theme color</span>
                     <section>
-                        <AppbarNormal fillMode="solid" themeColor={themeColor}>
+                        <AppbarNormal themeColor={themeColor}>
                             <AppbarSection>
                                 <Icon icon="menu" />
                             </AppbarSection>

--- a/tests/appbar/appbar-rtl.html
+++ b/tests/appbar/appbar-rtl.html
@@ -85,7 +85,7 @@
         </section>
         <span>RTL Appbar - inherit theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-inherit">
+            <div dir="rtl" class="k-appbar k-appbar-inherit">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -133,7 +133,7 @@
         </section>
         <span>RTL Appbar - base theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-base">
+            <div dir="rtl" class="k-appbar k-appbar-base">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -181,7 +181,7 @@
         </section>
         <span>RTL Appbar - primary theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-primary">
+            <div dir="rtl" class="k-appbar k-appbar-primary">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -229,7 +229,7 @@
         </section>
         <span>RTL Appbar - secondary theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-secondary">
+            <div dir="rtl" class="k-appbar k-appbar-secondary">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -277,7 +277,7 @@
         </section>
         <span>RTL Appbar - tertiary theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-tertiary">
+            <div dir="rtl" class="k-appbar k-appbar-tertiary">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -325,7 +325,7 @@
         </section>
         <span>RTL Appbar - success theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-success">
+            <div dir="rtl" class="k-appbar k-appbar-success">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -373,7 +373,7 @@
         </section>
         <span>RTL Appbar - warning theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-warning">
+            <div dir="rtl" class="k-appbar k-appbar-warning">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -421,7 +421,7 @@
         </section>
         <span>RTL Appbar - error theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-error">
+            <div dir="rtl" class="k-appbar k-appbar-error">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -469,7 +469,7 @@
         </section>
         <span>RTL Appbar - info theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-info">
+            <div dir="rtl" class="k-appbar k-appbar-info">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -517,7 +517,7 @@
         </section>
         <span>RTL Appbar - light theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-light">
+            <div dir="rtl" class="k-appbar k-appbar-light">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -565,7 +565,7 @@
         </section>
         <span>RTL Appbar - dark theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-dark">
+            <div dir="rtl" class="k-appbar k-appbar-dark">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -613,7 +613,7 @@
         </section>
         <span>RTL Appbar - inverse theme color</span>
         <section>
-            <div fillmode="solid" dir="rtl" class="k-appbar k-appbar-inverse">
+            <div dir="rtl" class="k-appbar k-appbar-inverse">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/tests/appbar/appbar.html
+++ b/tests/appbar/appbar.html
@@ -85,7 +85,7 @@
         </section>
         <span>Appbar inherit theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-inherit">
+            <div class="k-appbar k-appbar-inherit">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -133,7 +133,7 @@
         </section>
         <span>Appbar base theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-base">
+            <div class="k-appbar k-appbar-base">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -181,7 +181,7 @@
         </section>
         <span>Appbar primary theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-primary">
+            <div class="k-appbar k-appbar-primary">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -229,7 +229,7 @@
         </section>
         <span>Appbar secondary theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-secondary">
+            <div class="k-appbar k-appbar-secondary">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -277,7 +277,7 @@
         </section>
         <span>Appbar tertiary theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-tertiary">
+            <div class="k-appbar k-appbar-tertiary">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -325,7 +325,7 @@
         </section>
         <span>Appbar success theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-success">
+            <div class="k-appbar k-appbar-success">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -373,7 +373,7 @@
         </section>
         <span>Appbar warning theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-warning">
+            <div class="k-appbar k-appbar-warning">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -421,7 +421,7 @@
         </section>
         <span>Appbar error theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-error">
+            <div class="k-appbar k-appbar-error">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -469,7 +469,7 @@
         </section>
         <span>Appbar info theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-info">
+            <div class="k-appbar k-appbar-info">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -517,7 +517,7 @@
         </section>
         <span>Appbar light theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-light">
+            <div class="k-appbar k-appbar-light">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -565,7 +565,7 @@
         </section>
         <span>Appbar dark theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-dark">
+            <div class="k-appbar k-appbar-dark">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -613,7 +613,7 @@
         </section>
         <span>Appbar inverse theme color</span>
         <section>
-            <div fillmode="solid" class="k-appbar k-appbar-inverse">
+            <div class="k-appbar k-appbar-inverse">
                 <div class="k-appbar-section">
                     <span class="k-icon k-svg-icon k-svg-i-menu">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">


### PR DESCRIPTION
In the [Appbar tests](https://github.com/telerik/kendo-themes/blob/d84d6dd15dc96b01d20ce0a202650d237e5c200c/tests/appbar/appbar.html) there is a `fillMode="solid"` property set, however the Appbar itself only has a `themeColor` property.

This PR removes the `fillMode` as it does not result to anything and causes confusion.