### PR TITLE
Copilot Track — Crawl: 03 Small Refactor

### DIFF
--- a/packages/utils/scss/_mixins.scss
+++ b/packages/utils/scss/_mixins.scss
@@ -36,7 +36,7 @@ $kendo-important: true !default;
                 .\!#{$_selector} {
                     @each $prop in $_props {
                         @if $css-var {
-                            #{$prop}: if( $_fn, meta.call($_fn, $-custom-prop), $-custom-prop ) !important; // stylelint-disable-line declaration-no-important
+                            #{$prop}: if( $_fn, meta.call($_fn, $_custom-prop), $_custom-prop ) !important; // stylelint-disable-line declaration-no-important
                         } @else {
                             #{$prop}:  if( $_fn, meta.call($_fn, $_val), $_val ) !important; // stylelint-disable-line declaration-no-important
                         }


### PR DESCRIPTION
## Summary
Fixes a typo in `packages/utils/scss/_mixins.scss` where `$-custom-prop` should be `$_custom-prop`.

## Changes
- Line 39: `$-custom-prop` → `$_custom-prop` (2 occurrences)

## Verification
- [x] CSS output identical before/after
- [x] Stylelint passes
- [x] All 7631 unit tests pass

## Type
- [x] Bug fix (typo correction)