### PR TITLE
Copilot Track — Crawl: 10 CI/CD Baseline

### DIFF
--- a/.github/workflows/_test-integrations.yml
+++ b/.github/workflows/_test-integrations.yml
@@ -11,6 +11,7 @@ jobs:
 
   run:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       matrix:

--- a/.github/workflows/_test-units.yml
+++ b/.github/workflows/_test-units.yml
@@ -11,6 +11,7 @@ jobs:
 
   run:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
         matrix:

--- a/docs/build-test.md
+++ b/docs/build-test.md
@@ -72,6 +72,17 @@ npm run docs        # Generate metadata (required for unit tests)
 npm run test:units  # Run unit tests
 ```
 
+## Local CI Test Script
+
+Run the full CI test suite locally before pushing:
+
+```bash
+./scripts/run-tests-local.sh          # Full suite (lint, unit, integration)
+./scripts/run-tests-local.sh --quick  # Skip integration tests for faster iteration
+```
+
+This script mirrors CI behavior: installs deps, generates docs, runs lints, then tests.
+
 ## Cleanup
 
 | Command | Description |

--- a/scripts/run-tests-local.sh
+++ b/scripts/run-tests-local.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# run-tests-local.sh — Run the full CI test suite locally
+# Usage: ./scripts/run-tests-local.sh [--quick]
+#   --quick  Skip integration tests (faster iteration)
+
+set -euo pipefail
+
+QUICK_MODE=false
+if [[ "${1:-}" == "--quick" ]]; then
+    QUICK_MODE=true
+fi
+
+echo "==> Installing dependencies..."
+npm ci --no-audit --no-fund
+
+echo "==> Generating docs (required for unit tests)..."
+npm run docs
+
+echo "==> Running linters..."
+npm run lint
+
+echo "==> Running unit tests..."
+npm run test:units
+
+if [[ "$QUICK_MODE" == false ]]; then
+    echo "==> Running integration tests..."
+    npm run test:integrations
+else
+    echo "==> Skipping integration tests (--quick mode)"
+fi
+
+echo ""
+echo "✅ All tests passed!"


### PR DESCRIPTION
## Summary

Add reliability improvements to CI test workflows and provide a local test script for developers.

## Changes

### CI Reliability Tweak
- Added `timeout-minutes: 15` to `_test-units.yml` 
- Added `timeout-minutes: 20` to `_test-integrations.yml`

This prevents jobs from hanging indefinitely if tests stall, improving CI reliability.

### Local Test Script
Added `scripts/run-tests-local.sh` to run the full CI test suite locally:

```bash
./scripts/run-tests-local.sh          # Full suite (lint, unit, integration)
./scripts/run-tests-local.sh --quick  # Skip integration tests for faster iteration
```

### Documentation

Updated `build.test.md` with "Local CI Test Script" section explaining usage.

## How to Run Tests

| Method | Command |
|---------|-------------|
| CI | Tests run automatically on PRs (configured in `ci.yml`) |
| Locally | `run-tests-local.sh` or with `--quick` flag |

## Acceptance Criteria

- ✅ CI runs tests on PRs
- ✅ Reliability tweak landed (timeout-minutes)
- ✅ Local test script exists with instructions 