### PR TITLE
Correct Column List Max Height

### DIFF
--- a/packages/core/scss/components/grid/_layout.scss
+++ b/packages/core/scss/components/grid/_layout.scss
@@ -1306,9 +1306,6 @@
         padding: 0;
         margin: 0;
         list-style: none;
-        max-height: 200px;
-        overflow-x: hidden;
-        overflow-y: auto;
     }
 
     .k-column-chooser-title,

--- a/packages/core/scss/components/popup/_layout.scss
+++ b/packages/core/scss/components/popup/_layout.scss
@@ -73,6 +73,12 @@
         border-width: 0;
     }
 
+    .k-popup .k-column-list {
+        max-height: 200px;
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+
     // Legacy shadow
     .k-shadow {
         box-shadow: $kendo-popup-shadow;

--- a/packages/fluent/scss/grid/_layout.scss
+++ b/packages/fluent/scss/grid/_layout.scss
@@ -1281,9 +1281,6 @@
         padding: 0;
         margin: 0;
         list-style: none;
-        max-height: 200px;
-        overflow-x: hidden;
-        overflow-y: auto;
     }
 
     .k-column-chooser-title,

--- a/packages/fluent/scss/popup/_layout.scss
+++ b/packages/fluent/scss/popup/_layout.scss
@@ -71,4 +71,10 @@
         box-shadow: none;
     }
 
+    .k-popup .k-column-list {
+        max-height: 200px;
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+
 }


### PR DESCRIPTION
ColumnList applies `max-height: 200px` when used in ActionSheet, resulting in unexpected behavior:
![image](https://github.com/user-attachments/assets/b31d6616-8b3a-4703-8387-1576168eadc8)

ColumnList max-height styles should apply only in popups.