### PR TITLE
fix(breadcrumb): wrong focus indicator in Default a11y theme

### DIFF
--- a/packages/core/scss/components/breadcrumb/_theme.scss
+++ b/packages/core/scss/components/breadcrumb/_theme.scss
@@ -44,7 +44,7 @@
                 $kendo-breadcrumb-link-focus-bg,
                 $kendo-breadcrumb-link-focus-border
             );
-            @include focus-indicator( $kendo-breadcrumb-link-focus-shadow );
+            @include focus-indicator( $kendo-breadcrumb-link-focus-shadow, true );
         }
     }
 
@@ -75,7 +75,7 @@
                 $kendo-breadcrumb-root-link-focus-bg,
                 $kendo-breadcrumb-root-link-focus-border
             );
-            @include focus-indicator( $kendo-breadcrumb-root-link-focus-shadow );
+            @include focus-indicator( $kendo-breadcrumb-root-link-focus-shadow, true );
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/telerik/kendo-themes/issues/5425