### PR TITLE
Add HTML to Packages Report Tests

### DIFF
--- a/.github/workflows/_package-report.yml
+++ b/.github/workflows/_package-report.yml
@@ -52,7 +52,7 @@ jobs:
     needs: post-status-comment
     strategy:
       matrix:
-        theme: [core, default, classic, bootstrap, material, fluent, utils]
+        package: [core, default, classic, bootstrap, material, fluent, utils, html]
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -82,18 +82,31 @@ jobs:
           total_time=0
           for i in {1..3}; do
             SECONDS=0
-            npm run sass:compile:all --prefix packages/${{ matrix.theme }}
+            if [ "${{ matrix.package }}" = "html" ]; then
+              npm run build --prefix packages/${{ matrix.package }}
+            else
+              npm run sass:compile:all --prefix packages/${{ matrix.package }}
+            fi
             total_time=$((total_time + SECONDS))
           done
-          average_time=$(awk "BEGIN {printf \"%.0f\", $total_time / 3}")
-          size=$(du -b packages/${{ matrix.theme }}/dist/all.css | awk '{printf "%.2f", $1/1024}')
-          gzip_size=$(gzip -c packages/${{ matrix.theme }}/dist/all.css | wc -c | awk '{printf "%.2f", $1/1024}')
-          echo "${{ matrix.theme }}:$size:$gzip_size:$average_time" >> data.txt
+          build_time=$(awk "BEGIN {printf \"%.0f\", $total_time / 3}")
+
+          if [ "${{ matrix.package }}" = "html" ]; then
+            size=$(du -sb packages/${{ matrix.package }}/dist | awk '{printf "%.2f", $1/(1024*1024)}')
+            tar -czf packages/${{ matrix.package }}/dist.tar.gz -C packages/${{ matrix.package }} dist
+            gzip_size=$(du -b packages/${{ matrix.package }}/dist.tar.gz | awk '{printf "%.2f", $1/(1024*1024)}')
+            rm packages/${{ matrix.package }}/dist.tar.gz
+          else
+            size=$(du -b packages/${{ matrix.package }}/dist/all.css | awk '{printf "%.2f", $1/1024}')
+            gzip_size=$(gzip -c packages/${{ matrix.package }}/dist/all.css | wc -c | awk '{printf "%.2f", $1/1024}')
+          fi
+
+          echo "${{ matrix.package }}:$size:$gzip_size:$build_time" >> data.txt
 
       - name: Upload PR data
         uses: actions/upload-artifact@v4
         with:
-          name: pr-data-${{ matrix.theme }}
+          name: pr-data-${{ matrix.package }}
           path: data.txt
 
   extract-develop-data:
@@ -102,7 +115,7 @@ jobs:
     needs: post-status-comment
     strategy:
       matrix:
-        theme: [core, default, classic, bootstrap, material, fluent, utils]
+        package: [core, default, classic, bootstrap, material, fluent, utils, html]
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -135,18 +148,31 @@ jobs:
           total_time=0
           for i in {1..3}; do
             SECONDS=0
-            npm run sass:compile:all --prefix packages/${{ matrix.theme }}
+            if [ "${{ matrix.package }}" = "html" ]; then
+              npm run build --prefix packages/${{ matrix.package }}
+            else
+              npm run sass:compile:all --prefix packages/${{ matrix.package }}
+            fi
             total_time=$((total_time + SECONDS))
           done
-          average_time=$(awk "BEGIN {printf \"%.0f\", $total_time / 3}")
-          size=$(du -b packages/${{ matrix.theme }}/dist/all.css | awk '{printf "%.2f", $1/1024}')
-          gzip_size=$(gzip -c packages/${{ matrix.theme }}/dist/all.css | wc -c | awk '{printf "%.2f", $1/1024}')
-          echo "${{ matrix.theme }}:$size:$gzip_size:$average_time" >> data.txt
+          build_time=$(awk "BEGIN {printf \"%.0f\", $total_time / 3}")
+
+          if [ "${{ matrix.package }}" = "html" ]; then
+            size=$(du -sb packages/${{ matrix.package }}/dist | awk '{printf "%.2f", $1/(1024*1024)}')
+            tar -czf packages/${{ matrix.package }}/dist.tar.gz -C packages/${{ matrix.package }} dist
+            gzip_size=$(du -b packages/${{ matrix.package }}/dist.tar.gz | awk '{printf "%.2f", $1/(1024*1024)}')
+            rm packages/${{ matrix.package }}/dist.tar.gz
+          else
+            size=$(du -b packages/${{ matrix.package }}/dist/all.css | awk '{printf "%.2f", $1/1024}')
+            gzip_size=$(gzip -c packages/${{ matrix.package }}/dist/all.css | wc -c | awk '{printf "%.2f", $1/1024}')
+          fi
+
+          echo "${{ matrix.package }}:$size:$gzip_size:$build_time" >> data.txt
 
       - name: Upload Develop data
         uses: actions/upload-artifact@v4
         with:
-          name: develop-data-${{ matrix.theme }}
+          name: develop-data-${{ matrix.package }}
           path: data.txt
 
   generate-report:
@@ -161,16 +187,16 @@ jobs:
 
       - name: Generate Comparison Table
         run: |
-          echo "|                | core          | default            | classic               | bootstrap            | material            | fluent          | utils             |" >> size-comparison.md
-          echo "|----------------|---------------|--------------------|-----------------------|----------------------|---------------------|-----------------|-------------------|" >> size-comparison.md
+          echo "|                | core          | default            | classic               | bootstrap            | material            | fluent          | utils             | html              |" >> size-comparison.md
+          echo "|----------------|---------------|--------------------|-----------------------|----------------------|---------------------|-----------------|-------------------|-------------------|" >> size-comparison.md
 
           size_row="| **Size**       "
           gzip_row="| **Gzip Size**  "
           time_row="| **Compile Time** "
 
-          for theme in core default classic bootstrap material fluent utils; do
-            pr_file="pr-data-$theme/data.txt"
-            develop_file="develop-data-$theme/data.txt"
+          for package in core default classic bootstrap material fluent utils html; do
+            pr_file="pr-data-$package/data.txt"
+            develop_file="develop-data-$package/data.txt"
 
             if [[ ! -f "$pr_file" || ! -f "$develop_file" ]]; then
               size_row+="| N/A "
@@ -210,8 +236,13 @@ jobs:
             gzip_arrow=$(awk "BEGIN {if ($gzip_diff > 0) print \"🔼\"; else if ($gzip_diff < 0) print \"🔽\"; else print \"\"}")
             time_arrow=$(awk "BEGIN {if ($time_diff > 0) print \"🔼\"; else if ($time_diff < 0) print \"🔽\"; else print \"\"}")
 
-            size_row+="| $pr_size KB (${size_diff_percent}%$size_arrow)"
-            gzip_row+="| $pr_gzip_size KB (${gzip_diff_percent}%$gzip_arrow)"
+            if [ "$package" = "html" ]; then
+              size_row+="| $pr_size MB (${size_diff_percent}%$size_arrow)"
+              gzip_row+="| $pr_gzip_size MB (${gzip_diff_percent}%$gzip_arrow)"
+            else
+              size_row+="| $pr_size KB (${size_diff_percent}%$size_arrow)"
+              gzip_row+="| $pr_gzip_size KB (${gzip_diff_percent}%$gzip_arrow)"
+            fi
             time_row+="| $(awk "BEGIN {printf \"%.0f\", $pr_time}") s (${time_diff_percent}%$time_arrow)"
           done
 

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -39,14 +39,14 @@
   },
   "scripts": {
     "start": "node ./scripts/start",
-    "build": "node ./scripts/build.js && npm run typegen",
+    "build": "node ./scripts/build.js",
     "typegen": "npx tsc --emitDeclarationOnly --declaration --declarationDir dist/types/",
     "typecheck": "npx tsc --noEmit --emitDeclarationOnly false --project tsconfig.json ",
     "build:tests": "node ./scripts/build-tests.js",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build && npm run typegen"
   },
   "dependencies": {
     "@progress/kendo-svg-icons": "^4.5.0"


### PR DESCRIPTION
closes: https://github.com/telerik/kendo-themes-private/issues/396

## Summary

Enhanced the Package Report workflow to include the HTML package alongside other Kendo UI themes:

### Changes Made

- **Added HTML package to matrix**: Included `html` in both `extract-pr-data` and `extract-develop-data` job matrices
- **Different build command**: HTML package uses `npm run build` instead of `npm run sass:compile:all` 
- **Size measurement in MB**: HTML package size is calculated and displayed in MB (instead of KB) since it's significantly larger (~84MB vs ~100KB for CSS themes)
- **Updated report table**: Added HTML column to the comparison table with appropriate MB units

### Technical Details

- HTML package measures total `dist/` directory size (includes cjs & esm directory)
- Compressed size uses tar.gz of entire dist directory for accurate comparison
- Report dynamically shows "KB" for CSS themes and "MB" for HTML package
- Maintains backward compatibility with existing theme measurements

This allows the team to track HTML package size changes and build performance alongside the existing CSS theme monitoring.
