### PR TITLE
fix(fluent): empty cells should not be interactive

### DIFF
--- a/packages/fluent/scss/calendar/_layout.scss
+++ b/packages/fluent/scss/calendar/_layout.scss
@@ -109,6 +109,10 @@
         display: none;
     }
 
+    .k-calendar-td.k-empty {
+        pointer-events: none;
+    }
+
     @each $size, $size-props in $kendo-calendar-sizes {
         $_cell-font-size: map.get($size-props, cell-font-size);
 


### PR DESCRIPTION
In the Fluent theme empty calendar cells can be hovered, focused, etc which is not the case in the other themes.