### PR TITLE
Copilot Track — Crawl: 02 Build & Test Baseline

### DIFF
--- a/docs/build-test.md
+++ b/docs/build-test.md
@@ -1,0 +1,81 @@
+# Build & Test Guide
+
+Local development commands for the Kendo Themes monorepo.
+
+## Prerequisites
+
+```bash
+npm ci
+```
+
+## Build Commands
+
+| Command | Description |
+|---------|-------------|
+| `npm run sass` | Compile all themes → `packages/*/dist/all.css` |
+| `npm run sass:dist` | Compile all swatches → `{swatch}.css/scss` |
+| `npm run docs` | Generate SassDoc documentation |
+| `npm run build` | Build HTML components |
+| `npm run build:tests` | Build HTML test components |
+
+## Test Commands
+
+| Command | Description |
+|---------|-------------|
+| `npm run test:units` | Run Jest unit tests |
+| `npm run test:units:watch` | Run Jest in watch mode |
+| `npm run test:integrations` | Test bundler compatibility (gulp, parcel, vite, webpack, esbuild) |
+| `npm run test:create-screenshots` | Generate visual regression screenshots |
+| `npm run test:contrast` | Accessibility contrast tests |
+| `npm run test:html` | HTML component tests |
+
+### Run Tests for a Specific Theme
+
+```bash
+cd units
+npm run test:default
+npm run test:bootstrap
+npm run test:material
+npm run test:classic
+npm run test:fluent
+```
+
+## Linting
+
+| Command | Description |
+|---------|-------------|
+| `npm run lint` | Run all linters |
+| `npm run lint:scripts` | ESLint for JS/TS files |
+| `npm run lint:styles` | Stylelint for SCSS files |
+
+## Development Server
+
+```bash
+npm start   # Starts dev server on localhost:3000
+```
+
+## Caveats
+
+1. **Unit tests require docs first** — Always run `npm run docs` before `npm run test:units`. Tests depend on generated SassDoc metadata.
+
+2. **Integration tests install dependencies** — Running `npm run test:integrations` triggers `npm install` in each bundler subdirectory (`integrations/gulp`, `integrations/parcel`, etc.).
+
+3. **Git hooks** — Husky runs linting automatically on staged files via `lint-staged`.
+
+4. **Nx caching** — Build tasks use Nx for caching. Run `nx reset` if you encounter stale cache issues.
+
+## Quick Start
+
+```bash
+npm ci              # Install dependencies
+npm run docs        # Generate metadata (required for unit tests)
+npm run test:units  # Run unit tests
+```
+
+## Cleanup
+
+| Command | Description |
+|---------|-------------|
+| `npm run clean:dist` | Remove all `dist` folders |
+| `npm run clean:tests` | Clean test result files |
+| `npm run clean` | Full cleanup (includes `node_modules`) |

--- a/units/bootstrap/icon.test.ts
+++ b/units/bootstrap/icon.test.ts
@@ -1,0 +1,16 @@
+import "./theme.env.js";
+import { Icon } from "../../packages/html/src/icon/icon.spec";
+import { testKendoComponent } from "../utility";
+
+const component = Icon.moduleName;
+const group = "icon"; // SassDoc @group for icon variables
+// The icon module outputs .k-svg-icon as the primary selector (from @progress/kendo-svg-icons)
+// .k-icon-wrap is a utility wrapper class
+const className = "k-svg-icon";
+
+const dependencyClassNames = ["k-icon-wrap"];
+
+// Icon variables (like $kendo-icon-size) are used in arithmetic operations
+// across other components (e.g., bottom-navigation), so we cannot substitute
+// them with test strings. Disable customization testing.
+testKendoComponent(component, group, className, dependencyClassNames, [], false);

--- a/units/classic/icon.test.ts
+++ b/units/classic/icon.test.ts
@@ -1,0 +1,16 @@
+import "./theme.env.js";
+import { Icon } from "../../packages/html/src/icon/icon.spec";
+import { testKendoComponent } from "../utility";
+
+const component = Icon.moduleName;
+const group = "icon"; // SassDoc @group for icon variables
+// The icon module outputs .k-svg-icon as the primary selector (from @progress/kendo-svg-icons)
+// .k-icon-wrap is a utility wrapper class
+const className = "k-svg-icon";
+
+const dependencyClassNames = ["k-icon-wrap"];
+
+// Icon variables (like $kendo-icon-size) are used in arithmetic operations
+// across other components (e.g., bottom-navigation), so we cannot substitute
+// them with test strings. Disable customization testing.
+testKendoComponent(component, group, className, dependencyClassNames, [], false);

--- a/units/default/icon.test.ts
+++ b/units/default/icon.test.ts
@@ -1,0 +1,16 @@
+import "./theme.env.js";
+import { Icon } from "../../packages/html/src/icon/icon.spec";
+import { testKendoComponent } from "../utility";
+
+const component = Icon.moduleName;
+const group = "icon"; // SassDoc @group for icon variables
+// The icon module outputs .k-svg-icon as the primary selector (from @progress/kendo-svg-icons)
+// .k-icon-wrap is a utility wrapper class
+const className = "k-svg-icon";
+
+const dependencyClassNames = ["k-icon-wrap"];
+
+// Icon variables (like $kendo-icon-size) are used in arithmetic operations
+// across other components (e.g., bottom-navigation), so we cannot substitute
+// them with test strings. Disable customization testing.
+testKendoComponent(component, group, className, dependencyClassNames, [], false);

--- a/units/fluent/icon.test.ts
+++ b/units/fluent/icon.test.ts
@@ -1,0 +1,16 @@
+import "./theme.env.js";
+import { Icon } from "../../packages/html/src/icon/icon.spec";
+import { testKendoComponent } from "../utility";
+
+const component = Icon.moduleName;
+const group = "icon"; // SassDoc @group for icon variables
+// The icon module outputs .k-svg-icon as the primary selector (from @progress/kendo-svg-icons)
+// .k-icon-wrap is a utility wrapper class
+const className = "k-svg-icon";
+
+const dependencyClassNames = ["k-icon-wrap"];
+
+// Icon variables (like $kendo-icon-size) are used in arithmetic operations
+// across other components (e.g., bottom-navigation), so we cannot substitute
+// them with test strings. Disable customization testing.
+testKendoComponent(component, group, className, dependencyClassNames, [], false);

--- a/units/material/icon.test.ts
+++ b/units/material/icon.test.ts
@@ -1,0 +1,16 @@
+import "./theme.env.js";
+import { Icon } from "../../packages/html/src/icon/icon.spec";
+import { testKendoComponent } from "../utility";
+
+const component = Icon.moduleName;
+const group = "icon"; // SassDoc @group for icon variables
+// The icon module outputs .k-svg-icon as the primary selector (from @progress/kendo-svg-icons)
+// .k-icon-wrap is a utility wrapper class
+const className = "k-svg-icon";
+
+const dependencyClassNames = ["k-icon-wrap"];
+
+// Icon variables (like $kendo-icon-size) are used in arithmetic operations
+// across other components (e.g., bottom-navigation), so we cannot substitute
+// them with test strings. Disable customization testing.
+testKendoComponent(component, group, className, dependencyClassNames, [], false);


### PR DESCRIPTION
## Summary
- Added `build-test.md` documenting all local build/test commands and caveats (e.g., npm run docs required before unit tests).
- Added minimal 1icon.test.ts` unit tests for all 5 themes — a low-risk component that was missing test coverage due to variable arithmetic constraints.
- Files touched: `build-test.md`, `icon.test.ts`

## Test & Risk

- How to run tests: 
```bash
npm run docs && cd units && npx jest icon.test.ts
```
- Risk & rollback: Low risk - adds documentation and new test files only. No changes to production SCSS or existing tests. Rollback: delete the added files.

## Track
- Level: crawl
- Exercise: 02-build-test-baseline
- Evidence:

```bash
PASS  classic/icon.test.ts
PASS  bootstrap/icon.test.ts
PASS  default/icon.test.ts
PASS  material/icon.test.ts
PASS  fluent/icon.test.ts

Test Suites: 5 passed, 5 total
Tests:       15 passed, 15 total
```