### PR TITLE
Drawer use `$kendo-drawer-content-padding-x` and `$kendo-drawer-content-padding-y`

### DIFF
--- a/packages/bootstrap/docs/customization-drawer.md
+++ b/packages/bootstrap/docs/customization-drawer.md
@@ -98,10 +98,20 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-drawer-content-padding-x</td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the Drawer content.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-drawer-content-padding-y</td>
-    <td>String</td>
-    <td><code>$kendo-padding-md-y</code></td>
-    <td><code>var(--kendo-spacing-2, 0.5rem)</code></td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the Drawer content.</div></div>

--- a/packages/bootstrap/docs/customization.md
+++ b/packages/bootstrap/docs/customization.md
@@ -7339,10 +7339,20 @@ The following table lists the available variables for customizing the Bootstrap 
     </td>
 </tr>
 <tr>
+    <td>$kendo-drawer-content-padding-x</td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the Drawer content.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-drawer-content-padding-y</td>
-    <td>String</td>
-    <td><code>$kendo-padding-md-y</code></td>
-    <td><code>var(--kendo-spacing-2, 0.5rem)</code></td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the Drawer content.</div></div>

--- a/packages/bootstrap/scss/drawer/_variables.scss
+++ b/packages/bootstrap/scss/drawer/_variables.scss
@@ -22,10 +22,13 @@ $kendo-drawer-font-size: var( --kendo-font-size, inherit ) !default;
 /// The line height of the Drawer.
 /// @group drawer
 $kendo-drawer-line-height: var( --kendo-line-height, normal ) !default;
-$kendo-drawer-content-padding-x: $kendo-padding-md-x !default;
+
+/// The horizontal padding of the Drawer content.
+/// @group drawer
+$kendo-drawer-content-padding-x: null !default;
 /// The vertical padding of the Drawer content.
 /// @group drawer
-$kendo-drawer-content-padding-y: $kendo-padding-md-y !default;
+$kendo-drawer-content-padding-y: null !default;
 
 /// The width of the Drawer scrollbar.
 /// @group drawer

--- a/packages/classic/docs/customization-drawer.md
+++ b/packages/classic/docs/customization-drawer.md
@@ -98,10 +98,20 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-drawer-content-padding-x</td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the Drawer content.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-drawer-content-padding-y</td>
-    <td>String</td>
-    <td><code>$kendo-padding-md-y</code></td>
-    <td><code>var(--kendo-spacing-1, 0.25rem)</code></td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the Drawer content.</div></div>

--- a/packages/classic/docs/customization.md
+++ b/packages/classic/docs/customization.md
@@ -7510,10 +7510,20 @@ The following table lists the available variables for customizing the Classic th
     </td>
 </tr>
 <tr>
+    <td>$kendo-drawer-content-padding-x</td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the Drawer content.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-drawer-content-padding-y</td>
-    <td>String</td>
-    <td><code>$kendo-padding-md-y</code></td>
-    <td><code>var(--kendo-spacing-1, 0.25rem)</code></td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the Drawer content.</div></div>

--- a/packages/classic/scss/drawer/_variables.scss
+++ b/packages/classic/scss/drawer/_variables.scss
@@ -22,10 +22,13 @@ $kendo-drawer-font-size: var( --kendo-font-size, inherit ) !default;
 /// The line height of the Drawer.
 /// @group drawer
 $kendo-drawer-line-height: var( --kendo-line-height, normal ) !default;
-$kendo-drawer-content-padding-x: $kendo-padding-md-x !default;
+
+/// The horizontal padding of the Drawer content.
+/// @group drawer
+$kendo-drawer-content-padding-x: null !default;
 /// The vertical padding of the Drawer content.
 /// @group drawer
-$kendo-drawer-content-padding-y: $kendo-padding-md-y !default;
+$kendo-drawer-content-padding-y: null !default;
 
 /// The width of the Drawer scrollbar.
 /// @group drawer

--- a/packages/default/docs/customization-drawer.md
+++ b/packages/default/docs/customization-drawer.md
@@ -98,10 +98,20 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-drawer-content-padding-x</td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the Drawer content.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-drawer-content-padding-y</td>
-    <td>String</td>
-    <td><code>$kendo-padding-md-y</code></td>
-    <td><code>var(--kendo-spacing-1, 0.25rem)</code></td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the Drawer content.</div></div>

--- a/packages/default/docs/customization.md
+++ b/packages/default/docs/customization.md
@@ -7749,10 +7749,20 @@ The following table lists the available variables for customizing the Default th
     </td>
 </tr>
 <tr>
+    <td>$kendo-drawer-content-padding-x</td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the Drawer content.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-drawer-content-padding-y</td>
-    <td>String</td>
-    <td><code>$kendo-padding-md-y</code></td>
-    <td><code>var(--kendo-spacing-1, 0.25rem)</code></td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the Drawer content.</div></div>

--- a/packages/default/scss/drawer/_layout.scss
+++ b/packages/default/scss/drawer/_layout.scss
@@ -65,6 +65,8 @@
     .k-drawer-content {
         flex: 1 1 auto;
         overflow: auto;
+        padding-block: $kendo-drawer-content-padding-y;
+        padding-inline: $kendo-drawer-content-padding-x;
     }
 
 

--- a/packages/default/scss/drawer/_variables.scss
+++ b/packages/default/scss/drawer/_variables.scss
@@ -22,10 +22,14 @@ $kendo-drawer-font-size: var( --kendo-font-size, inherit ) !default;
 /// The line height of the Drawer.
 /// @group drawer
 $kendo-drawer-line-height: var( --kendo-line-height, normal ) !default;
-$kendo-drawer-content-padding-x: $kendo-padding-md-x !default;
+
+/// The horizontal padding of the Drawer content.
+/// @group drawer
+$kendo-drawer-content-padding-x: null !default;
+
 /// The vertical padding of the Drawer content.
 /// @group drawer
-$kendo-drawer-content-padding-y: $kendo-padding-md-y !default;
+$kendo-drawer-content-padding-y: null !default;
 
 /// The width of the Drawer scrollbar.
 /// @group drawer

--- a/packages/fluent/docs/customization-drawer.md
+++ b/packages/fluent/docs/customization-drawer.md
@@ -100,7 +100,7 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-drawer-content-padding-x</td>
     <td></td>
-    <td><code>var( --kendo-padding-x, #{$kendo-padding-md-x} )</code></td>
+    <td><code>null</code></td>
     <td></td>
 </tr>
 <tr>
@@ -110,7 +110,7 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-drawer-content-padding-y</td>
     <td></td>
-    <td><code>var( --kendo-padding-y, #{$kendo-padding-md-y} )</code></td>
+    <td><code>null</code></td>
     <td></td>
 </tr>
 <tr>

--- a/packages/fluent/docs/customization.md
+++ b/packages/fluent/docs/customization.md
@@ -8869,7 +8869,7 @@ The following table lists the available variables for customizing the Fluent the
 <tr>
     <td>$kendo-drawer-content-padding-x</td>
     <td></td>
-    <td><code>var( --kendo-padding-x, #{$kendo-padding-md-x} )</code></td>
+    <td><code>null</code></td>
     <td></td>
 </tr>
 <tr>
@@ -8879,7 +8879,7 @@ The following table lists the available variables for customizing the Fluent the
 <tr>
     <td>$kendo-drawer-content-padding-y</td>
     <td></td>
-    <td><code>var( --kendo-padding-y, #{$kendo-padding-md-y} )</code></td>
+    <td><code>null</code></td>
     <td></td>
 </tr>
 <tr>

--- a/packages/fluent/scss/drawer/_layout.scss
+++ b/packages/fluent/scss/drawer/_layout.scss
@@ -68,6 +68,8 @@
     .k-drawer-content {
         flex: 1 1 auto;
         overflow: auto;
+        padding-block: var( --kendo-drawer-content-padding-y, #{$kendo-drawer-content-padding-y} );
+        padding-inline: var( --kendo-drawer-content-padding-x, #{$kendo-drawer-content-padding-x} );
     }
 
 

--- a/packages/fluent/scss/drawer/_variables.scss
+++ b/packages/fluent/scss/drawer/_variables.scss
@@ -26,10 +26,10 @@ $kendo-drawer-line-height: var( --kendo-line-height, inherit ) !default;
 
 /// The horizontal padding of the Drawer content.
 /// @group drawer
-$kendo-drawer-content-padding-x: var( --kendo-padding-x, #{$kendo-padding-md-x} ) !default;
+$kendo-drawer-content-padding-x: null !default;
 /// The vertical padding of the Drawer content.
 /// @group drawer
-$kendo-drawer-content-padding-y: var( --kendo-padding-y, #{$kendo-padding-md-y} ) !default;
+$kendo-drawer-content-padding-y: null !default;
 
 /// The width of the Drawer scrollbar.
 /// @group drawer

--- a/packages/material/docs/customization-drawer.md
+++ b/packages/material/docs/customization-drawer.md
@@ -98,10 +98,20 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-drawer-content-padding-x</td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the Drawer content.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-drawer-content-padding-y</td>
-    <td>String</td>
-    <td><code>$kendo-padding-md-y</code></td>
-    <td><code>var(--kendo-spacing-1, 0.25rem)</code></td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the Drawer content.</div></div>

--- a/packages/material/docs/customization.md
+++ b/packages/material/docs/customization.md
@@ -7369,10 +7369,20 @@ The following table lists the available variables for customizing the Material t
     </td>
 </tr>
 <tr>
+    <td>$kendo-drawer-content-padding-x</td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The horizontal padding of the Drawer content.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-drawer-content-padding-y</td>
-    <td>String</td>
-    <td><code>$kendo-padding-md-y</code></td>
-    <td><code>var(--kendo-spacing-1, 0.25rem)</code></td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The vertical padding of the Drawer content.</div></div>

--- a/packages/material/scss/drawer/_variables.scss
+++ b/packages/material/scss/drawer/_variables.scss
@@ -22,10 +22,13 @@ $kendo-drawer-font-size: var( --kendo-font-size, inherit ) !default;
 /// The line height of the Drawer.
 /// @group drawer
 $kendo-drawer-line-height: var( --kendo-line-height, normal ) !default;
-$kendo-drawer-content-padding-x: $kendo-padding-md-x !default;
+
+/// The horizontal padding of the Drawer content.
+/// @group drawer
+$kendo-drawer-content-padding-x: null !default;
 /// The vertical padding of the Drawer content.
 /// @group drawer
-$kendo-drawer-content-padding-y: $kendo-padding-md-y !default;
+$kendo-drawer-content-padding-y: null !default;
 
 /// The width of the Drawer scrollbar.
 /// @group drawer


### PR DESCRIPTION
This is based on feedback from `Ticket ID: 1648341` where they want to set the padding using SCSS variables.

Currently, it is only possible to do this using CSS:
```
.k-content-drawer {
  padding-inline: 20px;
  padding-block: 20px;
}
```

https://stackblitz.com/edit/react-siozrp-d1bfnw?file=app%2Fmain.jsx,app%2Fstyles.scss