### PR TITLE
Material fluent border radius

### DIFF
--- a/packages/bootstrap/docs/customization-radii.md
+++ b/packages/bootstrap/docs/customization-radii.md
@@ -131,6 +131,7 @@ The following table lists the available variables for customization.
     <td>$kendo-border-radii</td>
     <td>Map</td>
     <td><code>(
+    none: $kendo-border-radius-none,
     xs: $kendo-border-radius-xs,
     sm: $kendo-border-radius-sm,
     md: $kendo-border-radius-md,

--- a/packages/bootstrap/docs/customization.md
+++ b/packages/bootstrap/docs/customization.md
@@ -17521,6 +17521,7 @@ The following table lists the available variables for customizing the Bootstrap 
     <td>$kendo-border-radii</td>
     <td>Map</td>
     <td><code>(
+    none: $kendo-border-radius-none,
     xs: $kendo-border-radius-xs,
     sm: $kendo-border-radius-sm,
     md: $kendo-border-radius-md,

--- a/packages/bootstrap/scss/core/border-radii/index.import.scss
+++ b/packages/bootstrap/scss/core/border-radii/index.import.scss
@@ -32,6 +32,7 @@ $kendo-border-radius-full: 50rem !default;
 /// The global radii Map.
 /// @group radii
 $kendo-border-radii: (
+    none: $kendo-border-radius-none,
     xs: $kendo-border-radius-xs,
     sm: $kendo-border-radius-sm,
     md: $kendo-border-radius-md,

--- a/packages/fluent/docs/customization-radii.md
+++ b/packages/fluent/docs/customization-radii.md
@@ -108,16 +108,6 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
-    <td>$kendo-border-radii</td>
-    <td>Map</td>
-    <td><code>$_default-border-radii</code></td>
-    <td><code>(none: 0px, xs: 1px, sm: 0.125rem, md: 0.25rem, lg: 0.5rem, xl: 0.75rem, xxl: 1rem, xxxl: 1.25rem)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The global radii Map.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-border-radius-full</td>
     <td>Number</td>
     <td><code>9999px</code></td>
@@ -125,6 +115,16 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The largest border radius used across the Components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-border-radii</td>
+    <td>Map</td>
+    <td><code>$_default-border-radii</code></td>
+    <td><code>(none: 0px, xs: 1px, sm: 0.125rem, md: 0.25rem, lg: 0.5rem, xl: 0.75rem, xxl: 1rem, xxxl: 1.25rem, full: 9999px)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The global radii Map.</div></div>
     </td>
 </tr>
 </tbody>

--- a/packages/fluent/docs/customization.md
+++ b/packages/fluent/docs/customization.md
@@ -22908,16 +22908,6 @@ The following table lists the available variables for customizing the Fluent the
     </td>
 </tr>
 <tr>
-    <td>$kendo-border-radii</td>
-    <td>Map</td>
-    <td><code>$_default-border-radii</code></td>
-    <td><code>(none: 0px, xs: 1px, sm: 0.125rem, md: 0.25rem, lg: 0.5rem, xl: 0.75rem, xxl: 1rem, xxxl: 1.25rem)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The global radii Map.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-border-radius-full</td>
     <td>Number</td>
     <td><code>9999px</code></td>
@@ -22925,6 +22915,16 @@ The following table lists the available variables for customizing the Fluent the
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The largest border radius used across the Components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-border-radii</td>
+    <td>Map</td>
+    <td><code>$_default-border-radii</code></td>
+    <td><code>(none: 0px, xs: 1px, sm: 0.125rem, md: 0.25rem, lg: 0.5rem, xl: 0.75rem, xxl: 1rem, xxxl: 1.25rem, full: 9999px)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The global radii Map.</div></div>
     </td>
 </tr>
 </tbody>

--- a/packages/fluent/scss/core/border-radii/_index.scss
+++ b/packages/fluent/scss/core/border-radii/_index.scss
@@ -25,6 +25,9 @@ $kendo-border-radius-xxl: map.get($kendo-spacing, 4) !default;
 /// The second largest border radius used across the Components.
 /// @group radii
 $kendo-border-radius-xxxl: map.get($kendo-spacing, 5) !default;
+/// The largest border radius used across the Components.
+/// @group radii
+$kendo-border-radius-full: 9999px !default;
 
 $_default-border-radii: (
     none: $kendo-border-radius-none,
@@ -34,7 +37,8 @@ $_default-border-radii: (
     lg: $kendo-border-radius-lg,
     xl: $kendo-border-radius-xl,
     xxl: $kendo-border-radius-xxl,
-    xxxl: $kendo-border-radius-xxxl
+    xxxl: $kendo-border-radius-xxxl,
+    full: $kendo-border-radius-full
 ) !default;
 
 /// The global radii Map.

--- a/packages/material/docs/customization-radii.md
+++ b/packages/material/docs/customization-radii.md
@@ -108,6 +108,16 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-border-radius-full</td>
+    <td>Number</td>
+    <td><code>9999px</code></td>
+    <td><code>9999px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The largest border radius used across the Components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-border-radii</td>
     <td>Map</td>
     <td><code>(
@@ -118,22 +128,13 @@ The following table lists the available variables for customization.
     lg: $kendo-border-radius-lg,
     xl: $kendo-border-radius-xl,
     xxl: $kendo-border-radius-xxl,
-    xxxl: $kendo-border-radius-xxxl
+    xxxl: $kendo-border-radius-xxxl,
+    full: $kendo-border-radius-full
 )</code></td>
     <td><code>(none: 0px, xs: 1px, sm: 0.125rem, md: 0.25rem, lg: 0.5rem, xl: 0.75rem, xxl: 1rem, xxxl: 1.25rem, full: 9999px)</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The global radii Map.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-border-radius-full</td>
-    <td>Number</td>
-    <td><code>9999px</code></td>
-    <td><code>9999px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The largest border radius used across the Components.</div></div>
     </td>
 </tr>
 </tbody>

--- a/packages/material/docs/customization.md
+++ b/packages/material/docs/customization.md
@@ -17439,6 +17439,16 @@ The following table lists the available variables for customizing the Material t
     </td>
 </tr>
 <tr>
+    <td>$kendo-border-radius-full</td>
+    <td>Number</td>
+    <td><code>9999px</code></td>
+    <td><code>9999px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The largest border radius used across the Components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-border-radii</td>
     <td>Map</td>
     <td><code>(
@@ -17449,22 +17459,13 @@ The following table lists the available variables for customizing the Material t
     lg: $kendo-border-radius-lg,
     xl: $kendo-border-radius-xl,
     xxl: $kendo-border-radius-xxl,
-    xxxl: $kendo-border-radius-xxxl
+    xxxl: $kendo-border-radius-xxxl,
+    full: $kendo-border-radius-full
 )</code></td>
     <td><code>(none: 0px, xs: 1px, sm: 0.125rem, md: 0.25rem, lg: 0.5rem, xl: 0.75rem, xxl: 1rem, xxxl: 1.25rem, full: 9999px)</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The global radii Map.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-border-radius-full</td>
-    <td>Number</td>
-    <td><code>9999px</code></td>
-    <td><code>9999px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The largest border radius used across the Components.</div></div>
     </td>
 </tr>
 </tbody>

--- a/packages/material/scss/core/border-radii/index.import.scss
+++ b/packages/material/scss/core/border-radii/index.import.scss
@@ -22,6 +22,9 @@ $kendo-border-radius-xxl: k-map-get($kendo-spacing, 4) !default;
 /// The second largest border radius used across the Components.
 /// @group radii
 $kendo-border-radius-xxxl: k-map-get($kendo-spacing, 5) !default;
+/// The largest border radius used across the Components.
+/// @group radii
+$kendo-border-radius-full: 9999px !default;
 
 /// The global radii Map.
 /// @group radii
@@ -33,7 +36,8 @@ $kendo-border-radii: (
     lg: $kendo-border-radius-lg,
     xl: $kendo-border-radius-xl,
     xxl: $kendo-border-radius-xxl,
-    xxxl: $kendo-border-radius-xxxl
+    xxxl: $kendo-border-radius-xxxl,
+    full: $kendo-border-radius-full
 ) !default;
 
 @import "@progress/kendo-theme-core/scss/border-radii/index.import.scss";


### PR DESCRIPTION
According to [this issue](https://github.com/telerik/web-components-ux/issues/943#issuecomment-1845388821), there should be values for full border radius in the Material and Fluent themes as well