### PR TITLE
feat(pdfviewer): add annotations and forms styling

### DIFF
--- a/packages/core/scss/components/pdf-viewer/_layout.scss
+++ b/packages/core/scss/components/pdf-viewer/_layout.scss
@@ -100,7 +100,6 @@
                 }
             }
 
-
             .k-text-layer {
                 position: absolute;
                 inset-block-start: 0;
@@ -148,9 +147,38 @@
                 transform-origin: 0 0;
                 pointer-events: none;
 
-                section {
+                * {
+                    box-sizing: border-box;
+                }
+
+                .k-link-annotation > a,
+                .k-button-widget-annotation.k-push-button-widget-annotation > a {
+                    position: absolute;
+                    inset-block-start: 0;
+                    inset-inline-start: 0;
+                    width: 100%;
+                    height: 100%;
+                }
+
+                section[class$="annotation" i] {
                     position: absolute;
                     pointer-events: auto;
+
+                    input, select {
+                        height: 100%;
+                        width: 100%;
+                    }
+
+                    .k-text-widget-annotation > input[type="text"] {
+                        border: none;
+                        text-indent: 0.25em;
+                    }
+
+                    .k-checkbox-widget-annotation > input[type="checkbox"],
+                    .k-radio-button-widget-annotation > input[type="radio"] {
+                        margin-inline-start: 0;
+                        margin-block-start: 0;
+                    }
                 }
 
                 .k-annotation-text-content {
@@ -161,14 +189,6 @@
                     color: transparent;
                     user-select: none;
                     pointer-events: none;
-                }
-
-                .k-link-annotation > a {
-                    position: absolute;
-                    inset-block-start: 0;
-                    inset-inline-start: 0;
-                    width: 100%;
-                    height: 100%;
                 }
 
                 .k-text-widget-annotation .k-annotation-content {

--- a/packages/core/scss/components/pdf-viewer/_theme.scss
+++ b/packages/core/scss/components/pdf-viewer/_theme.scss
@@ -41,6 +41,14 @@
                 $kendo-pdf-viewer-page-border
             );
             @include box-shadow( $kendo-pdf-viewer-page-shadow );
+
+            .k-annotation-layer {
+                .k-link-annotation > a:hover {
+                    opacity: 0.2;
+                    background-color: $kendo-pdf-viewer-search-highlight-mark-bg;
+                    box-shadow: 0 2px 10px $kendo-pdf-viewer-search-highlight-mark-bg;
+                }
+            }
         }
 
         .k-blank-page > .k-icon {


### PR DESCRIPTION
fixes #5409 

After a discussion with @Juveniel and members of the PDFViewer common virtual team, we decided that basic PDF form elements styling should come from the themes so that developers will not be required to add custom styling to their applications when using the PDFViewer form filling feature.

Further polishing and enhancements will be a subject to a separate dedicated effort when the FE team capacity allows.

