### PR TITLE
Remove HTML Tests Distribution

### DIFF
--- a/packages/html/scripts/build.js
+++ b/packages/html/scripts/build.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const p = require("path");
 const { globSync } = require("glob");
 
-const components = globSync("./src/**/*.tsx", { dotRelative: true, ignore: ["./src/**/tests/*.tsx"] });
+const components = globSync("./src/**/*.tsx", { dotRelative: true, ignore: ["./src/utils/**/*.tsx", "./src/**/tests/*.tsx"] });
 components.push("./src/index.ts");
 
 const commonConfig = {


### PR DESCRIPTION
Removes the `{component}/tests` from the HTML package distribution.
Removes the `utils/` from the HTML package distribution.