### PR TITLE
fix(scheduler): recurring events have incorrect margin in rtl

### DIFF
--- a/packages/bootstrap/docs/customization-scheduler.md
+++ b/packages/bootstrap/docs/customization-scheduler.md
@@ -790,8 +790,8 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-scheduler-rtl-indicators-margin</td>
     <td>List</td>
-    <td><code>k-spacing(1) 0 k-spacing(2) .4ex</code></td>
-    <td><code>(var(--kendo-spacing-1, 0.25rem) 0 var(--kendo-spacing-2, 0.5rem) 0.4ex)</code></td>
+    <td><code>k-spacing(1) k-spacing(2) 0 .4ex</code></td>
+    <td><code>(var(--kendo-spacing-1, 0.25rem) var(--kendo-spacing-2, 0.5rem) 0 0.4ex)</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The margin of the Scheduler event indicators in rtl.</div></div>

--- a/packages/bootstrap/docs/customization.md
+++ b/packages/bootstrap/docs/customization.md
@@ -22101,8 +22101,8 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$kendo-scheduler-rtl-indicators-margin</td>
     <td>List</td>
-    <td><code>k-spacing(1) 0 k-spacing(2) .4ex</code></td>
-    <td><code>(var(--kendo-spacing-1, 0.25rem) 0 var(--kendo-spacing-2, 0.5rem) 0.4ex)</code></td>
+    <td><code>k-spacing(1) k-spacing(2) 0 .4ex</code></td>
+    <td><code>(var(--kendo-spacing-1, 0.25rem) var(--kendo-spacing-2, 0.5rem) 0 0.4ex)</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The margin of the Scheduler event indicators in rtl.</div></div>

--- a/packages/bootstrap/scss/scheduler/_variables.scss
+++ b/packages/bootstrap/scss/scheduler/_variables.scss
@@ -261,7 +261,7 @@ $kendo-scheduler-event-actions-inset-x: k-spacing(4) !default;
 $kendo-scheduler-indicators-margin: k-spacing(1) .4ex 0 k-spacing(2) !default;
 /// The margin of the Scheduler event indicators in rtl.
 /// @group scheduler
-$kendo-scheduler-rtl-indicators-margin: k-spacing(1) 0 k-spacing(2) .4ex !default;
+$kendo-scheduler-rtl-indicators-margin: k-spacing(1) k-spacing(2) 0 .4ex !default;
 
 /// The inline inset of the Scheduler marquee labels.
 /// @group scheduler

--- a/packages/classic/docs/customization-scheduler.md
+++ b/packages/classic/docs/customization-scheduler.md
@@ -790,8 +790,8 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-scheduler-rtl-indicators-margin</td>
     <td>List</td>
-    <td><code>k-spacing(0.5) 0 k-spacing(1) .4ex</code></td>
-    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) 0 var(--kendo-spacing-1, 0.25rem) 0.4ex)</code></td>
+    <td><code>k-spacing(0.5) k-spacing(1) 0 .4ex</code></td>
+    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) var(--kendo-spacing-1, 0.25rem) 0 0.4ex)</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The margin of the Scheduler event indicators in rtl.</div></div>

--- a/packages/classic/docs/customization.md
+++ b/packages/classic/docs/customization.md
@@ -22462,8 +22462,8 @@ The following table lists the available variables for customizing the Classic th
 <tr>
     <td>$kendo-scheduler-rtl-indicators-margin</td>
     <td>List</td>
-    <td><code>k-spacing(0.5) 0 k-spacing(1) .4ex</code></td>
-    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) 0 var(--kendo-spacing-1, 0.25rem) 0.4ex)</code></td>
+    <td><code>k-spacing(0.5) k-spacing(1) 0 .4ex</code></td>
+    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) var(--kendo-spacing-1, 0.25rem) 0 0.4ex)</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The margin of the Scheduler event indicators in rtl.</div></div>

--- a/packages/classic/scss/scheduler/_variables.scss
+++ b/packages/classic/scss/scheduler/_variables.scss
@@ -263,7 +263,7 @@ $kendo-scheduler-event-actions-inset-x: k-spacing(2) !default;
 $kendo-scheduler-indicators-margin: k-spacing(0.5) .4ex 0 k-spacing(1) !default;
 /// The margin of the Scheduler event indicators in rtl.
 /// @group scheduler
-$kendo-scheduler-rtl-indicators-margin: k-spacing(0.5) 0 k-spacing(1) .4ex !default;
+$kendo-scheduler-rtl-indicators-margin: k-spacing(0.5) k-spacing(1) 0 .4ex !default;
 
 /// The inline inset of the Scheduler marquee labels.
 /// @group scheduler

--- a/packages/default/docs/customization-scheduler.md
+++ b/packages/default/docs/customization-scheduler.md
@@ -790,8 +790,8 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-scheduler-rtl-indicators-margin</td>
     <td>List</td>
-    <td><code>k-spacing(0.5) 0 k-spacing(1) .4ex</code></td>
-    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) 0 var(--kendo-spacing-1, 0.25rem) 0.4ex)</code></td>
+    <td><code>k-spacing(0.5) k-spacing(1) 0 .4ex</code></td>
+    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) var(--kendo-spacing-1, 0.25rem) 0 0.4ex)</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The margin of the Scheduler event indicators in rtl.</div></div>

--- a/packages/default/docs/customization.md
+++ b/packages/default/docs/customization.md
@@ -21096,8 +21096,8 @@ The following table lists the available variables for customizing the Default th
 <tr>
     <td>$kendo-scheduler-rtl-indicators-margin</td>
     <td>List</td>
-    <td><code>k-spacing(0.5) 0 k-spacing(1) .4ex</code></td>
-    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) 0 var(--kendo-spacing-1, 0.25rem) 0.4ex)</code></td>
+    <td><code>k-spacing(0.5) k-spacing(1) 0 .4ex</code></td>
+    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) var(--kendo-spacing-1, 0.25rem) 0 0.4ex)</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The margin of the Scheduler event indicators in rtl.</div></div>

--- a/packages/default/scss/scheduler/_variables.scss
+++ b/packages/default/scss/scheduler/_variables.scss
@@ -260,7 +260,7 @@ $kendo-scheduler-event-actions-inset-x: k-spacing(2) !default;
 $kendo-scheduler-indicators-margin: k-spacing(0.5) .4ex 0 k-spacing(1) !default;
 /// The margin of the Scheduler event indicators in rtl.
 /// @group scheduler
-$kendo-scheduler-rtl-indicators-margin: k-spacing(0.5) 0 k-spacing(1) .4ex !default;
+$kendo-scheduler-rtl-indicators-margin: k-spacing(0.5) k-spacing(1) 0 .4ex !default;
 
 /// The inline inset of the Scheduler marquee labels.
 /// @group scheduler

--- a/packages/material/docs/customization-scheduler.md
+++ b/packages/material/docs/customization-scheduler.md
@@ -790,8 +790,8 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-scheduler-rtl-indicators-margin</td>
     <td>List</td>
-    <td><code>k-spacing(0.5) 0 k-spacing(2) .4ex</code></td>
-    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) 0 var(--kendo-spacing-2, 0.5rem) 0.4ex)</code></td>
+    <td><code>k-spacing(0.5) k-spacing(2) 0 .4ex</code></td>
+    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) var(--kendo-spacing-2, 0.5rem) 0 0.4ex)</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The margin of the Scheduler event indicators in rtl.</div></div>

--- a/packages/material/docs/customization.md
+++ b/packages/material/docs/customization.md
@@ -21912,8 +21912,8 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$kendo-scheduler-rtl-indicators-margin</td>
     <td>List</td>
-    <td><code>k-spacing(0.5) 0 k-spacing(2) .4ex</code></td>
-    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) 0 var(--kendo-spacing-2, 0.5rem) 0.4ex)</code></td>
+    <td><code>k-spacing(0.5) k-spacing(2) 0 .4ex</code></td>
+    <td><code>(var(--kendo-spacing-0\.5, 0.125rem) var(--kendo-spacing-2, 0.5rem) 0 0.4ex)</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The margin of the Scheduler event indicators in rtl.</div></div>

--- a/packages/material/scss/scheduler/_variables.scss
+++ b/packages/material/scss/scheduler/_variables.scss
@@ -262,7 +262,7 @@ $kendo-scheduler-event-actions-inset-x: k-spacing(4) !default;
 $kendo-scheduler-indicators-margin: k-spacing(0.5) .4ex 0 k-spacing(2) !default;
 /// The margin of the Scheduler event indicators in rtl.
 /// @group scheduler
-$kendo-scheduler-rtl-indicators-margin: k-spacing(0.5) 0 k-spacing(2) .4ex !default;
+$kendo-scheduler-rtl-indicators-margin: k-spacing(0.5) k-spacing(2) 0 .4ex !default;
 
 /// The inline inset of the Scheduler marquee labels.
 /// @group scheduler


### PR DESCRIPTION
Fixes a bug introduced with https://github.com/telerik/kendo-themes/pull/5165 where recurring Scheduler events have wrong margin in rtl mode. 