### PR TITLE
fix(input): adornments icon padding

### DIFF
--- a/packages/bootstrap/scss/input/_layout.scss
+++ b/packages/bootstrap/scss/input/_layout.scss
@@ -19,8 +19,10 @@
 
             .k-input-#{$size} {
                 .k-input-prefix > .k-icon,
+                .k-input-prefix > .k-icon-wrapper-host .k-icon,
                 .k-input-prefix > .k-input-prefix-text,
                 .k-input-suffix > .k-icon,
+                .k-input-suffix > .k-icon-wrapper-host .k-icon,
                 .k-input-suffix > .k-input-suffix-text {
                     padding-inline: $_padding-x;
                 }

--- a/packages/core/scss/components/input/_layout.scss
+++ b/packages/core/scss/components/input/_layout.scss
@@ -493,8 +493,10 @@
             .k-input-loading-icon,
             .k-clear-value,
             .k-input-prefix > .k-icon,
+            .k-input-prefix > .k-icon-wrapper-host .k-icon,
             .k-input-prefix > .k-input-prefix-text,
             .k-input-suffix > .k-icon,
+            .k-input-suffix > .k-icon-wrapper-host .k-icon,
             .k-input-suffix > .k-input-suffix-text {
                 padding-block: $_padding-y;
                 padding-inline: $_padding-y;


### PR DESCRIPTION
closes: https://github.com/telerik/kendo-themes/issues/5026

The bug is caused because the Angular rendering includes an extra element wrapping the icon:
`k-input-prefix > .k-icon-wrapper-host .k-icon`

cc: @svetq 