### PR TITLE
fix(stepper): remove outline of k-step element

### DIFF
--- a/packages/default/scss/stepper/_layout.scss
+++ b/packages/default/scss/stepper/_layout.scss
@@ -40,7 +40,9 @@
 
 
         // Step
-        .k-step { }
+        .k-step {
+            outline: none;
+        }
 
 
         // Step link

--- a/packages/fluent/scss/stepper/_layout.scss
+++ b/packages/fluent/scss/stepper/_layout.scss
@@ -39,6 +39,8 @@
 
         // Step
         .k-step {
+            outline: none;
+
             &.k-disabled {
                 background: transparent;
             }
@@ -110,7 +112,7 @@
         .k-step.k-disabled {
             .k-step-indicator {
                 border: 0;
-                
+
                 &::after {
                     display: none;
                 }


### PR DESCRIPTION
This outline has to be removed for two reasons:
1. The `k-focus` class is added to `li.k-step` element by the reference rendering: https://github.com/telerik/kendo-themes/blob/develop/packages/html/src/stepper/step.tsx#L76
 2. According to the new a11y spec for keyboard navigation, the Stepper should change the focus of steps via `Tab / Shift + Tab`.