### PR TITLE
chore: make docs:check cross-platform

### DIFF
--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -44,7 +44,7 @@
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "css:prefix": "npx postcss --replace ./dist/**/*.css",
     "docs": "node ../../scripts/sassdoc.js",
-    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (bootstrap).' && exit 1)",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/classic/package.json
+++ b/packages/classic/package.json
@@ -44,7 +44,7 @@
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "css:prefix": "npx postcss --replace ./dist/**/*.css",
     "docs": "node ../../scripts/sassdoc.js",
-    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (classic).' && exit 1)",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "sass:compile:dist": "npx sass --style=compressed --no-source-map --load-path=../../node_modules ./dist:dist",
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "docs": "node ../../scripts/sassdoc.js",
-    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (core).' && exit 1)",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/default/package.json
+++ b/packages/default/package.json
@@ -43,7 +43,7 @@
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "css:prefix": "npx postcss --replace ./dist/**/*.css",
     "docs": "node ../../scripts/sassdoc.js",
-    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (default).' && exit 1)",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/fluent/package.json
+++ b/packages/fluent/package.json
@@ -45,7 +45,7 @@
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "css:prefix": "npx postcss --replace ./dist/**/*.css",
     "docs": "node ../../scripts/sassdoc.js",
-    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (fluent).' && exit 1)",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -45,7 +45,7 @@
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "css:prefix": "npx postcss --replace ./dist/**/*.css",
     "docs": "node ../../scripts/sassdoc.js",
-    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (material).' && exit 1)",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,7 +36,7 @@
     "sass:compile:dist": "npx sass --style=compressed --no-source-map --load-path=../../node_modules ./dist:dist",
     "sass:watch": "npx sass --no-source-map --load-path=../../node_modules --watch ./scss/all.scss ./dist/all.css",
     "docs": "node ../../scripts/sassdoc.js",
-    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (utils).' && exit 1)",
+    "docs:check": "npm run docs && git diff --name-only --exit-code -- docs",
     "predocs": "npm run resolve-variables",
     "resolve-variables": "node ../../scripts/resolve-variables.js",
     "nuget-pack": "jq '.version' package.json | xargs nuget pack package.nuspec -Version",


### PR DESCRIPTION
## Overview
`npm run docs:check` failed on Windows with error: `.' was unexpected at this time.`

The scripts used Unix shell syntax incompatible with Windows `cmd.exe`:
```json
"docs:check": "npm run docs && git diff --name-only --exit-code -- docs || (echo 'Docs out of date (theme).' && exit 1)"
```

### Solution
Simplified to cross-platform compatible syntax:
```json
"docs:check": "npm run docs && git diff --name-only --exit-code -- docs"
```

The `git diff --exit-code` command naturally returns a non-zero exit code when docs are out of date, eliminating the need for shell-specific error handling.
