### PR TITLE
chore(ci): publish swatches only for stable

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -100,3 +100,9 @@ jobs:
         run: |
           git push origin master --tags --quiet > /dev/null 2>&1
           git push origin master:develop --quiet > /dev/null 2>&1
+
+      - name: Trigger swatches publish
+        if: env.RELEASE_TYPE == 'stable'
+        run: gh workflow run publish_swatches.yml -f ref=master
+        env:
+          GH_TOKEN: ${{ steps.import-secrets.outputs.GH_TOKEN }}

--- a/.github/workflows/publish_swatches.yml
+++ b/.github/workflows/publish_swatches.yml
@@ -11,16 +11,9 @@ on:
         required: true
         default: "master"
 
-  workflow_run:
-    workflows:
-      - "Publish to npm"
-    types:
-      - completed
-
 jobs:
   publish:
     runs-on: "ubuntu-latest"
-    if: ${{ github.event.inputs.ref || github.event.workflow_run.conclusion == 'success' }}
 
     permissions:
       id-token: write # Required by Akeyless
@@ -28,6 +21,15 @@ jobs:
       packages: read
 
     steps:
+      - name: Checkout branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Read version
+        run: |
+          echo "VERSION=$(jq -r '.version' lerna.json)" >> $GITHUB_ENV
+
       - name: Import Secrets
         id: import-secrets
         uses: LanceMcCarthy/akeyless-action@v5
@@ -35,23 +37,6 @@ jobs:
           access-id: ${{ secrets.GH_AKEYLESS_ACCESS_ID }}
           static-secrets: '{ "/WebComponents/prod/tokens/GH_TOKEN": "GH_TOKEN" }'
           export-secrets-to-environment: false
-
-      - name: Checkout branch
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.event.inputs.ref }}
-
-      - name: Read version
-        run: |
-          echo "VERSION=$(jq -r '.version' lerna.json)" >> $GITHUB_ENV
-
-      - name: Check if dev release
-        if: github.event_name == 'workflow_run'
-        run: |
-          if [[ "$VERSION" == *"-dev"* ]]; then
-            echo "Dev release detected ($VERSION), skipping swatch publish"
-            exit 0
-          fi
 
       - name: Setup node
         id: setup-node


### PR DESCRIPTION
_Root cause_: The original `exit 0` in the "Check if dev release" step only exited the shell script — it didn't stop the job. GitHub Actions treated it as a passing step and continued executing all `build/package/publish` steps, so dev releases were published to the CDN.

_Fix_: Replaced the implicit `workflow_run` trigger with an explicit `gh workflow run` call from `publish_npm.yml`:

- Removed the `workflow_run` trigger from `publish_swatches.yml` entirely
- Added a "Trigger swatches publish" step in `publish_npm.yml`,  gated on `RELEASE_TYPE == 'stable'`, that explicitly dispatches the swatches workflow with `ref=master`
- Simplified `publish_swatches.yml` to only use `workflow_dispatch` — serving both automated (from `publish_npm`) and manual triggers
- Reordered steps to check out and read version before importing secrets