### PR TITLE
fix(grid): remove cells text alignment inheritance

### DIFF
--- a/packages/core/scss/components/grid/_layout.scss
+++ b/packages/core/scss/components/grid/_layout.scss
@@ -93,7 +93,6 @@
             border-color: inherit;
             outline: 0;
             font-weight: inherit;
-            text-align: inherit;
             position: static;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/packages/fluent/scss/grid/_layout.scss
+++ b/packages/fluent/scss/grid/_layout.scss
@@ -78,7 +78,6 @@
             border-color: inherit;
             outline: 0;
             font-weight: inherit;
-            text-align: inherit;
             position: static;
             overflow: hidden;
             text-overflow: ellipsis;


### PR DESCRIPTION
Part of https://github.com/telerik/kendo-themes/issues/4601

Note: removing the _text-align: inherit_ rule will address the problem for grid content cells only. Currently header cells include an additional `<span class="k-cell-inner">` element, which used Flexbox for styling. Aligning the header cells to the right requires an alternative approach to adjust the Flexbox layout and achieve the desired alignment. (Updated example from the issue - https://dojo.telerik.com/XTRvnfcl