### PR TITLE
chore(ci): fine tune package reporter

### DIFF
--- a/.github/workflows/_package-report.yml
+++ b/.github/workflows/_package-report.yml
@@ -78,17 +78,23 @@ jobs:
 
       - name: Measure time and size
         run: |
-          total_time=0
-          for i in {1..3}; do
-            SECONDS=0
+          # Run 5 times to get median with decimal precision
+          times=()
+          for i in {1..5}; do
+            start_time=$(date +%s.%N)
             if [ "${{ matrix.package }}" = "html" ]; then
               npm run build --prefix packages/${{ matrix.package }}
             else
               npm run sass:compile:all --prefix packages/${{ matrix.package }}
             fi
-            total_time=$((total_time + SECONDS))
+            end_time=$(date +%s.%N)
+            elapsed=$(awk "BEGIN {printf \"%.1f\", $end_time - $start_time}")
+            times+=($elapsed)
           done
-          build_time=$(awk "BEGIN {printf \"%.0f\", $total_time / 3}")
+
+          # Sort times and get median (middle value)
+          IFS=$'\n' sorted_times=($(sort -n <<<"${times[*]}"))
+          build_time=${sorted_times[2]}
 
           if [ "${{ matrix.package }}" = "html" ]; then
             size=$(du -sb packages/${{ matrix.package }}/dist | awk '{printf "%.2f", $1/(1024*1024)}')
@@ -146,17 +152,23 @@ jobs:
 
       - name: Measure time and size
         run: |
-          total_time=0
-          for i in {1..3}; do
-            SECONDS=0
+          # Run 5 times to get median with decimal precision
+          times=()
+          for i in {1..5}; do
+            start_time=$(date +%s.%N)
             if [ "${{ matrix.package }}" = "html" ]; then
               npm run build --prefix packages/${{ matrix.package }}
             else
               npm run sass:compile:all --prefix packages/${{ matrix.package }}
             fi
-            total_time=$((total_time + SECONDS))
+            end_time=$(date +%s.%N)
+            elapsed=$(awk "BEGIN {printf \"%.1f\", $end_time - $start_time}")
+            times+=($elapsed)
           done
-          build_time=$(awk "BEGIN {printf \"%.0f\", $total_time / 3}")
+
+          # Sort times and get median (middle value)
+          IFS=$'\n' sorted_times=($(sort -n <<<"${times[*]}"))
+          build_time=${sorted_times[2]}
 
           if [ "${{ matrix.package }}" = "html" ]; then
             size=$(du -sb packages/${{ matrix.package }}/dist | awk '{printf "%.2f", $1/(1024*1024)}')
@@ -223,18 +235,23 @@ jobs:
             gzip_diff=$(awk "BEGIN {print $pr_gzip_size - $develop_gzip_size}")
             gzip_diff_percent=$(awk "BEGIN {if ($develop_gzip_size > 0) print sprintf(\"%.1f\", (($pr_gzip_size - $develop_gzip_size) / $develop_gzip_size) * 100); else print 0}")
 
-            time_diff_abs=$(awk "BEGIN {print ($pr_time > $develop_time ? $pr_time - $develop_time : $develop_time - $pr_time)}")
-
-            # Adds 2 seconds tolerance for time difference
-            if [ "$time_diff_abs" -le 2 ]; then
-              time_diff=0
-            fi
-
+            time_diff=$(awk "BEGIN {print $pr_time - $develop_time}")
+            time_diff_abs=$(awk "BEGIN {x = $time_diff; print (x < 0 ? -x : x)}")
             time_diff_percent=$(awk "BEGIN {if ($develop_time > 0) print sprintf(\"%.1f\", ($time_diff / $develop_time) * 100); else print 0}")
+            time_diff_percent_abs=$(awk "BEGIN {x = $time_diff_percent; print (x < 0 ? -x : x)}")
+
+            # Hybrid tolerance: Hide indicator if BOTH conditions are met:
+            # 1. Absolute difference < 1 second (filters small timing noise)
+            # 2. Percentage difference < 15% (filters variance relative to baseline)
+
+            if (( $(awk "BEGIN {print ($time_diff_abs < 1 && $time_diff_percent_abs < 15)}") )); then
+              time_diff_percent="0.0"
+            fi
 
             size_arrow=$(awk "BEGIN {if ($size_diff > 0) print \"🔼\"; else if ($size_diff < 0) print \"🔽\"; else print \"\"}")
             gzip_arrow=$(awk "BEGIN {if ($gzip_diff > 0) print \"🔼\"; else if ($gzip_diff < 0) print \"🔽\"; else print \"\"}")
-            time_arrow=$(awk "BEGIN {if ($time_diff > 0) print \"🔼\"; else if ($time_diff < 0) print \"🔽\"; else print \"\"}")
+
+            time_arrow=$(awk "BEGIN {if ($time_diff_percent > 0) print \"🔼\"; else if ($time_diff_percent < 0) print \"🔽\"; else print \"\"}")
 
             if [ "$package" = "html" ]; then
               size_row+="| $pr_size MB (${size_diff_percent}%$size_arrow)"
@@ -243,7 +260,7 @@ jobs:
               size_row+="| $pr_size KB (${size_diff_percent}%$size_arrow)"
               gzip_row+="| $pr_gzip_size KB (${gzip_diff_percent}%$gzip_arrow)"
             fi
-            time_row+="| $(awk "BEGIN {printf \"%.0f\", $pr_time}") s (${time_diff_percent}%$time_arrow)"
+            time_row+="| $(awk "BEGIN {printf \"%.1f\", $pr_time}") s (${time_diff_percent}%$time_arrow)"
           done
 
           echo "$size_row|" >> size-comparison.md


### PR DESCRIPTION
## Changes

1. **Median of 5 runs** - Uses middle value instead of average to ignore CI runner outliers
   Example: `[5.2, 5.4, 5.3, 5.5, 9.1]` → median = `5.4s` (ignores 9.1s outlier)
2. **Decimal precision** - Changed from integer seconds to `date +%s.%N` for nanosecond accuracy (displays as `5.4 s` instead of `5 s`)
3. **Hybrid tolerance** - Hides indicators only when BOTH absolute (<1s) AND relative (<15%) changes are small, catches real regressions while filtering CI variance

## Result

More reliable compile time comparisons that filter CI noise while catching performance changes ≥15%.
