### PR TITLE
Copilot Track — Crawl: 09 Observability

### DIFF
--- a/ai-track-docs/logging.md
+++ b/ai-track-docs/logging.md
@@ -1,0 +1,157 @@
+# Logging Guidelines
+
+> Last updated: 2026-01-09
+
+## Overview
+
+This document describes structured logging in the kendo-themes build pipeline.
+
+## Log Format
+
+All logs use JSON format with consistent fields:
+
+```json
+{
+  "ts": "2026-01-09T10:30:00.000Z",
+  "op": "resolve-variables",
+  "phase": "start|compile|end|skip",
+  "status": "ok|error",
+  "elapsedMs": 1234,
+  "theme": "default",
+  "err": "error message if status=error"
+}
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ts` | string | ISO 8601 timestamp |
+| `op` | string | Operation name (e.g., `resolve-variables`) |
+| `phase` | string | Execution phase (`start`, `compile`, `end`, `skip`) |
+| `status` | string | `ok` or `error` |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `elapsedMs` | number | Duration in milliseconds |
+| `theme` | string | Theme being processed |
+| `variables` | number | Count of resolved variables |
+| `err` | string | Error message (when `status=error`) |
+
+## Instrumented Paths
+
+| Script | Operation | Description |
+|--------|-----------|-------------|
+| `scripts/resolve-variables.js` | `resolve-variables` | SCSS variable resolution before docs |
+
+## How to Run & View Logs
+
+### Run with logs visible
+
+```bash
+# Single theme
+cd packages/default && npm run resolve-variables
+
+# All themes (via docs)
+npm run docs
+```
+
+### Filter structured logs
+
+```bash
+# Extract only JSON log lines
+npm run docs 2>&1 | grep '^{' | jq .
+
+# Filter by operation
+npm run docs 2>&1 | grep '^{' | jq 'select(.op == "resolve-variables")'
+
+# Filter errors only
+npm run docs 2>&1 | grep '^{' | jq 'select(.status == "error")'
+
+# Get timing summary
+npm run docs 2>&1 | grep '^{' | jq -r 'select(.phase == "end") | "\(.theme): \(.elapsed_ms)ms"'
+```
+
+### Save logs to file
+
+```bash
+npm run docs 2>&1 | grep '^{' > build.log
+
+# Pretty print
+cat build.log | jq .
+```
+
+## Example Output
+
+### Successful run
+
+```json
+{"ts":"2026-01-09T10:30:00.000Z","op":"resolve-variables","phase":"start","status":"ok","theme":"default","src":"/path/to/scss/all.scss"}
+{"ts":"2026-01-09T10:30:00.010Z","op":"resolve-variables","phase":"compile","status":"ok","theme":"default"}
+{"ts":"2026-01-09T10:30:01.234Z","op":"resolve-variables","phase":"end","status":"ok","theme":"default","elapsedMs":1234,"variables":847}
+```
+
+### Error case
+
+```json
+{"ts":"2026-01-09T10:30:00.000Z","op":"resolve-variables","phase":"start","status":"ok","theme":"broken","src":"/path/to/scss/all.scss"}
+{"ts":"2026-01-09T10:30:00.010Z","op":"resolve-variables","phase":"compile","status":"ok","theme":"broken"}
+{"ts":"2026-01-09T10:30:00.150Z","op":"resolve-variables","phase":"end","status":"error","theme":"broken","elapsedMs":150,"err":"Undefined variable $missing"}
+```
+
+### Skipped (no source file)
+
+```json
+{"ts":"2026-01-09T10:30:00.000Z","op":"resolve-variables","phase":"skip","status":"ok","reason":"srcFile not found","src":"/path/to/scss/all.scss"}
+```
+
+## Adding New Logs
+
+Use the `log()` helper pattern:
+
+```javascript
+function log(op, phase, status, extra = {}) {
+    const entry = {
+        ts: new Date().toISOString(),
+        op,
+        phase,
+        status,
+        ...extra
+    };
+    console.log(JSON.stringify(entry));
+}
+
+// Usage
+const startTime = Date.now();
+log('my-operation', 'start', 'ok', { file: inputFile });
+
+try {
+    // ... work ...
+    log('my-operation', 'end', 'ok', { elapsedMs: Date.now() - startTime });
+} catch (err) {
+    log('my-operation', 'end', 'error', { elapsedMs: Date.now() - startTime, err: err.message });
+    throw err;
+}
+```
+
+## Troubleshooting
+
+### No JSON output visible
+
+Logs go to stdout. If running via npm scripts, ensure output isn't suppressed:
+
+```bash
+npm run docs --silent=false
+```
+
+### jq not installed
+
+```bash
+# macOS
+brew install jq
+
+# Or use Node.js
+npm run docs 2>&1 | grep '^{' | node -e "const r=require('readline').createInterface({input:process.stdin});r.on('line',l=>console.log(JSON.stringify(JSON.parse(l),null,2)))"
+```

--- a/scripts/resolve-variables.js
+++ b/scripts/resolve-variables.js
@@ -4,6 +4,19 @@ const fs = require('fs');
 const path = require('path');
 const dartSass = require('sass');
 
+// Structured logging utility
+function log(op, phase, status, extra = {}) {
+    const entry = {
+        ts: new Date().toISOString(),
+        op,
+        phase,
+        status,
+        ...extra
+    };
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(entry));
+}
+
 const themeDir = process.cwd();
 const srcFile = path.resolve( themeDir, 'scss', 'all.scss' );
 const variablesJson = path.resolve( themeDir, `dist/meta/variables.json` );
@@ -85,6 +98,9 @@ function prettifySassNumber(sassNumber) {
 // #endregion
 
 if (fs.existsSync( srcFile )) {
+    const startTime = Date.now();
+    const themeName = path.basename(themeDir);
+    log('resolve-variables', 'start', 'ok', { theme: themeName, src: srcFile });
 
     fs.writeFileSync( path.resolve( output.path, output.filename), '@forward "../scss/all.scss";');
 
@@ -96,29 +112,41 @@ if (fs.existsSync( srcFile )) {
 
     fs.copyFileSync( path.resolve( __dirname, '../lib/variables.scss' ), variablesScss );
 
-    dartSass.compile(variablesScss, {
-        functions: {
-            'k-resolve-var($key, $type, $value)': ([ rawKey, rawType, rawValue ]) => {
-                const _key = rawKey.toString();
-                const _type = rawType.toString();
-                const _val = rawValue.toString();
-                const prettyValue = prettifySassValue(rawValue);
+    try {
+        log('resolve-variables', 'compile', 'ok', { theme: themeName });
+        dartSass.compile(variablesScss, {
+            functions: {
+                'k-resolve-var($key, $type, $value)': ([ rawKey, rawType, rawValue ]) => {
+                    const _key = rawKey.toString();
+                    const _type = rawType.toString();
+                    const _val = rawValue.toString();
+                    const prettyValue = prettifySassValue(rawValue);
 
-                content[_key] = {
-                    type: _capitalize( _type ),
-                    value: _val
-                };
-                _type === "map" && (content[_key].prettyValue = prettyValue);
+                    content[_key] = {
+                        type: _capitalize( _type ),
+                        value: _val
+                    };
+                    _type === "map" && (content[_key].prettyValue = prettyValue);
 
-                return new dartSass.SassString('');
-            }
-        },
-        logger: dartSass.Logger.silent,
-        loadPaths: [
-            nodeModules
-        ]
-    });
+                    return new dartSass.SassString('');
+                }
+            },
+            logger: dartSass.Logger.silent,
+            loadPaths: [
+                nodeModules
+            ]
+        });
 
-    fs.writeFileSync( variablesJson, JSON.stringify( content, null, 4 ) );
+        fs.writeFileSync( variablesJson, JSON.stringify( content, null, 4 ) );
 
+        const elapsedMs = Date.now() - startTime;
+        const varCount = Object.keys(content).length;
+        log('resolve-variables', 'end', 'ok', { theme: themeName, elapsedMs, variables: varCount });
+    } catch (err) {
+        const elapsedMs = Date.now() - startTime;
+        log('resolve-variables', 'end', 'error', { theme: themeName, elapsedMs, err: err.message });
+        throw err;
+    }
+} else {
+    log('resolve-variables', 'skip', 'ok', { reason: 'srcFile not found', src: srcFile });
 }


### PR DESCRIPTION
## Summary

Adds structured JSON logging to the critical `resolve-variables.js` build path with documentation for local viewing.

## Changes

| File | Change |
|------|--------|
| `scripts/resolve-variables.js` | Added structured JSON logs with `op`, `phase`, `status`, `elapsedMs`, `err` fields |
| `ai-track-docs/logging.md` | Documentation: log format, how to run/view, filtering examples |

## Log Fields

| Field | Type | Description |
|-------|------|-------------|
| `ts` | string | ISO 8601 timestamp |
| `op` | string | Operation name (`resolve-variables`) |
| `phase` | string | `start`, `compile`, `end`, `skip` |
| `status` | string | `ok` or `error` |
| `elapsedMs` | number | Duration in milliseconds |
| `err` | string | Error message (on failure) |

## Sample Output

```json
{"ts":"2026-01-09T09:06:53.989Z","op":"resolve-variables","phase":"start","status":"ok","theme":"default","src":"/path/to/scss/all.scss"}
{"ts":"2026-01-09T09:06:53.992Z","op":"resolve-variables","phase":"compile","status":"ok","theme":"default"}
{"ts":"2026-01-09T09:06:54.841Z","op":"resolve-variables","phase":"end","status":"ok","theme":"default","elapsedMs":852,"variables":3454}
```

## How to View

```bash
# Run and filter JSON logs
npm run docs 2>&1 | grep '^{' | jq .

# Get timing summary
npm run docs 2>&1 | grep '^{' | jq -r 'select(.phase == "end") | "\(.theme): \(.elapsedMs)ms"'
```

## Acceptance Criteria

- ✅ Structured logs added with consistent fields
- ✅ Logging doc included examples
- ✅ PR shows sample output