### PR TITLE
fix(pdf-viewer): link annotations are not clickable

### DIFF
--- a/packages/default/scss/pdf-viewer/_layout.scss
+++ b/packages/default/scss/pdf-viewer/_layout.scss
@@ -149,6 +149,7 @@
 
                 section {
                     position: absolute;
+                    pointer-events: auto;
                 }
 
                 .k-annotation-text-content {
@@ -159,6 +160,14 @@
                     color: transparent;
                     user-select: none;
                     pointer-events: none;
+                }
+
+                .k-link-annotation > a {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    width: 100%;
+                    height: 100%;
                 }
             }
 
@@ -192,6 +201,12 @@
                         width: 100%;
                         height: 100%;
                         pointer-events: auto;
+                    }
+
+                    &.k-highlight-editor-disabled {
+                        .k-internal {
+                            pointer-events: none;
+                        }
                     }
                 }
 

--- a/packages/fluent/scss/pdf-viewer/_layout.scss
+++ b/packages/fluent/scss/pdf-viewer/_layout.scss
@@ -146,6 +146,7 @@
 
                 section {
                     position: absolute;
+                    pointer-events: auto;
                 }
 
                 .k-annotation-text-content {
@@ -156,6 +157,14 @@
                     color: transparent;
                     user-select: none;
                     pointer-events: none;
+                }
+
+                .k-link-annotation > a {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    width: 100%;
+                    height: 100%;
                 }
             }
 
@@ -189,6 +198,12 @@
                         width: 100%;
                         height: 100%;
                         pointer-events: auto;
+                    }
+
+                    &.k-highlight-editor-disabled {
+                        .k-internal {
+                            pointer-events: none;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes: https://github.com/telerik/kendo-themes/issues/5256

Notes:
As discussed with @Stamo-Gochev, both _**k-link-annotation**_ and _**k-highlight-editor-disabled**_ would be added to the component (currently they don't present)