### PR TITLE
chore(html): prevent react 19 script tag duplication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4518,20 +4518,13 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
-    },
     "node_modules/@types/react": {
-      "version": "18.3.13",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.13.tgz",
-      "integrity": "sha512-ii/gswMmOievxAJed4PAHT949bpYjPKXvXo1v6cRB/kqc2ZR4n+SgyCyvyc5Fec5ez8VnUumI1Vk7j6fRyRogg==",
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
+      "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -10592,7 +10585,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -12285,6 +12279,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -15346,6 +15341,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -15357,6 +15353,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17027,6 +17024,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -19965,12 +19963,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@progress/kendo-svg-icons": "^4.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       },
       "devDependencies": {
-        "@types/react": "^18.3.3"
+        "@types/react": "^19.0.8"
       }
+    },
+    "packages/html/node_modules/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/html/node_modules/react-dom": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "packages/html/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
     },
     "packages/material": {
       "name": "@progress/kendo-theme-material",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -47,10 +47,10 @@
   },
   "dependencies": {
     "@progress/kendo-svg-icons": "^4.0.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@types/react": "^18.3.3"
+    "@types/react": "^19.0.8"
   }
 }

--- a/scripts/render-test-pages.mjs
+++ b/scripts/render-test-pages.mjs
@@ -26,6 +26,10 @@ async function loadUrl(browser, url) {
     }, 10000, `Failed to load ${url}`, 500);
 }
 
+function trimScriptTag(content) {
+    return content.replace(/<script src=".\/app.js">.*?<\/script>/g, '');
+}
+
 const browser = new Browser();
 const server = createServer({
     root: './',
@@ -47,7 +51,7 @@ server.listen(PORT, HOST, async() => {
         fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
         await snapshotMarkup(browser.driver, 'html', outputPath, {
-            template: (output) => `<!doctype html>${output}`,
+            template: (output) => `<!doctype html>${trimScriptTag(output)}`,
             preserveAttributes: true,
             preserveCommentNodes: true,
             beautifyOptions: {


### PR DESCRIPTION
With React 19, `<script>` tags inside components are now rendered instead of being ignored.

It seems like it will do this only if the tag is a direct child of `<body>`

What I've tried so far is:

- remove the `<script>` tag from `packages/html/shared/index.html` and add it later in `build-tests.js`
> This does not seem like a valid solution since it seems it does not matter whether the `<script>` is in `packages/html/shared/index.html` or `packages/html/dist/`. It will be rendered if it is a direct child of body.

- wrap the `<script>` tag inside a `div`
> While it may not seem like the best solution it does work and does not produce an additional `<div>` wrapper in our tests.

- trim the extra <script> tag before creating screenshots
> This seems like a more valid solution