### PR TITLE
fix(fluent): use correct variable for input suffix disabled text

### DIFF
--- a/packages/fluent/scss/input/_theme.scss
+++ b/packages/fluent/scss/input/_theme.scss
@@ -53,7 +53,7 @@
             }
 
             .k-input-suffix {
-                color: var( --kendo-input-prefix-disabled-text, #{$kendo-input-prefix-disabled-text} );
+                color: var( --kendo-input-suffix-disabled-text, #{$kendo-input-suffix-disabled-text} );
             }
 
             @if($kendo-enable-color-system) {


### PR DESCRIPTION
Sets the correct variable for the input suffix disabled text in the Fluent theme.