### PR TITLE
chore: fix flaky docs tasks

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -32,10 +32,16 @@
       ]
     },
     "docs": {
-      "cache": true
+      "cache": true,
+      "dependsOn": [
+        "^docs"
+      ]
     },
     "docs:check": {
       "cache": false,
+      "dependsOn": [
+        "^docs"
+      ],
       "executor": "nx:run-script",
       "options": {
         "script": "docs:check"


### PR DESCRIPTION
### Summary
Root cause: No task dependency between themes and core for the docs / docs:check targets. When nx runs docs:check for all packages in parallel, fluent's `sassdoc.js` reads `sassdoc-raw-data.json` — a file that core's own docs task writes. If core hasn't finished (or started) writing it, fluent either skips all core variables (early return on `sassdoc.js:47`) or gets a JSON parse error, producing different docs than what's committed. The `git diff --exit-code` then fails. On re-run, core's file is already there, so it passes — flaky task.

Fix: Added `"dependsOn": ["^docs"]` to both the docs and docs:check targets in `nx.json`. The `^` prefix means "run the docs target in all dependency packages first." Since fluent (and default, bootstrap, etc.) depend on `@progress/kendo-theme-core` in their `package.json`, nx will now ensure core's docs completes before any downstream theme's `docs` or `docs:check` starts