### PR TITLE
Rollback to ubuntu-22.04 due to lack of NuGet in latest

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -19,7 +19,7 @@ env:
 jobs:
 
   nuget-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: upload
 
     permissions:


### PR DESCRIPTION
Since ubuntu-latest is now ubuntu-24.04 and does not have support for NuGet.
We are switching to ubuntu-22.04 until NuGet is available.