### PR TITLE
Concentric Border Radius

### DIFF
--- a/packages/core/scss/mixins/_border-radius.scss
+++ b/packages/core/scss/mixins/_border-radius.scss
@@ -66,3 +66,11 @@
         border-end-start-radius: $radius;
     }
 }
+
+@mixin concentric-radius($radius, $padding, $selector) {
+  border-radius: $radius;
+
+  #{$selector} {
+    border-radius: max(0px, $radius - $padding);
+  }
+}


### PR DESCRIPTION
related to: https://github.com/telerik/kendo-themes-private/issues/470

### Concentric Border-Radius

When a container has both `border-radius` and `padding`, nested elements need a proportionally smaller radius to maintain visual alignment. The correct inner radius is:

$$r_{\text{inner}} = \max(0,\; r_{\text{outer}} - \text{padding})$$

Without this adjustment, inner elements appear to "bulge" at the corners — especially noticeable at larger radii like `full`. The new `concentric-radius` mixin in _border-radius.scss encapsulates this pattern:

```scss
@mixin concentric-radius($radius, $padding, $selector) {
  border-radius: $radius;
  padding: $padding;

  #{$selector} {
    border-radius: max(0px, $radius - $padding);
  }
}
```

The calculation uses CSS `max()` at runtime (with `0px`, not unitless `0`) since the radius and padding may use different units (`rem` vs `px`) via CSS custom properties.

### Changes

- **New `concentric-radius` mixin** (_border-radius.scss)

### Showcase (remove commit before merge)

- **Segmented Control roundness** — added `$kendo-segmented-control-roundness` (`none`, `sm`, `md`, `lg`, `full`) with `full` as default. Each roundness class applies `concentric-radius` to both `.k-segmented-control-thumb` and `.k-segmented-control-button`, so the inner radius automatically adjusts when the component's border-radius changes.
- **HTML spec** — added `rounded` option to segmented-control.spec.tsx.

The segmented-control-sizes.tsx test is just a showcase — it renders a size × rounded matrix to demonstrate how changing the component's border-radius automatically applies the correct concentric radius to both the thumb and button selectors via the mixin.