### PR TITLE
chore(slider): remove reduntant styles

### DIFF
--- a/packages/core/scss/components/slider/_layout.scss
+++ b/packages/core/scss/components/slider/_layout.scss
@@ -348,20 +348,6 @@
         }
     }
 
-
-    // Slider tooltip
-    .k-slider-tooltip {
-        .k-callout-n,
-        .k-callout-s {
-            margin-inline-start: - list.slash( $kendo-tooltip-callout-size, 2 );
-        }
-
-        .k-callout-w,
-        .k-callout-e {
-            margin-block-start: - list.slash( $kendo-tooltip-callout-size, 2 );
-        }
-    }
-
     // RTL
     .k-slider-rtl {
         &.k-slider-horizontal {


### PR DESCRIPTION
closes: https://github.com/telerik/kendo-themes/issues/5354

The styles for the slider tooltip callout come from the Tooltip component, and the ones coming from the slider are redundant (and in fact compile to invalid CSS)

