### PR TITLE
chore: generate css variables for gap utils

### DIFF
--- a/packages/utils/scss/flex-grid/_gap.scss
+++ b/packages/utils/scss/flex-grid/_gap.scss
@@ -182,8 +182,8 @@
 
     // Gap utility classes
     $kendo-utils-gap: k-map-get( $kendo-utils, "gap" ) !default;
-    @include generate-utils( gap, gap, $kendo-utils-gap );
-    @include generate-utils( gap-x, column-gap, $kendo-utils-gap );
-    @include generate-utils( gap-y, row-gap, $kendo-utils-gap );
+    @include generate-utils( gap, gap, $kendo-utils-gap, $css-var: "spacing" );
+    @include generate-utils( gap-x, column-gap, $kendo-utils-gap, $css-var: "spacing" );
+    @include generate-utils( gap-y, row-gap, $kendo-utils-gap, $css-var: "spacing" );
 
 }


### PR DESCRIPTION
Same as padding / margin, gap should be related to the spacing system