### PR TITLE
chore: add actionsheet backwards compatibility

### DIFF
--- a/packages/core/scss/components/action-sheet/_layout.scss
+++ b/packages/core/scss/components/action-sheet/_layout.scss
@@ -69,7 +69,12 @@
         overflow: hidden;
         position: relative;
         display: flex;
-        flex-flow: row nowrap;
+
+        // Leave only "flex-flow: row nowrap;" here after the suites adopt the "k-actionsheet-view" element.
+        flex-flow: column nowrap;
+        &:has(> .k-actionsheet-view) {
+            flex-flow: row nowrap;
+        }
 
         .k-actionsheet-view {
             display: flex;

--- a/packages/fluent/scss/action-sheet/_layout.scss
+++ b/packages/fluent/scss/action-sheet/_layout.scss
@@ -72,7 +72,12 @@
         overflow: hidden;
         position: relative;
         display: flex;
-        flex-flow: row nowrap;
+
+        // Leave only "flex-flow: row nowrap;" here after the suites adopt the "k-actionsheet-view" element.
+        flex-flow: column nowrap;
+        &:has(> .k-actionsheet-view) {
+            flex-flow: row nowrap;
+        }
 
         .k-actionsheet-view {
             display: flex;


### PR DESCRIPTION
Backwards compatibility of https://github.com/telerik/kendo-themes/pull/5406

Ensure the `k-actionsheet` element of this rendering
```html
<div class="k-actionsheet">
   <div class="k-actionsheet-titlebar">
   <div class="k-actionsheet-content">
   <div class="k-actionsheet-footer">
</div>
```
is styled with `flex-flow: column nowrap;`