### PR TITLE
chore(ci): adjust reporter cacheing

### DIFF
--- a/.github/workflows/_package-report.yml
+++ b/.github/workflows/_package-report.yml
@@ -72,8 +72,7 @@ jobs:
           path: node_modules
           key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Install
-        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
+      - name: Install PR dependencies
         run: |
           npm ci --no-audit --no-fund
 
@@ -122,29 +121,31 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout develop branch
+        run: |
+          git fetch origin develop
+          git checkout origin/develop
+
       - name: Setup node
         id: setup-node
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
 
-      - name: Use cache for root node_modules
-        id: cache-root-node_modules
+      - name: Use cache for develop node_modules
+        id: cache-develop-node_modules
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+          key: develop-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Install
-        if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
+      - name: Install develop dependencies
+        if: steps.cache-develop-node_modules.outputs.cache-hit != 'true'
         run: |
           npm ci --no-audit --no-fund
 
       - name: Measure time and size
         run: |
-          git fetch origin develop
-          git checkout origin/develop
-
           total_time=0
           for i in {1..3}; do
             SECONDS=0
@@ -223,18 +224,14 @@ jobs:
             gzip_diff_percent=$(awk "BEGIN {if ($develop_gzip_size > 0) print sprintf(\"%.1f\", (($pr_gzip_size - $develop_gzip_size) / $develop_gzip_size) * 100); else print 0}")
 
             time_diff=$(awk "BEGIN {print $pr_time - $develop_time}")
-            time_diff_abs=$(awk "BEGIN {print ($pr_time > $develop_time ? $pr_time - $develop_time : $develop_time - $pr_time)}")
-
-            # Adds 2 seconds tolerance for time difference
-            if [ "$time_diff_abs" -le 2 ]; then
-              time_diff=0
-            fi
-
             time_diff_percent=$(awk "BEGIN {if ($develop_time > 0) print sprintf(\"%.1f\", ($time_diff / $develop_time) * 100); else print 0}")
 
             size_arrow=$(awk "BEGIN {if ($size_diff > 0) print \"🔼\"; else if ($size_diff < 0) print \"🔽\"; else print \"\"}")
+
             gzip_arrow=$(awk "BEGIN {if ($gzip_diff > 0) print \"🔼\"; else if ($gzip_diff < 0) print \"🔽\"; else print \"\"}")
-            time_arrow=$(awk "BEGIN {if ($time_diff > 0) print \"🔼\"; else if ($time_diff < 0) print \"🔽\"; else print \"\"}")
+
+            # Adds 1 seconds tolerance for technical time difference
+            time_arrow=$(awk "BEGIN {if ($time_diff > 1) print \"🔼\"; else if ($time_diff < -1) print \"🔽\"; else print \"\"}")
 
             if [ "$package" = "html" ]; then
               size_row+="| $pr_size MB (${size_diff_percent}%$size_arrow)"


### PR DESCRIPTION
## Package Reporter Fix

Fixed package reporter compile time indicators not displaying properly due to incorrect dependency caching. The workflow was using the same (newer) dependencies for both PR and develop measurements, causing identical results and hiding performance regressions. 

Updated the develop measurement job to checkout the develop branch before dependency installation, ensuring proper isolation between PR and baseline measurements. This enables accurate tracking of compile time differences, particularly important for detecting performance impacts from dependency updates like the Sass version bump.

Also reduced the compile time tolerance from `2 seconds` to `1 second` for more sensitive performance change detection.

Real case example: https://github.com/telerik/kendo-themes/pull/5587