### PR TITLE
fix(spreadsheet): prevent triggering the Open tool in Safari

### DIFF
--- a/packages/default/scss/spreadsheet/_layout.scss
+++ b/packages/default/scss/spreadsheet/_layout.scss
@@ -33,6 +33,10 @@
     // Toolbar
     .k-spreadsheet-toolbar {
         border-width: 0;
+
+        > .k-upload-button-wrap {
+            overflow: hidden;
+        }
     }
 
     // Action bar

--- a/packages/fluent/scss/spreadsheet/_layout.scss
+++ b/packages/fluent/scss/spreadsheet/_layout.scss
@@ -55,6 +55,10 @@
     // Toolbar
     .k-spreadsheet-toolbar {
         border-width: 0;
+
+        > .k-upload-button-wrap {
+            overflow: hidden;
+        }
     }
 
 


### PR DESCRIPTION
On Mac in Safari browser -> Go to https://demos.telerik.com/kendo-ui/spreadsheet/index

Clicking on any tool button of the Spreadsheet, this triggers the Open tool and the browser's file selection dialog appears.

CC @dimodi 