### PR TITLE
fix(material): button duplicate selectors

### DIFF
--- a/packages/material/scss/button/_theme.scss
+++ b/packages/material/scss/button/_theme.scss
@@ -6,17 +6,17 @@
 
     @include kendo-button--theme-base();
 
+    .k-button {
+        &:focus,
+        &.k-focus {
+            outline-style: solid;
+            outline-width: calc( (#{$kendo-button-border-width} * 2 ));
+            outline-offset: calc( (#{$kendo-button-border-width} * 2 ) * -1);
+        }
+    }
+
     // Solid button
     @each $name, $color in $kendo-button-theme-colors {
-        .k-button {
-            &:focus,
-            &.k-focus {
-                outline-style: solid;
-                outline-width: calc( (#{$kendo-button-border-width} * 2 ));
-                outline-offset: calc( (#{$kendo-button-border-width} * 2 ) * -1);
-            }
-        }
-
         .k-button-solid-#{$name} {
             // Focus state
             &:focus,


### PR DESCRIPTION
@inikolova and I encountered a selector definition in a `for-each` block that produced duplicate, redundant selectors for each button theme color.