### PR TITLE
fix: remove zwsp unicode usage across themes

### DIFF
--- a/packages/core/scss/components/calendar/_layout.scss
+++ b/packages/core/scss/components/calendar/_layout.scss
@@ -356,9 +356,9 @@
                 display: block;
                 position: absolute;
                 inset-block-end: 0;
-                content: "\200b";
+                content: "";
                 height: 0;
-                line-height: 0;
+                line-height: 1lh;
                 z-index: k-z-index("base", 1);
                 width: 150%;
                 inset-inline-start: -25%;
@@ -395,7 +395,7 @@
         &::after {
             display: block;
             position: absolute;
-            content: "\200b";
+            content: "";
             height: 0;
             line-height: 0;
             z-index: k-z-index("base", 1);

--- a/packages/core/scss/components/checkbox/_layout.scss
+++ b/packages/core/scss/components/checkbox/_layout.scss
@@ -125,8 +125,9 @@
         position: relative;
 
         &::before {
-            content: "\200b";
-            width: 0px;
+            content: "";
+            width: 0;
+            height: 1lh;
             overflow: hidden;
             flex: none;
             display: inline-block;

--- a/packages/core/scss/components/dropdowntree/_layout.scss
+++ b/packages/core/scss/components/dropdowntree/_layout.scss
@@ -27,8 +27,9 @@
         }
 
         .k-input-inner::before {
-            content: "\200b";
-            width: 0px;
+            content: "";
+            width: 0;
+            height: 1lh;
             overflow: hidden;
             flex: none;
             display: inline-block;

--- a/packages/core/scss/components/gantt/_layout.scss
+++ b/packages/core/scss/components/gantt/_layout.scss
@@ -416,7 +416,7 @@
             position: relative;
             vertical-align: middle;
         }
-        td::after { content: "\200b"; }
+        td::after { content: ""; }
     }
 
     .k-task-wrap {

--- a/packages/core/scss/components/icons/_layout.scss
+++ b/packages/core/scss/components/icons/_layout.scss
@@ -21,8 +21,9 @@
         position: relative;
 
         &::before {
-            content: "\200b";
+            content: "";
             width: 0;
+            height: 1lh;
             overflow: hidden;
             flex: none;
             display: inline-block;

--- a/packages/core/scss/components/input/_layout.scss
+++ b/packages/core/scss/components/input/_layout.scss
@@ -288,7 +288,9 @@
 
 
     // Input value
-    // Input value
+    .k-input-value-icon {
+        flex: none;
+    }
     .k-input-value-text {
         flex: 1;
         overflow: hidden;

--- a/packages/core/scss/components/input/_layout.scss
+++ b/packages/core/scss/components/input/_layout.scss
@@ -288,24 +288,22 @@
 
 
     // Input value
-    .k-input-value-icon {
-        flex: none;
-    }
+    // Input value
     .k-input-value-text {
         flex: 1;
         overflow: hidden;
         text-overflow: ellipsis;
-    }
-    .k-input-value-text::before {
-        content: "\200b";
-        width: 0px;
-        overflow: hidden;
-        flex: none;
-        display: inline-block;
-        vertical-align: top;
-    }
 
-
+        &::before {
+            content: "";
+            width: 0;
+            height: 1lh;
+            overflow: hidden;
+            flex: none;
+            display: inline-block;
+            vertical-align: top;
+        }
+    }
     // Input multiple values
     .k-input-values {
         min-width: 0px;

--- a/packages/core/scss/components/list/_layout.scss
+++ b/packages/core/scss/components/list/_layout.scss
@@ -217,8 +217,9 @@
     .k-list-header-text,
     .k-list-optionlabel {
         &::before {
-            content: "\200b";
-            width: 0px;
+            content: "";
+            width: 0;
+            height: 1lh;
             overflow: hidden;
         }
     }

--- a/packages/core/scss/components/radio/_layout.scss
+++ b/packages/core/scss/components/radio/_layout.scss
@@ -113,8 +113,9 @@
         position: relative;
 
         &::before {
-            content: "\200b";
-            width: 0px;
+            content: "";
+            width: 0;
+            height: 1lh;
             overflow: hidden;
             flex: none;
             display: inline-block;

--- a/packages/core/scss/components/skeleton/_layout.scss
+++ b/packages/core/scss/components/skeleton/_layout.scss
@@ -12,7 +12,8 @@
         transform: $kendo-skeleton-text-transform;
 
         &:empty::before {
-            content: "\200b";
+            content: "";
+            display: inline-block;
         }
     }
 

--- a/packages/core/scss/components/table/_layout.scss
+++ b/packages/core/scss/components/table/_layout.scss
@@ -141,12 +141,12 @@
             position: sticky;
 
             &::before {
-                content: "\200b";
-                padding-block: $kendo-table-md-cell-padding-y;
-                padding-inline: 0;
+                content: "";
+                height: 1lh;
                 width: 0;
                 display: block;
                 overflow: hidden;
+                box-sizing: content-box;
             }
 
             .k-table-th {

--- a/packages/core/scss/components/timeselector/_layout.scss
+++ b/packages/core/scss/components/timeselector/_layout.scss
@@ -151,7 +151,7 @@
             &::before,
             &::after {
                 display: block;
-                content: "\200b";
+                content: "";
                 position: absolute;
                 width: 100%;
                 inset-inline-start: 0;
@@ -188,7 +188,7 @@
         &::after {
             display: block;
             position: absolute;
-            content: "\200b";
+            content: "";
             height: 0;
             line-height: 0;
             z-index: k-z-index("base", 1);

--- a/packages/core/scss/components/window/_layout.scss
+++ b/packages/core/scss/components/window/_layout.scss
@@ -72,7 +72,8 @@
         flex: 1;
 
         &:empty::before {
-            content: "\200b";
+            content: "";
+            display: inline-block;
         }
     }
 


### PR DESCRIPTION
closes: https://github.com/telerik/kendo-themes/issues/5639
https://progresssoftware.atlassian.net/browse/FE-671

### Overview

The usage of unicode characters has intermittently caused issues with strange looking charactes sometimes being displayed. At the moment this can be observed when using the themes from unpkg, where the problem is related to encoding. Since we are minifying the `all.css` file and relying on SASS's `--style=compressed` option to do so the `@charset` declaration at the top of the file is being removed (which is stardard behaviour). The problem stems from the lack of `charset` in the content-type header of the files from unpkg, but we do not seem to have control over that.

### `\200b` unicode usage patterns

There are two main usage patters for the zero-width space unicode character at the moment:

1. **Wrapper elements** (checkbox-wrap, radio-wrap, icon-wrap) - Use ::before with \200b to establish minimum height for flex containers
2. **Text elements** (input-value-text, list-item-text, window-title) - Use ::before or &:empty::before with \200b to prevent collapse

### What has been tried

1. Simply removing the unicode character is not a solution because the outlined usage patterns break and there are visual degradations. The same can be said about replacing `\200b` with a simple space `" "`
2. Release CSS files that contain "\200b" rather than a special invisible character - We can tell SASS not to parse the zero-width space character and escape it with `\\200b` however this would cause the literal characters `\200b` to be displayed.
3. Set explicit height equal to the calculated line height: This could work, but we should probably use the `lh` unit instead of calculating the line height ourselves (e.g. `var(--kendo-font-size) * var(--kendo-line-height)`. I have tried the second approach and there are some edge cases that are tricky and in general it does not seem like a good solution since if someone customizes either of these css variables the content will shift (e.g. checkboxes inside ActionSheet).
4. Explicitly add `@charset` after minification - We could have some script or use a tool like PostCSS to add the `@charset` that is being stripped, but that needs to be tested after we ship the css files to unpkg. 
