### PR TITLE
chore: support CSS Color Level 4 syntax for semi-transparent colors i…

### DIFF
--- a/scripts/test-contrast.mjs
+++ b/scripts/test-contrast.mjs
@@ -281,7 +281,8 @@ const selfAndBackground = async(el, parent) => {
 
     // If background is semi-transparent, blend it with the parent background
     // to get the actual solid background color
-    if (background.indexOf('rgba') > -1 && background !== 'rgba(255, 255, 255, 1)') {
+    if ((background.indexOf('rgba') > -1 && background !== 'rgba(255, 255, 255, 1)') ||
+        (background.includes('color(srgb') && background.includes('/'))) {
         let parentParent = await (par || parent).findElement(By.xpath('..'));
         let parentBackground = await parentParent.getCssValue('backgroundColor');
 
@@ -296,11 +297,11 @@ const selfAndBackground = async(el, parent) => {
 
     // If element background is semi-transparent, blend it with the background
     // to get the actual solid element background color
-    if (self.indexOf('rgba') > -1 && self !== 'rgba(255, 255, 255, 1)') {
+    if ((self.indexOf('rgba') > -1 && self !== 'rgba(255, 255, 255, 1)') ||
+        (self.includes('color(srgb') && self.includes('/'))) {
         decomposed = getRGBFromRGBA(decomposeColor(self), decomposeColor(background));
         self = 'rgb(' + decomposed.r + ', ' + decomposed.g + ', ' + decomposed.b + ')';
     }
-
     // If element background is fully transparent, use the background color
     // of the parent element instead
     if (self === 'rgba(0, 0, 0, 0)') {


### PR DESCRIPTION
…n test-contrast script

- Add support for color(srgb ...) format with alpha channel in contrast tests
- Extend RGBA detection to handle modern CSS color syntax with '/' alpha separator
- Ensure semi-transparent backgrounds using sRGB format are properly alpha-blended
- Resolves focus contrast test failures for components using color(srgb) backgrounds

The fix ensures that colors like 'color(srgb 0.258824 0.258824 0.258824 / 0.04)' are correctly blended with their parent backgrounds before contrast calculations, improving accessibility compliance for modern CSS color formats.