### PR TITLE
chore: add docs to ci

### DIFF
--- a/.github/workflows/_compile-themes.yml
+++ b/.github/workflows/_compile-themes.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Pack themes
         run: |
           tar -cf themes.tar \
+            packages/core/dist/all.css \
             packages/default/dist/all.css \
             packages/default/dist/default-ocean-blue-a11y.css \
             packages/bootstrap/dist/all.css \

--- a/.github/workflows/_docs-check.yml
+++ b/.github/workflows/_docs-check.yml
@@ -1,0 +1,49 @@
+name: CI | Docs
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: docs-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  docs-verify:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Use cache for root node_modules
+        id: cache-root-node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install
+        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
+        run: |
+          npm ci --no-audit --no-fund
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: .tmp
+
+      - name: Unpack artifacts
+        run: find .tmp -name "*.tar" -type f -exec tar -xf {} \;
+
+      - name: Check docs
+        run: npm run docs:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,29 +17,6 @@ jobs:
     name: Compile themes
     uses: ./.github/workflows/_compile-themes.yml
 
-  test-units:
-    name: Test units
-    uses: ./.github/workflows/_test-units.yml
-
-  ci-test-units:
-    name: Status check > Unit
-    runs-on: ubuntu-latest
-    needs: [ test-units ]
-    steps:
-      - name: Done
-        run: echo "Done!"
-
-  test-integrations:
-    name: Test integrations
-    uses: ./.github/workflows/_test-integrations.yml
-
-  ci-test-integrations:
-    name: Status check > Integration
-    runs-on: ubuntu-latest
-    needs: [ test-integrations ]
-    steps:
-      - name: Done
-        run: echo "Done!"
 
   render-test-pages:
     name: Render test pages
@@ -59,6 +36,9 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     needs: [ render-test-pages, create-screenshots ]
+
+    outputs:
+      snapshot_sha: ${{ steps.snapshot_sha.outputs.sha }}
 
     steps:
       - name: Checkout branch
@@ -98,11 +78,58 @@ jobs:
 
           git push
 
-          echo "Mark checks as successful"
+      - name: Get snapshot commit SHA
+        if: ${{ (env.HAS_CHANGES == 1 || env.HAS_NEW == 1) }}
+        id: snapshot_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-          commit=$(git rev-parse HEAD)
-          ./build/mark-checks.sh $commit
 
+  set-commit-status:
+    name: Set commit status
+    runs-on: ubuntu-latest
+    needs: [ detect-changes, ci-lint-scripts, ci-lint-styles, ci-docs, ci-test-units, ci-test-integrations, ci-a11y ]
+    timeout-minutes: 30
+    if: ${{ always() && needs.detect-changes.outputs.snapshot_sha }}
+
+    permissions:
+      statuses: write
+
+    steps:
+      - name: Set visual snapshot commit status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const results = [
+              ['${{ needs.ci-test-units.result }}', 'Status check > Unit'],
+              ['${{ needs.ci-test-integrations.result }}', 'Status check > Integration'],
+              ['${{ needs.ci-lint-scripts.result }}', 'Status check > Lint scripts'],
+              ['${{ needs.ci-lint-styles.result }}', 'Status check > Lint styles'],
+              ['${{ needs.ci-a11y.result }}', 'Status check > A11y'],
+              ['${{ needs.ci-docs.result }}', 'Status check > Docs'],
+              // Visual status will correspond to this detect-changes job succeeding (since snapshots updated successfully)
+              ['success', 'Status check > Visual']
+            ];
+
+            const mapState = (r) => {
+              if (r === 'success') return 'success';
+              if (r === 'cancelled' || r === 'skipped') return 'failure';
+              return 'failure';
+            };
+
+            const sha = '${{ needs.detect-changes.outputs.snapshot_sha }}';
+            const targetUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+            await Promise.all(results.map(([result, contextName]) =>
+              github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                context: contextName,
+                state: mapState(result),
+                target_url: targetUrl,
+                description: 'Automated visual snapshot commit'
+              })
+            ));
 
   ci-visual:
     name: Status check > Visual
@@ -130,7 +157,6 @@ jobs:
     name: Lint styles
     uses: ./.github/workflows/_lint-styles.yml
 
-
   ci-lint-styles:
     name: Status check > Lint styles
     runs-on: ubuntu-latest
@@ -154,6 +180,7 @@ jobs:
       - name: Done
         run: echo "Done!"
 
+
   docs:
     name: Docs
     needs: [ compile-themes ]
@@ -163,6 +190,32 @@ jobs:
     name: Status check > Docs
     runs-on: ubuntu-latest
     needs: [ docs ]
+    steps:
+      - name: Done
+        run: echo "Done!"
+
+
+  test-units:
+    name: Test units
+    uses: ./.github/workflows/_test-units.yml
+
+  ci-test-units:
+    name: Status check > Unit
+    runs-on: ubuntu-latest
+    needs: [ test-units ]
+    steps:
+      - name: Done
+        run: echo "Done!"
+
+
+  test-integrations:
+    name: Test integrations
+    uses: ./.github/workflows/_test-integrations.yml
+
+  ci-test-integrations:
+    name: Status check > Integration
+    runs-on: ubuntu-latest
+    needs: [ test-integrations ]
     steps:
       - name: Done
         run: echo "Done!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,16 @@ jobs:
     steps:
       - name: Done
         run: echo "Done!"
+
+  docs:
+    name: Docs
+    needs: [ compile-themes ]
+    uses: ./.github/workflows/_docs-check.yml
+
+  ci-docs:
+    name: Status check > Docs
+    runs-on: ubuntu-latest
+    needs: [ docs ]
+    steps:
+      - name: Done
+        run: echo "Done!"

--- a/build/mark-checks.sh
+++ b/build/mark-checks.sh
@@ -18,6 +18,7 @@ declare -a checks=( \
   'Status check > A11y' \
   'Status check > Integration' \
   'Status check > Unit' \
+  'Status check > Docs' \
   'Status check > HTML spec' \
 )
 

--- a/build/mark-checks.sh
+++ b/build/mark-checks.sh
@@ -10,8 +10,6 @@ then
 fi
 
 declare -a checks=( \
-  'CI | Unit' \
-  'CI | Visual' \
   'Status check > Lint scripts' \
   'Status check > Lint styles' \
   'Status check > Visual' \

--- a/nx.json
+++ b/nx.json
@@ -33,6 +33,13 @@
     },
     "docs": {
       "cache": true
+    },
+    "docs:check": {
+      "cache": false,
+      "executor": "nx:run-script",
+      "options": {
+        "script": "docs:check"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sass": "nx run-many -t sass",
     "sass:dist": "nx run-many -t sass:dist",
     "docs": "nx run-many -t docs",
-    "docs:check": "npm run docs -- git diff --exit-code -- docs/",
+    "docs:check": "nx run-many -t docs:check",
     "test:render-test-pages": "node ./scripts/render-test-pages.mjs",
     "test:contrast": "node ./scripts/test-contrast.mjs",
     "test:create-screenshots": "./build/create-screenshots.sh",

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -44,6 +44,7 @@
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "css:prefix": "npx postcss --replace ./dist/**/*.css",
     "docs": "node ../../scripts/sassdoc.js",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (bootstrap). Run npm run sass && npm run docs' && exit 1)",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -44,7 +44,7 @@
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "css:prefix": "npx postcss --replace ./dist/**/*.css",
     "docs": "node ../../scripts/sassdoc.js",
-    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (bootstrap). Run npm run sass && npm run docs' && exit 1)",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (bootstrap).' && exit 1)",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/classic/package.json
+++ b/packages/classic/package.json
@@ -44,6 +44,7 @@
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "css:prefix": "npx postcss --replace ./dist/**/*.css",
     "docs": "node ../../scripts/sassdoc.js",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (classic).' && exit 1)",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "sass:compile:dist": "npx sass --style=compressed --no-source-map --load-path=../../node_modules ./dist:dist",
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "docs": "node ../../scripts/sassdoc.js",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (core).' && exit 1)",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/default/package.json
+++ b/packages/default/package.json
@@ -43,6 +43,7 @@
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "css:prefix": "npx postcss --replace ./dist/**/*.css",
     "docs": "node ../../scripts/sassdoc.js",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (default).' && exit 1)",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/fluent/package.json
+++ b/packages/fluent/package.json
@@ -45,6 +45,7 @@
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "css:prefix": "npx postcss --replace ./dist/**/*.css",
     "docs": "node ../../scripts/sassdoc.js",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (fluent).' && exit 1)",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -45,6 +45,7 @@
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "css:prefix": "npx postcss --replace ./dist/**/*.css",
     "docs": "node ../../scripts/sassdoc.js",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (material).' && exit 1)",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,6 +36,7 @@
     "sass:compile:dist": "npx sass --style=compressed --no-source-map --load-path=../../node_modules ./dist:dist",
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "docs": "node ../../scripts/sassdoc.js",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (utils).' && exit 1)",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",


### PR DESCRIPTION
## PR Summary
This PR augments the CI to attach granular commit statuses to any auto-generated visual snapshot commit.

### Key Changes

* `detect-changes` now exposes snapshot_sha when visual test files are added or modified and pushed.
* New `set-commit-status` job:
    * Runs only if a snapshot commit exists: if: ${{ always() && needs.detect-changes.outputs.snapshot_sha }}.
    * Depends on all status-producing jobs to collect their results.
    * Uses actions/github-script to post commit statuses (Unit, Integration, Lint scripts, Lint styles, A11y, Docs, Visual) to the snapshot commit.
* Visual context marked success when snapshot update succeeds; skipped/cancelled upstream jobs map to failure per current mapping.

## Outcome
Visual snapshot commits now carry the full matrix of CI statuses, enabling reviewers to gate or trust regenerated visual assets.