### PR TITLE
chore: move the k-color function in core/functions

### DIFF
--- a/packages/core/docs/customization.md
+++ b/packages/core/docs/customization.md
@@ -488,7 +488,7 @@ k-generate-color-variations($name, $color, $theme) // => Map
 #### Source
 
 ```scss
-// Location https://github.com/telerik/kendo-themes/blob/develop/packages/core/scss/functions/_color-variations.import.scss#L8-L122
+// Location https://github.com/telerik/kendo-themes/blob/develop/packages/core/scss/functions/_color-system.import.scss#L8-L122
 @function k-generate-color-variations($name, $color, $theme) {
     $result: ();
 
@@ -603,6 +603,42 @@ k-generate-color-variations($name, $color, $theme) // => Map
     }
 
     @return $result;
+}
+```
+
+### `k-color`
+
+Takes a color name from the $kendo-colors map as a parameter
+and returns a CSS variable with the actual color as a fallback
+
+
+#### Syntax
+
+```scss
+k-color($key) // => String
+```
+
+#### Parameters
+
+
+`<String> $key`
+: The name of a color/key in the $kendo-colors map
+
+
+
+
+#### Source
+
+```scss
+// Location https://github.com/telerik/kendo-themes/blob/develop/packages/core/scss/functions/_color-system.import.scss#L130-L138
+@function k-color($key) {
+    $_color: k-map-get($kendo-colors, $key);
+
+    @if ($_color) {
+        @return var(--kendo-color-#{$key}, $_color);
+    } @else {
+        @error "Color Variable \`#{$key}\` does not exists in the color collection.";
+    }
 }
 ```
 

--- a/packages/core/scss/color-system/_swatch.scss
+++ b/packages/core/scss/color-system/_swatch.scss
@@ -177,16 +177,6 @@ $_default-colors: (
 $kendo-colors: $_default-colors !default;
 $kendo-colors: k-map-merge($_default-colors, $kendo-colors);
 
-@function k-color($key) {
-    $_color: k-map-get($kendo-colors, $key);
-
-    @if ($_color) {
-        @return var(--kendo-color-#{$key}, $_color);
-    } @else {
-        @error "Color Variable \`#{$key}\` does not exists in the color collection.";
-    }
-}
-
 @mixin color-system--styles() {
     :root {
         @each $key, $value in $kendo-colors {

--- a/packages/core/scss/functions/_color-system.import.scss
+++ b/packages/core/scss/functions/_color-system.import.scss
@@ -120,3 +120,19 @@
 
     @return $result;
 }
+
+/// Takes a color name from the $kendo-colors map as a parameter
+/// and returns a CSS variable with the actual color as a fallback
+/// @param {String} $key - The name of a color/key in the $kendo-colors map
+/// @return {String} - CSS variable with the actual color as a fallback
+///
+/// @group color-system
+@function k-color($key) {
+    $_color: k-map-get($kendo-colors, $key);
+
+    @if ($_color) {
+        @return var(--kendo-color-#{$key}, $_color);
+    } @else {
+        @error "Color Variable \`#{$key}\` does not exists in the color collection.";
+    }
+}

--- a/packages/core/scss/functions/index.import.scss
+++ b/packages/core/scss/functions/index.import.scss
@@ -1,7 +1,7 @@
 @import "./_color.import.scss";
 @import "./_color-contrast.import.scss";
 @import "./_color-manipulation.import.scss";
-@import "./_color-variations.import.scss";
+@import "./_color-system.import.scss";
 @import "./_custom-properties.import.scss";
 @import "./_escape-string.import.scss";
 @import "./_lang.import.scss";


### PR DESCRIPTION
This adjustment is in big part related to the [Migration](https://www.telerik.com/design-system/docs/themes/theme-default/migration/) to the new Color System (ticket ID - 1652186).

If the user has made the following customization:

```scss
$kendo-color-primary: #9c27b0;
$kendo-panelbar-header-bg: $kendo-color-primary;

@import "@progress/kendo-theme-default/dist/all.scss";
```

They would need to migrate the above customization to the new Color System.
If they use the [Migration script](https://www.telerik.com/design-system/docs/themes/theme-default/migration/#automated-migration), they would get the following result, where the `k-color()` function will not work because it is not available/imported:

```scss
@import "@progress/kendo-theme-core/scss/functions/index.import.scss";
$kendo-colors: ();
$kendo-colors: k-map-merge($kendo-colors, k-generate-color-variations(primary,  #9c27b0, default));
$kendo-panelbar-header-bg: k-color( primary );

@import "@progress/kendo-theme-default/dist/all.scss";
```

The cleanest and most consistent solution seems to be to make sure that the `k-color()` function is available wherever the `k-generate-color-variations()` is.

P.S. - The generated screenshots do not seem to be caused by the changes in this PR.