### PR TITLE
chore: generate missing utils

### DIFF
--- a/packages/utils/docs/customization.md
+++ b/packages/utils/docs/customization.md
@@ -3933,20 +3933,6 @@ This is equivalent to `padding: 0.25rem;`.
 
 
 
-### `.k-p--1px`
-
-This is equivalent to `padding: -1px;`.
-
-
-
-
-### `.k-p--1`
-
-This is equivalent to `padding: -0.25rem;`.
-
-
-
-
 ### `.k-p-xs`
 
 This is equivalent to `padding: 0.25rem;`.
@@ -4020,20 +4006,6 @@ This is equivalent to `padding-top: 1px;`.
 ### `.k-pt-1`
 
 This is equivalent to `padding-top: 0.25rem;`.
-
-
-
-
-### `.k-pt--1px`
-
-This is equivalent to `padding-top: -1px;`.
-
-
-
-
-### `.k-pt--1`
-
-This is equivalent to `padding-top: -0.25rem;`.
 
 
 
@@ -4115,20 +4087,6 @@ This is equivalent to `padding-right: 0.25rem;`.
 
 
 
-### `.k-pr--1px`
-
-This is equivalent to `padding-right: -1px;`.
-
-
-
-
-### `.k-pr--1`
-
-This is equivalent to `padding-right: -0.25rem;`.
-
-
-
-
 ### `.k-pr-xs`
 
 This is equivalent to `padding-right: 0.25rem;`.
@@ -4202,20 +4160,6 @@ This is equivalent to `padding-bottom: 1px;`.
 ### `.k-pb-1`
 
 This is equivalent to `padding-bottom: 0.25rem;`.
-
-
-
-
-### `.k-pb--1px`
-
-This is equivalent to `padding-bottom: -1px;`.
-
-
-
-
-### `.k-pb--1`
-
-This is equivalent to `padding-bottom: -0.25rem;`.
 
 
 
@@ -4297,20 +4241,6 @@ This is equivalent to `padding-left: 0.25rem;`.
 
 
 
-### `.k-pl--1px`
-
-This is equivalent to `padding-left: -1px;`.
-
-
-
-
-### `.k-pl--1`
-
-This is equivalent to `padding-left: -0.25rem;`.
-
-
-
-
 ### `.k-pl-xs`
 
 This is equivalent to `padding-left: 0.25rem;`.
@@ -4388,20 +4318,6 @@ This is equivalent to `padding-inline: 0.25rem;`.
 
 
 
-### `.k-px--1px`
-
-This is equivalent to `padding-inline: -1px;`.
-
-
-
-
-### `.k-px--1`
-
-This is equivalent to `padding-inline: -0.25rem;`.
-
-
-
-
 ### `.k-px-xs`
 
 This is equivalent to `padding-inline: 0.25rem;`.
@@ -4475,20 +4391,6 @@ This is equivalent to `padding-block: 1px;`.
 ### `.k-py-1`
 
 This is equivalent to `padding-block: 0.25rem;`.
-
-
-
-
-### `.k-py--1px`
-
-This is equivalent to `padding-block: -1px;`.
-
-
-
-
-### `.k-py--1`
-
-This is equivalent to `padding-block: -0.25rem;`.
 
 
 

--- a/packages/utils/scss/spacing/_margin.scss
+++ b/packages/utils/scss/spacing/_margin.scss
@@ -547,12 +547,13 @@
 @mixin kendo-utils--spacing--margin() {
 
     // Margin utility classes
-    @include generate-utils( m, margin, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( mt, margin-top, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( mr, margin-right, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( mb, margin-bottom, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( ml, margin-left, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( mx, margin-inline, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( my, margin-block, $kendo-spacing, $css-var: "spacing" );
+    $kendo-utils-margin: k-map-get( $kendo-utils, "margin" ) !default;
+    @include generate-utils( m, margin, $kendo-utils-margin, $css-var: "spacing" );
+    @include generate-utils( mt, margin-top, $kendo-utils-margin, $css-var: "spacing" );
+    @include generate-utils( mr, margin-right, $kendo-utils-margin, $css-var: "spacing" );
+    @include generate-utils( mb, margin-bottom, $kendo-utils-margin, $css-var: "spacing" );
+    @include generate-utils( ml, margin-left, $kendo-utils-margin, $css-var: "spacing" );
+    @include generate-utils( mx, margin-inline, $kendo-utils-margin, $css-var: "spacing" );
+    @include generate-utils( my, margin-block, $kendo-utils-margin, $css-var: "spacing" );
 
 }

--- a/packages/utils/scss/spacing/_padding.scss
+++ b/packages/utils/scss/spacing/_padding.scss
@@ -16,18 +16,6 @@
 /// @group padding
 /// @contextType css
 
-/// This is equivalent to `padding: -1px;`.
-/// @example padding: -1px;
-/// @name .k-p--1px
-/// @group padding
-/// @contextType css
-
-/// This is equivalent to `padding: -0.25rem;`.
-/// @example padding: -0.25rem;
-/// @name .k-p--1
-/// @group padding
-/// @contextType css
-
 /// This is equivalent to `padding: 0.25rem;`.
 /// @example padding: 0.25rem;
 /// @name .k-p-xs
@@ -91,18 +79,6 @@
 /// This is equivalent to `padding-top: 0.25rem;`.
 /// @example padding-top: 0.25rem;
 /// @name .k-pt-1
-/// @group padding
-/// @contextType css
-
-/// This is equivalent to `padding-top: -1px;`.
-/// @example padding-top: -1px;
-/// @name .k-pt--1px
-/// @group padding
-/// @contextType css
-
-/// This is equivalent to `padding-top: -0.25rem;`.
-/// @example padding-top: -0.25rem;
-/// @name .k-pt--1
 /// @group padding
 /// @contextType css
 
@@ -172,18 +148,6 @@
 /// @group padding
 /// @contextType css
 
-/// This is equivalent to `padding-right: -1px;`.
-/// @example padding-right: -1px;
-/// @name .k-pr--1px
-/// @group padding
-/// @contextType css
-
-/// This is equivalent to `padding-right: -0.25rem;`.
-/// @example padding-right: -0.25rem;
-/// @name .k-pr--1
-/// @group padding
-/// @contextType css
-
 /// This is equivalent to `padding-right: 0.25rem;`.
 /// @example padding-right: 0.25rem;
 /// @name .k-pr-xs
@@ -247,18 +211,6 @@
 /// This is equivalent to `padding-bottom: 0.25rem;`.
 /// @example padding-bottom: 0.25rem;
 /// @name .k-pb-1
-/// @group padding
-/// @contextType css
-
-/// This is equivalent to `padding-bottom: -1px;`.
-/// @example padding-bottom: -1px;
-/// @name .k-pb--1px
-/// @group padding
-/// @contextType css
-
-/// This is equivalent to `padding-bottom: -0.25rem;`.
-/// @example padding-bottom: -0.25rem;
-/// @name .k-pb--1
 /// @group padding
 /// @contextType css
 
@@ -328,18 +280,6 @@
 /// @group padding
 /// @contextType css
 
-/// This is equivalent to `padding-left: -1px;`.
-/// @example padding-left: -1px;
-/// @name .k-pl--1px
-/// @group padding
-/// @contextType css
-
-/// This is equivalent to `padding-left: -0.25rem;`.
-/// @example padding-left: -0.25rem;
-/// @name .k-pl--1
-/// @group padding
-/// @contextType css
-
 /// This is equivalent to `padding-left: 0.25rem;`.
 /// @example padding-left: 0.25rem;
 /// @name .k-pl-xs
@@ -403,18 +343,6 @@
 /// This is equivalent to `padding-inline: 0.25rem;`.
 /// @example padding-inline: 0.25rem;
 /// @name .k-px-1
-/// @group padding
-/// @contextType css
-
-/// This is equivalent to `padding-inline: -1px;`.
-/// @example padding-inline: -1px;
-/// @name .k-px--1px
-/// @group padding
-/// @contextType css
-
-/// This is equivalent to `padding-inline: -0.25rem;`.
-/// @example padding-inline: -0.25rem;
-/// @name .k-px--1
 /// @group padding
 /// @contextType css
 
@@ -484,18 +412,6 @@
 /// @group padding
 /// @contextType css
 
-/// This is equivalent to `padding-block: -1px;`.
-/// @example padding-block: -1px;
-/// @name .k-py--1px
-/// @group padding
-/// @contextType css
-
-/// This is equivalent to `padding-block: -0.25rem;`.
-/// @example padding-block: -0.25rem;
-/// @name .k-py--1
-/// @group padding
-/// @contextType css
-
 /// This is equivalent to `padding-block: 0.25rem;`.
 /// @example padding-block: 0.25rem;
 /// @name .k-py-xs
@@ -547,12 +463,13 @@
 @mixin kendo-utils--spacing--padding() {
 
     // Padding utility classes
-    @include generate-utils( p, padding, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( pt, padding-top, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( pr, padding-right, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( pb, padding-bottom, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( pl, padding-left, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( px, padding-inline, $kendo-spacing, $css-var: "spacing" );
-    @include generate-utils( py, padding-block, $kendo-spacing, $css-var: "spacing" );
+    $kendo-utils-padding: k-map-get( $kendo-utils, "padding" ) !default;
+    @include generate-utils( p, padding, $kendo-utils-padding, $css-var: "spacing" );
+    @include generate-utils( pt, padding-top, $kendo-utils-padding, $css-var: "spacing" );
+    @include generate-utils( pr, padding-right, $kendo-utils-padding, $css-var: "spacing" );
+    @include generate-utils( pb, padding-bottom, $kendo-utils-padding, $css-var: "spacing" );
+    @include generate-utils( pl, padding-left, $kendo-utils-padding, $css-var: "spacing" );
+    @include generate-utils( px, padding-inline, $kendo-utils-padding, $css-var: "spacing" );
+    @include generate-utils( py, padding-block, $kendo-utils-padding, $css-var: "spacing" );
 
 }


### PR DESCRIPTION
In this PR:

- Generate missing spacing-related utils;
- Remove examples with negative paddings, as values for padding cannot be negative;