### PR TITLE
Remove sankey label pointer-events

### DIFF
--- a/packages/default/scss/dataviz/_layout.scss
+++ b/packages/default/scss/dataviz/_layout.scss
@@ -268,7 +268,10 @@
     }
 
 
-
+    // Sankey labels
+    .k-sankey text {
+        pointer-events: none;
+    }
 
     // Treemap
     .k-treemap {

--- a/packages/fluent/scss/dataviz/_layout.scss
+++ b/packages/fluent/scss/dataviz/_layout.scss
@@ -272,6 +272,11 @@
         height: 100%;
     }
 
+    // Sankey labels
+    .k-sankey text {
+        pointer-events: none;
+    }
+
     // Base
     .k-treemap {
         height: 400px;


### PR DESCRIPTION
Sankey labels should not have hover effects and trigger mouse events.

cc/ @tsvetomir 