### PR TITLE
fix(window): not resizing properly from sides in RTL

### DIFF
--- a/packages/core/scss/components/window/_layout.scss
+++ b/packages/core/scss/components/window/_layout.scss
@@ -168,10 +168,10 @@
 
     // Resize Handles
     .k-window { // stylelint-disable-line
-        .k-resize-n { inset-block-start: 0; }
-        .k-resize-e { inset-inline-end: 0; }
-        .k-resize-s { inset-block-end: 0; }
-        .k-resize-w { inset-inline-start: 0; }
+        .k-resize-n { top: 0; }
+        .k-resize-e { right: 0; }
+        .k-resize-s { bottom: 0; }
+        .k-resize-w { left: 0; }
     }
 
 }


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-ui-core/issues/8361

When using cardinal directions, no logical properties should be used