### PR TITLE
fix(dock-manager): content inside unpinned container does not resize …

### DIFF
--- a/packages/core/scss/components/dock-manager/_layout.scss
+++ b/packages/core/scss/components/dock-manager/_layout.scss
@@ -133,6 +133,7 @@
             flex-direction: column;
             position: relative;
             flex: 1 1 auto;
+            width: 100%;
         }
 
         .k-splitbar {

--- a/packages/fluent/scss/dock-manager/_layout.scss
+++ b/packages/fluent/scss/dock-manager/_layout.scss
@@ -131,6 +131,7 @@
             flex-direction: column;
             position: relative;
             flex: 1 1 auto;
+            width: 100%;
         }
 
         .k-splitbar {


### PR DESCRIPTION
…properly

Fixes a bug where content inside an unpinned pane does not resize with its container. Example: https://demos.telerik.com/kendo-ui/dockmanager/index#