### PR TITLE
fix(charts): add display properties to diagram and gauge

### DIFF
--- a/packages/core/scss/components/dataviz/_layout.scss
+++ b/packages/core/scss/components/dataviz/_layout.scss
@@ -262,6 +262,7 @@
 
     // Diagram
     .k-diagram {
+        display: block;
         height: 600px;
     }
 
@@ -381,6 +382,7 @@
 
     // Gauge
     .k-gauge {
+        display: block;
         text-align: start;
         position: relative;
     }

--- a/packages/fluent/scss/dataviz/_layout.scss
+++ b/packages/fluent/scss/dataviz/_layout.scss
@@ -257,6 +257,7 @@
         }
 
     .k-diagram {
+        display: block;
         height: 600px;
     }
 
@@ -371,6 +372,7 @@
     }
 
     .k-gauge {
+        display: block;
         text-align: start;
         position: relative;
     }


### PR DESCRIPTION
closes https://github.com/telerik/kendo-themes/issues/5491