### PR TITLE
fix(pager): select value in adaptive pager has wrong vertical alignment in Safari

### DIFF
--- a/packages/default/scss/input/_layout.scss
+++ b/packages/default/scss/input/_layout.scss
@@ -91,6 +91,7 @@
         padding-block: $kendo-input-padding-y;
         padding-inline: $kendo-input-padding-x;
         appearance: auto;
+        align-items: center;
 
         &:disabled,
         &[disabled] {

--- a/packages/fluent/scss/input/_layout.scss
+++ b/packages/fluent/scss/input/_layout.scss
@@ -113,6 +113,7 @@
         padding-inline: var( --INTERNAL--kendo-input-padding-x, 0 );
         padding-block: var( --INTERNAL--kendo-input-padding-y,  0 );
         appearance: auto;
+        align-items: center;
     }
 
 

--- a/packages/nouvelle/scss/input/_layout.scss
+++ b/packages/nouvelle/scss/input/_layout.scss
@@ -68,6 +68,7 @@
         padding-block: var( --kendo-input-padding-y,  0 );
         appearance: auto;
         -webkit-appearance: none;
+        align-items: center;
     }
 
 


### PR DESCRIPTION
Fixes https://github.com/telerik/kendo-themes/issues/5242

Another option may be to avoid flexbox for the `select` element, but this may need more lines of code.