### PR TITLE
fix(action-sheet): reduce filter calc nesting

### DIFF
--- a/packages/default/scss/action-sheet/_layout.scss
+++ b/packages/default/scss/action-sheet/_layout.scss
@@ -253,7 +253,7 @@
         }
 
         .k-actionsheet-filter {
-            width: calc( min(100%, calc( 360px - calc( #{$kendo-adaptive-actionsheet-titlebar-padding-x} * 2 )) ) );
+            width: calc( 360px - #{$kendo-adaptive-actionsheet-titlebar-padding-x} * 2 );
         }
         .k-actionsheet-content,
         .k-actionsheet-footer {

--- a/packages/fluent/scss/action-sheet/_layout.scss
+++ b/packages/fluent/scss/action-sheet/_layout.scss
@@ -283,7 +283,7 @@
         }
 
         .k-actionsheet-filter {
-            width: calc( min(100%, calc( 360px - calc( #{$kendo-adaptive-actionsheet-header-padding-x} * 2 ) ) ) );
+            width: calc( 360px - #{$kendo-adaptive-actionsheet-header-padding-x} * 2 );
         }
         .k-actionsheet-content,
         .k-actionsheet-footer {


### PR DESCRIPTION
Reduce calc expression to workaround a build warning in create-react-app ( which is deprecated for ~2 years ).

Related: https://github.com/telerik/kendo-themes/issues/4337#issuecomment-1485379417

// cc @zdravkov, @elena-gancheva, @bptodorova 