### PR TITLE
chore(utils): use correct css var in font weight utils

### DIFF
--- a/packages/utils/scss/typography/_font-weight.scss
+++ b/packages/utils/scss/typography/_font-weight.scss
@@ -57,7 +57,7 @@
 @mixin kendo-utils--typography--font-weight() {
 
     // Font weight utility classes
-    @include generate-utils( font, font-weight, $kendo-font-weights, $css-var: "font" );
+    @include generate-utils( font, font-weight, $kendo-font-weights, $css-var: "font-weight" );
 
 
     // Legacy aliases


### PR DESCRIPTION
`k-font-*` utils were not using the correct css variables `--kendo-font-weight-*`, this PR addresses that