### PR TITLE
Streamline typography maps

### DIFF
--- a/packages/bootstrap/docs/customization-typography.md
+++ b/packages/bootstrap/docs/customization-typography.md
@@ -38,6 +38,16 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-size-xxs</td>
+    <td>Number</td>
+    <td><code>( $kendo-font-size * .5 )</code></td>
+    <td><code>0.5rem</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-size-xs</td>
     <td>Number</td>
     <td><code>( $kendo-font-size * .75 )</code></td>
@@ -148,6 +158,36 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-weight</td>
+    <td>Number</td>
+    <td><code>400</code></td>
+    <td><code>400</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-weight-thin</td>
+    <td>Number</td>
+    <td><code>100</code></td>
+    <td><code>100</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The thin font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-weight-extra-light</td>
+    <td>Number</td>
+    <td><code>200</code></td>
+    <td><code>200</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra light font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-weight-light</td>
     <td>Number</td>
     <td><code>300</code></td>
@@ -160,11 +200,11 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-font-weight-normal</td>
     <td>Number</td>
-    <td><code>400</code></td>
+    <td><code>$kendo-font-weight</code></td>
     <td><code>400</code></td>
 </tr>
 <tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The normal font weight across all components.</div></div>
     </td>
 </tr>
 <tr>
@@ -195,116 +235,6 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The bold font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family-sans-serif</td>
-    <td>List</td>
-    <td><code>system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"</code></td>
-    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sans-serif font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family-monospace</td>
-    <td>List</td>
-    <td><code>SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace</code></td>
-    <td><code>(SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The monospace font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family</td>
-    <td>List</td>
-    <td><code>$kendo-font-family-sans-serif</code></td>
-    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-sizes</td>
-    <td>Map</td>
-    <td><code>$_default-font-sizes</code></td>
-    <td><ul><li>xs: 0.75rem</li><li>sm: 0.875rem</li><li>md: 1rem</li><li>lg: 1.25rem</li><li>xl: 1.5rem</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-line-heights</td>
-    <td>Map</td>
-    <td><code>$_default-line-heights</code></td>
-    <td><ul><li>xs: 1</li><li>sm: 1.2</li><li>md: 1.5</li><li>lg: 2</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weights</td>
-    <td>Map</td>
-    <td><code>$_default-font-weights</code></td>
-    <td><ul><li>light: 300</li><li>normal: 400</li><li>medium: 500</li><li>semibold: 600</li><li>bold: 700</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font weights map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-families</td>
-    <td>Map</td>
-    <td><code>$_default-font-families</code></td>
-    <td><ul><li>sans-serif: (system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</li><li>monospace: (SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace)</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font families map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-size-xxs</td>
-    <td>Number</td>
-    <td><code>0.5rem</code></td>
-    <td><code>0.5rem</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight</td>
-    <td>Number</td>
-    <td><code>400</code></td>
-    <td><code>400</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight-thin</td>
-    <td>Number</td>
-    <td><code>100</code></td>
-    <td><code>100</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The thin font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight-extra-light</td>
-    <td>Number</td>
-    <td><code>200</code></td>
-    <td><code>200</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra light font weight across all components.</div></div>
     </td>
 </tr>
 <tr>
@@ -428,13 +358,83 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-family-sans-serif</td>
+    <td>List</td>
+    <td><code>system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"</code></td>
+    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sans-serif font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-family-monospace</td>
+    <td>List</td>
+    <td><code>SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace</code></td>
+    <td><code>(SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The monospace font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-family</td>
+    <td>List</td>
+    <td><code>$kendo-font-family-sans-serif</code></td>
+    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-sizes</td>
+    <td>Map</td>
+    <td><code>$_default-font-sizes</code></td>
+    <td><ul><li>xxs: 0.5rem</li><li>xs: 0.75rem</li><li>sm: 0.875rem</li><li>md: 1rem</li><li>lg: 1.25rem</li><li>xl: 1.5rem</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-line-heights</td>
+    <td>Map</td>
+    <td><code>$_default-line-heights</code></td>
+    <td><ul><li>xs: 1</li><li>sm: 1.2</li><li>md: 1.5</li><li>lg: 2</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-weights</td>
+    <td>Map</td>
+    <td><code>$_default-font-weights</code></td>
+    <td><ul><li>thin: 100</li><li>extra-light: 200</li><li>light: 300</li><li>normal: 400</li><li>medium: 500</li><li>semibold: 600</li><li>bold: 700</li><li>extra-bold: 800</li><li>black: 900</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font weights map</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-letter-spacings</td>
     <td>Map</td>
-    <td><code>$default-letter-spacings</code></td>
+    <td><code>$_default-letter-spacings</code></td>
     <td><ul><li>tightest: -0.15px</li><li>tighter: -0.1px</li><li>tight: -0.5px</li><li>normal: 0px</li><li>wide: 0.5px</li><li>wider: 0.1px</li><li>widest: 0.15px</li></ul></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The letter spacings map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-families</td>
+    <td>Map</td>
+    <td><code>$_default-font-families</code></td>
+    <td><ul><li>sans: (Arial, Verdana, Tahoma, "Trebuchet MS", Helvetica, Impact, Gill Sans)</li><li>serif: ("Times New Roman", Georgia, Garamond, Palatino, Baskerville)</li><li>sans-serif: (system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</li><li>monospace: (SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace)</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font families map</div></div>
     </td>
 </tr>
 </tbody>

--- a/packages/bootstrap/docs/customization.md
+++ b/packages/bootstrap/docs/customization.md
@@ -37524,6 +37524,16 @@ The following table lists the available variables for customizing the Bootstrap 
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-size-xxs</td>
+    <td>Number</td>
+    <td><code>( $kendo-font-size * .5 )</code></td>
+    <td><code>0.5rem</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-size-xs</td>
     <td>Number</td>
     <td><code>( $kendo-font-size * .75 )</code></td>
@@ -37634,6 +37644,36 @@ The following table lists the available variables for customizing the Bootstrap 
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-weight</td>
+    <td>Number</td>
+    <td><code>400</code></td>
+    <td><code>400</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-weight-thin</td>
+    <td>Number</td>
+    <td><code>100</code></td>
+    <td><code>100</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The thin font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-weight-extra-light</td>
+    <td>Number</td>
+    <td><code>200</code></td>
+    <td><code>200</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra light font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-weight-light</td>
     <td>Number</td>
     <td><code>300</code></td>
@@ -37646,11 +37686,11 @@ The following table lists the available variables for customizing the Bootstrap 
 <tr>
     <td>$kendo-font-weight-normal</td>
     <td>Number</td>
-    <td><code>400</code></td>
+    <td><code>$kendo-font-weight</code></td>
     <td><code>400</code></td>
 </tr>
 <tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The normal font weight across all components.</div></div>
     </td>
 </tr>
 <tr>
@@ -37681,116 +37721,6 @@ The following table lists the available variables for customizing the Bootstrap 
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The bold font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family-sans-serif</td>
-    <td>List</td>
-    <td><code>system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"</code></td>
-    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sans-serif font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family-monospace</td>
-    <td>List</td>
-    <td><code>SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace</code></td>
-    <td><code>(SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The monospace font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family</td>
-    <td>List</td>
-    <td><code>$kendo-font-family-sans-serif</code></td>
-    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-sizes</td>
-    <td>Map</td>
-    <td><code>$_default-font-sizes</code></td>
-    <td><ul><li>xs: 0.75rem</li><li>sm: 0.875rem</li><li>md: 1rem</li><li>lg: 1.25rem</li><li>xl: 1.5rem</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-line-heights</td>
-    <td>Map</td>
-    <td><code>$_default-line-heights</code></td>
-    <td><ul><li>xs: 1</li><li>sm: 1.2</li><li>md: 1.5</li><li>lg: 2</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weights</td>
-    <td>Map</td>
-    <td><code>$_default-font-weights</code></td>
-    <td><ul><li>light: 300</li><li>normal: 400</li><li>medium: 500</li><li>semibold: 600</li><li>bold: 700</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font weights map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-families</td>
-    <td>Map</td>
-    <td><code>$_default-font-families</code></td>
-    <td><ul><li>sans-serif: (system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</li><li>monospace: (SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace)</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font families map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-size-xxs</td>
-    <td>Number</td>
-    <td><code>0.5rem</code></td>
-    <td><code>0.5rem</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight</td>
-    <td>Number</td>
-    <td><code>400</code></td>
-    <td><code>400</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight-thin</td>
-    <td>Number</td>
-    <td><code>100</code></td>
-    <td><code>100</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The thin font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight-extra-light</td>
-    <td>Number</td>
-    <td><code>200</code></td>
-    <td><code>200</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra light font weight across all components.</div></div>
     </td>
 </tr>
 <tr>
@@ -37914,13 +37844,83 @@ The following table lists the available variables for customizing the Bootstrap 
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-family-sans-serif</td>
+    <td>List</td>
+    <td><code>system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"</code></td>
+    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sans-serif font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-family-monospace</td>
+    <td>List</td>
+    <td><code>SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace</code></td>
+    <td><code>(SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The monospace font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-family</td>
+    <td>List</td>
+    <td><code>$kendo-font-family-sans-serif</code></td>
+    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-sizes</td>
+    <td>Map</td>
+    <td><code>$_default-font-sizes</code></td>
+    <td><ul><li>xxs: 0.5rem</li><li>xs: 0.75rem</li><li>sm: 0.875rem</li><li>md: 1rem</li><li>lg: 1.25rem</li><li>xl: 1.5rem</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-line-heights</td>
+    <td>Map</td>
+    <td><code>$_default-line-heights</code></td>
+    <td><ul><li>xs: 1</li><li>sm: 1.2</li><li>md: 1.5</li><li>lg: 2</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-weights</td>
+    <td>Map</td>
+    <td><code>$_default-font-weights</code></td>
+    <td><ul><li>thin: 100</li><li>extra-light: 200</li><li>light: 300</li><li>normal: 400</li><li>medium: 500</li><li>semibold: 600</li><li>bold: 700</li><li>extra-bold: 800</li><li>black: 900</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font weights map</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-letter-spacings</td>
     <td>Map</td>
-    <td><code>$default-letter-spacings</code></td>
+    <td><code>$_default-letter-spacings</code></td>
     <td><ul><li>tightest: -0.15px</li><li>tighter: -0.1px</li><li>tight: -0.5px</li><li>normal: 0px</li><li>wide: 0.5px</li><li>wider: 0.1px</li><li>widest: 0.15px</li></ul></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The letter spacings map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-families</td>
+    <td>Map</td>
+    <td><code>$_default-font-families</code></td>
+    <td><ul><li>sans: (Arial, Verdana, Tahoma, "Trebuchet MS", Helvetica, Impact, Gill Sans)</li><li>serif: ("Times New Roman", Georgia, Garamond, Palatino, Baskerville)</li><li>sans-serif: (system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</li><li>monospace: (SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace)</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font families map</div></div>
     </td>
 </tr>
 </tbody>

--- a/packages/bootstrap/scss/core/_index.scss
+++ b/packages/bootstrap/scss/core/_index.scss
@@ -41,6 +41,12 @@
 
     $default-font-weights: $kendo-font-weights,
     $kendo-font-weights: $kendo-font-weights !default,
+    $kendo-font-weight: $kendo-font-weight !default,
+
+    $default-letter-spacings: $kendo-letter-spacings,
+    $kendo-letter-spacings: $kendo-letter-spacings !default,
+    $kendo-letter-spacing: $kendo-letter-spacing !default,
+
     // Border Radii
     $default-border-radii: $kendo-border-radii,
     $kendo-border-radii: $kendo-border-radii !default,

--- a/packages/bootstrap/scss/core/typography/index.scss
+++ b/packages/bootstrap/scss/core/typography/index.scss
@@ -3,6 +3,9 @@
 /// The base font size across all components.
 /// @group typography
 $kendo-font-size: 1rem !default;
+/// The extra extra small font size across all components.
+/// @group typography
+$kendo-font-size-xxs: ( $kendo-font-size * .5 ) !default;
 /// The extra small font size across all components.
 /// @group typography
 $kendo-font-size-xs: ( $kendo-font-size * .75 ) !default;
@@ -38,12 +41,21 @@ $kendo-line-height-lg: 2 !default;
 /// @group typography
 $kendo-line-height-em: calc( #{$kendo-line-height} * 1em ) !default;
 
+/// The base font weight across all components.
+/// @group typography
+$kendo-font-weight: 400 !default;
+/// The thin font weight across all components.
+/// @group typography
+$kendo-font-weight-thin: 100 !default;
+/// The extra light font weight across all components.
+/// @group typography
+$kendo-font-weight-extra-light: 200 !default;
 /// The light font weight across all components.
 /// @group typography
 $kendo-font-weight-light: 300 !default;
-/// The base font weight across all components.
+/// The normal font weight across all components.
 /// @group typography
-$kendo-font-weight-normal: 400 !default;
+$kendo-font-weight-normal: $kendo-font-weight !default;
 /// The medium font weight across all components.
 /// @group typography
 $kendo-font-weight-medium: 500 !default;
@@ -53,7 +65,44 @@ $kendo-font-weight-semibold: 600 !default;
 /// The bold font weight across all components.
 /// @group typography
 $kendo-font-weight-bold: 700 !default;
+/// The extra bold font weight across all components.
+/// @group typography
+$kendo-font-weight-extra-bold: 800 !default;
+/// The most pronounced font weight across all components.
+/// @group typography
+$kendo-font-weight-black: 900 !default;
 
+/// The base letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing: null !default;
+/// The tightest letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-tightest: -.15px !default;
+/// Slightly looser than the tighter letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-tighter: -.10px !default;
+/// Moderately tight letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-tight: -.5px !default;
+/// The normal letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-normal: 0px !default;
+/// Wide letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-wide: .5px !default;
+/// Slightly wider than the wide letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-wider: .10px !default;
+/// The widest letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-widest: .15px !default;
+
+/// The sans font family across all components.
+/// @group typography
+$kendo-font-family-sans: Arial, Verdana, Tahoma, "Trebuchet MS", Helvetica, Impact, Gill Sans !default;
+/// The serif font family across all components.
+/// @group typography
+$kendo-font-family-serif: "Times New Roman", Georgia, Garamond, Palatino, Baskerville !default;
 /// The sans-serif font family across all components.
 /// @group typography
 $kendo-font-family-sans-serif: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
@@ -65,6 +114,7 @@ $kendo-font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberati
 $kendo-font-family: $kendo-font-family-sans-serif !default;
 
 $_default-font-sizes: (
+    xxs: $kendo-font-size-xxs,
     xs: $kendo-font-size-xs,
     sm: $kendo-font-size-sm,
     md: $kendo-font-size-md,
@@ -80,14 +130,30 @@ $_default-line-heights: (
 ) !default;
 
 $_default-font-weights: (
+    thin: $kendo-font-weight-thin,
+    extra-light: $kendo-font-weight-extra-light,
     light: $kendo-font-weight-light,
     normal: $kendo-font-weight-normal,
     medium: $kendo-font-weight-medium,
     semibold: $kendo-font-weight-semibold,
-    bold: $kendo-font-weight-bold
+    bold: $kendo-font-weight-bold,
+    extra-bold: $kendo-font-weight-extra-bold,
+    "black": $kendo-font-weight-black
+) !default;
+
+$_default-letter-spacings: (
+    tightest: $kendo-letter-spacing-tightest,
+    tighter: $kendo-letter-spacing-tighter,
+    tight: $kendo-letter-spacing-tight,
+    normal: $kendo-letter-spacing-normal,
+    wide: $kendo-letter-spacing-wide,
+    wider: $kendo-letter-spacing-wider,
+    widest: $kendo-letter-spacing-widest
 ) !default;
 
 $_default-font-families: (
+    sans: $kendo-font-family-sans,
+    serif: $kendo-font-family-serif,
     sans-serif: $kendo-font-family-sans-serif,
     monospace: $kendo-font-family-monospace
 ) !default;
@@ -106,6 +172,11 @@ $kendo-line-heights: map.merge( $_default-line-heights, $kendo-line-heights );
 /// @group typography
 $kendo-font-weights: $_default-font-weights !default;
 $kendo-font-weights: map.merge( $_default-font-weights, $kendo-font-weights );
+
+/// The letter spacings map
+/// @group typography
+$kendo-letter-spacings: $_default-letter-spacings !default;
+$kendo-letter-spacings: map.merge( $_default-letter-spacings, $kendo-letter-spacings );
 
 /// The font families map
 /// @group typography

--- a/packages/fluent/docs/customization-common.md
+++ b/packages/fluent/docs/customization-common.md
@@ -117,26 +117,6 @@ The following table lists the available variables for customization.
     <td colspan="4" class="theme-variables-description-container"><div><b>Deprecated</b><div class="theme-variables-description">Use the `$kendo-elevation` map instead.</div></div><div><b>Description</b><div class="theme-variables-description">Shadow for focus window.</div></div>
     </td>
 </tr>
-<tr>
-    <td>$kendo-h5-font-family</td>
-    <td>String</td>
-    <td><code>var(--kendo-font-family)</code></td>
-    <td><code>var(--kendo-font-family)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font family of the fifth highest level heading.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-h6-line-height</td>
-    <td>Number</td>
-    <td><code>32px</code></td>
-    <td><code>32px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line height of the sixth highest level heading.</div></div>
-    </td>
-</tr>
 </tbody>
 </table>
 

--- a/packages/fluent/docs/customization-typography-component.md
+++ b/packages/fluent/docs/customization-typography-component.md
@@ -128,6 +128,16 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-h5-font-family</td>
+    <td>String</td>
+    <td><code>var(--kendo-font-family)</code></td>
+    <td><code>var(--kendo-font-family)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font family of the fifth highest level heading.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-h6-font-family</td>
     <td>String</td>
     <td><code>var(--kendo-font-family)</code></td>
@@ -188,7 +198,17 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
-    <td>$kendo-h2-font-weight</td>
+    <td>$kendo-h6-line-height</td>
+    <td>Number</td>
+    <td><code>32px</code></td>
+    <td><code>32px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line height of the sixth highest level heading.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-h1-font-weight</td>
     <td>String</td>
     <td><code>var(--kendo-font-weight-semibold)</code></td>
     <td><code>var(--kendo-font-weight-semibold)</code></td>
@@ -198,7 +218,7 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
-    <td>$kendo-h1-font-weight</td>
+    <td>$kendo-h2-font-weight</td>
     <td>String</td>
     <td><code>var(--kendo-font-weight-semibold)</code></td>
     <td><code>var(--kendo-font-weight-semibold)</code></td>

--- a/packages/fluent/docs/customization-typography.md
+++ b/packages/fluent/docs/customization-typography.md
@@ -38,6 +38,16 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-size-xxs</td>
+    <td>Number</td>
+    <td><code>0.5rem</code></td>
+    <td><code>0.5rem</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-size-xs</td>
     <td>Number</td>
     <td><code>0.625rem</code></td>
@@ -148,6 +158,36 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-weight</td>
+    <td>Number</td>
+    <td><code>400</code></td>
+    <td><code>400</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-weight-thin</td>
+    <td>Number</td>
+    <td><code>100</code></td>
+    <td><code>100</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The thin font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-weight-extra-light</td>
+    <td>Number</td>
+    <td><code>200</code></td>
+    <td><code>200</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra light font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-weight-light</td>
     <td>Number</td>
     <td><code>300</code></td>
@@ -160,11 +200,11 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-font-weight-normal</td>
     <td>Number</td>
-    <td><code>400</code></td>
+    <td><code>$kendo-font-weight</code></td>
     <td><code>400</code></td>
 </tr>
 <tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The normal font weight across all components.</div></div>
     </td>
 </tr>
 <tr>
@@ -198,86 +238,6 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
-    <td>$kendo-letter-spacing</td>
-    <td>String</td>
-    <td><code>normal</code></td>
-    <td><code>normal</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family</td>
-    <td>List</td>
-    <td><code>"Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif</code></td>
-    <td><code>("Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-sizes</td>
-    <td>Map</td>
-    <td><code>$_default-font-sizes</code></td>
-    <td><ul><li>xs: 0.625rem</li><li>sm: 0.75rem</li><li>md: 0.875rem</li><li>lg: 1rem</li><li>xl: 1.25rem</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-line-heights</td>
-    <td>Map</td>
-    <td><code>$_default-line-heights</code></td>
-    <td><ul><li>xs: 1</li><li>sm: 1.25</li><li>md: 1.4285714285714286</li><li>lg: 1.33</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-size-xxs</td>
-    <td>Number</td>
-    <td><code>0.5rem</code></td>
-    <td><code>0.5rem</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight</td>
-    <td>Number</td>
-    <td><code>400</code></td>
-    <td><code>400</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight-thin</td>
-    <td>Number</td>
-    <td><code>100</code></td>
-    <td><code>100</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The thin font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight-extra-light</td>
-    <td>Number</td>
-    <td><code>200</code></td>
-    <td><code>200</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra light font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-font-weight-extra-bold</td>
     <td>Number</td>
     <td><code>800</code></td>
@@ -295,6 +255,16 @@ The following table lists the available variables for customization.
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The most pronounced font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing</td>
+    <td>String</td>
+    <td><code>normal</code></td>
+    <td><code>normal</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base letter spacing across all components.</div></div>
     </td>
 </tr>
 <tr>
@@ -408,9 +378,39 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-family</td>
+    <td>List</td>
+    <td><code>"Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif</code></td>
+    <td><code>("Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-sizes</td>
+    <td>Map</td>
+    <td><code>$_default-font-sizes</code></td>
+    <td><ul><li>xxs: 0.5rem</li><li>xs: 0.625rem</li><li>sm: 0.75rem</li><li>md: 0.875rem</li><li>lg: 1rem</li><li>xl: 1.25rem</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-line-heights</td>
+    <td>Map</td>
+    <td><code>$_default-line-heights</code></td>
+    <td><ul><li>xs: 1</li><li>sm: 1.25</li><li>md: 1.4285714285714286</li><li>lg: 1.33</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-weights</td>
     <td>Map</td>
-    <td><code>$default-font-weights</code></td>
+    <td><code>$_default-font-weights</code></td>
     <td><ul><li>thin: 100</li><li>extra-light: 200</li><li>light: 300</li><li>normal: 400</li><li>medium: 500</li><li>semibold: 600</li><li>bold: 700</li><li>extra-bold: 800</li><li>black: 900</li></ul></td>
 </tr>
 <tr>
@@ -420,7 +420,7 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-letter-spacings</td>
     <td>Map</td>
-    <td><code>$default-letter-spacings</code></td>
+    <td><code>$_default-letter-spacings</code></td>
     <td><ul><li>tightest: -0.15px</li><li>tighter: -0.1px</li><li>tight: -0.5px</li><li>normal: 0px</li><li>wide: 0.5px</li><li>wider: 0.1px</li><li>widest: 0.15px</li></ul></td>
 </tr>
 <tr>
@@ -430,7 +430,7 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-font-families</td>
     <td>Map</td>
-    <td><code>$default-font-families</code></td>
+    <td><code>$_default-font-families</code></td>
     <td><ul><li>sans: (Arial, Verdana, Tahoma, "Trebuchet MS", Helvetica, Impact, Gill Sans)</li><li>serif: ("Times New Roman", Georgia, Garamond, Palatino, Baskerville)</li><li>sans-serif: (system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</li><li>monospace: (SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</li></ul></td>
 </tr>
 <tr>

--- a/packages/fluent/docs/customization.md
+++ b/packages/fluent/docs/customization.md
@@ -121,26 +121,6 @@ The following table lists the available variables for customizing the Fluent the
     <td colspan="4" class="theme-variables-description-container"><div><b>Deprecated</b><div class="theme-variables-description">Use the `$kendo-elevation` map instead.</div></div><div><b>Description</b><div class="theme-variables-description">Shadow for focus window.</div></div>
     </td>
 </tr>
-<tr>
-    <td>$kendo-h5-font-family</td>
-    <td>String</td>
-    <td><code>var(--kendo-font-family)</code></td>
-    <td><code>var(--kendo-font-family)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font family of the fifth highest level heading.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-h6-line-height</td>
-    <td>Number</td>
-    <td><code>32px</code></td>
-    <td><code>32px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line height of the sixth highest level heading.</div></div>
-    </td>
-</tr>
 </tbody>
 </table>
 
@@ -38375,6 +38355,16 @@ The following table lists the available variables for customizing the Fluent the
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-size-xxs</td>
+    <td>Number</td>
+    <td><code>0.5rem</code></td>
+    <td><code>0.5rem</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-size-xs</td>
     <td>Number</td>
     <td><code>0.625rem</code></td>
@@ -38485,6 +38475,36 @@ The following table lists the available variables for customizing the Fluent the
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-weight</td>
+    <td>Number</td>
+    <td><code>400</code></td>
+    <td><code>400</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-weight-thin</td>
+    <td>Number</td>
+    <td><code>100</code></td>
+    <td><code>100</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The thin font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-weight-extra-light</td>
+    <td>Number</td>
+    <td><code>200</code></td>
+    <td><code>200</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra light font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-weight-light</td>
     <td>Number</td>
     <td><code>300</code></td>
@@ -38497,11 +38517,11 @@ The following table lists the available variables for customizing the Fluent the
 <tr>
     <td>$kendo-font-weight-normal</td>
     <td>Number</td>
-    <td><code>400</code></td>
+    <td><code>$kendo-font-weight</code></td>
     <td><code>400</code></td>
 </tr>
 <tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The normal font weight across all components.</div></div>
     </td>
 </tr>
 <tr>
@@ -38535,86 +38555,6 @@ The following table lists the available variables for customizing the Fluent the
     </td>
 </tr>
 <tr>
-    <td>$kendo-letter-spacing</td>
-    <td>String</td>
-    <td><code>normal</code></td>
-    <td><code>normal</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family</td>
-    <td>List</td>
-    <td><code>"Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif</code></td>
-    <td><code>("Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-sizes</td>
-    <td>Map</td>
-    <td><code>$_default-font-sizes</code></td>
-    <td><ul><li>xs: 0.625rem</li><li>sm: 0.75rem</li><li>md: 0.875rem</li><li>lg: 1rem</li><li>xl: 1.25rem</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-line-heights</td>
-    <td>Map</td>
-    <td><code>$_default-line-heights</code></td>
-    <td><ul><li>xs: 1</li><li>sm: 1.25</li><li>md: 1.4285714285714286</li><li>lg: 1.33</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-size-xxs</td>
-    <td>Number</td>
-    <td><code>0.5rem</code></td>
-    <td><code>0.5rem</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight</td>
-    <td>Number</td>
-    <td><code>400</code></td>
-    <td><code>400</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight-thin</td>
-    <td>Number</td>
-    <td><code>100</code></td>
-    <td><code>100</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The thin font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-weight-extra-light</td>
-    <td>Number</td>
-    <td><code>200</code></td>
-    <td><code>200</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra light font weight across all components.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-font-weight-extra-bold</td>
     <td>Number</td>
     <td><code>800</code></td>
@@ -38632,6 +38572,16 @@ The following table lists the available variables for customizing the Fluent the
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The most pronounced font weight across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing</td>
+    <td>String</td>
+    <td><code>normal</code></td>
+    <td><code>normal</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base letter spacing across all components.</div></div>
     </td>
 </tr>
 <tr>
@@ -38745,9 +38695,39 @@ The following table lists the available variables for customizing the Fluent the
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-family</td>
+    <td>List</td>
+    <td><code>"Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif</code></td>
+    <td><code>("Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-sizes</td>
+    <td>Map</td>
+    <td><code>$_default-font-sizes</code></td>
+    <td><ul><li>xxs: 0.5rem</li><li>xs: 0.625rem</li><li>sm: 0.75rem</li><li>md: 0.875rem</li><li>lg: 1rem</li><li>xl: 1.25rem</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-line-heights</td>
+    <td>Map</td>
+    <td><code>$_default-line-heights</code></td>
+    <td><ul><li>xs: 1</li><li>sm: 1.25</li><li>md: 1.4285714285714286</li><li>lg: 1.33</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-weights</td>
     <td>Map</td>
-    <td><code>$default-font-weights</code></td>
+    <td><code>$_default-font-weights</code></td>
     <td><ul><li>thin: 100</li><li>extra-light: 200</li><li>light: 300</li><li>normal: 400</li><li>medium: 500</li><li>semibold: 600</li><li>bold: 700</li><li>extra-bold: 800</li><li>black: 900</li></ul></td>
 </tr>
 <tr>
@@ -38757,7 +38737,7 @@ The following table lists the available variables for customizing the Fluent the
 <tr>
     <td>$kendo-letter-spacings</td>
     <td>Map</td>
-    <td><code>$default-letter-spacings</code></td>
+    <td><code>$_default-letter-spacings</code></td>
     <td><ul><li>tightest: -0.15px</li><li>tighter: -0.1px</li><li>tight: -0.5px</li><li>normal: 0px</li><li>wide: 0.5px</li><li>wider: 0.1px</li><li>widest: 0.15px</li></ul></td>
 </tr>
 <tr>
@@ -38767,7 +38747,7 @@ The following table lists the available variables for customizing the Fluent the
 <tr>
     <td>$kendo-font-families</td>
     <td>Map</td>
-    <td><code>$default-font-families</code></td>
+    <td><code>$_default-font-families</code></td>
     <td><ul><li>sans: (Arial, Verdana, Tahoma, "Trebuchet MS", Helvetica, Impact, Gill Sans)</li><li>serif: ("Times New Roman", Georgia, Garamond, Palatino, Baskerville)</li><li>sans-serif: (system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</li><li>monospace: (SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</li></ul></td>
 </tr>
 <tr>
@@ -38895,6 +38875,16 @@ The following table lists the available variables for customizing the Fluent the
     </td>
 </tr>
 <tr>
+    <td>$kendo-h5-font-family</td>
+    <td>String</td>
+    <td><code>var(--kendo-font-family)</code></td>
+    <td><code>var(--kendo-font-family)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font family of the fifth highest level heading.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-h6-font-family</td>
     <td>String</td>
     <td><code>var(--kendo-font-family)</code></td>
@@ -38955,7 +38945,17 @@ The following table lists the available variables for customizing the Fluent the
     </td>
 </tr>
 <tr>
-    <td>$kendo-h2-font-weight</td>
+    <td>$kendo-h6-line-height</td>
+    <td>Number</td>
+    <td><code>32px</code></td>
+    <td><code>32px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line height of the sixth highest level heading.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-h1-font-weight</td>
     <td>String</td>
     <td><code>var(--kendo-font-weight-semibold)</code></td>
     <td><code>var(--kendo-font-weight-semibold)</code></td>
@@ -38965,7 +38965,7 @@ The following table lists the available variables for customizing the Fluent the
     </td>
 </tr>
 <tr>
-    <td>$kendo-h1-font-weight</td>
+    <td>$kendo-h2-font-weight</td>
     <td>String</td>
     <td><code>var(--kendo-font-weight-semibold)</code></td>
     <td><code>var(--kendo-font-weight-semibold)</code></td>

--- a/packages/fluent/scss/core/_index.scss
+++ b/packages/fluent/scss/core/_index.scss
@@ -37,6 +37,15 @@
 
     $kendo-letter-spacing: $kendo-letter-spacing !default,
 
+    $default-font-weights: $kendo-font-weights,
+    $kendo-font-weights: $kendo-font-weights !default,
+    $kendo-font-weight: $kendo-font-weight !default,
+
+    $default-letter-spacings: $kendo-letter-spacings,
+    $kendo-letter-spacings: $kendo-letter-spacings !default,
+
+    $default-font-families: $kendo-font-families,
+    $kendo-font-families: $kendo-font-families !default,
     $kendo-font-family: $kendo-font-family !default,
     // Spacing
     $default-spacing: $kendo-spacing,

--- a/packages/fluent/scss/core/typography/_index.scss
+++ b/packages/fluent/scss/core/typography/_index.scss
@@ -1,8 +1,12 @@
+@use "sass:map";
 @use "sass:math";
 
 /// The base font size across all components.
 /// @group typography
 $kendo-font-size: 0.875rem !default;
+/// The extra extra small font size across all components.
+/// @group typography
+$kendo-font-size-xxs: 0.5rem !default;
 /// The extra extra small font size across all components.
 /// @group typography
 $kendo-font-size-xs: 0.625rem !default;
@@ -38,12 +42,21 @@ $kendo-line-height-lg: 1.33 !default;
 /// @group typography
 $kendo-line-height-em: calc( #{$kendo-line-height} * 1em) !default;
 
+/// The base font weight across all components.
+/// @group typography
+$kendo-font-weight: 400 !default;
+/// The thin font weight across all components.
+/// @group typography
+$kendo-font-weight-thin: 100 !default;
+/// The extra light font weight across all components.
+/// @group typography
+$kendo-font-weight-extra-light: 200 !default;
 /// The light font weight across all components.
 /// @group typography
 $kendo-font-weight-light: 300 !default;
-/// The base font weight across all components.
+/// The normal font weight across all components.
 /// @group typography
-$kendo-font-weight-normal: 400 !default;
+$kendo-font-weight-normal: $kendo-font-weight !default;
 /// The medium font weight across all components.
 /// @group typography
 $kendo-font-weight-medium: 500 !default;
@@ -53,16 +66,57 @@ $kendo-font-weight-semibold: 600 !default;
 /// The bold font weight across all components.
 /// @group typography
 $kendo-font-weight-bold: 700 !default;
+/// The extra bold font weight across all components.
+/// @group typography
+$kendo-font-weight-extra-bold: 800 !default;
+/// The most pronounced font weight across all components.
+/// @group typography
+$kendo-font-weight-black: 900 !default;
 
 /// The base letter spacing across all components.
 /// @group typography
 $kendo-letter-spacing: normal !default;
+/// The tightest letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-tightest: -.15px !default;
+/// Slightly looser than the tighter letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-tighter: -.10px !default;
+/// Moderately tight letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-tight: -.5px !default;
+/// The normal letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-normal: 0px !default;
+/// Wide letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-wide: .5px !default;
+/// Slightly wider than the wide letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-wider: .10px !default;
+/// The widest letter spacing across all components.
+/// @group typography
+$kendo-letter-spacing-widest: .15px !default;
 
-/// The font family across all components.
+/// The sans font family across all components.
+/// @group typography
+$kendo-font-family-sans: Arial, Verdana, Tahoma, "Trebuchet MS", Helvetica, Impact, Gill Sans !default;
+/// The serif font family across all components.
+/// @group typography
+$kendo-font-family-serif: "Times New Roman", Georgia, Garamond, Palatino, Baskerville !default;
+/// The sans-serif font family across all components.
+/// @group typography
+$kendo-font-family-sans-serif: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
+/// The monospace font family across all components.
+/// @group typography
+$kendo-font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace !default;
+
+/// The base font family across all components.
 /// @group typography
 $kendo-font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif !default;
 
 $_default-font-sizes: (
+    xxs: $kendo-font-size-xxs,
     xs: $kendo-font-size-xs,
     sm: $kendo-font-size-sm,
     md: $kendo-font-size-md,
@@ -78,17 +132,55 @@ $_default-line-heights: (
 ) !default;
 
 $_default-font-weights: (
+    thin: $kendo-font-weight-thin,
+    extra-light: $kendo-font-weight-extra-light,
     light: $kendo-font-weight-light,
     normal: $kendo-font-weight-normal,
     medium: $kendo-font-weight-medium,
     semibold: $kendo-font-weight-semibold,
-    bold: $kendo-font-weight-bold
+    bold: $kendo-font-weight-bold,
+    extra-bold: $kendo-font-weight-extra-bold,
+    "black": $kendo-font-weight-black
+) !default;
+
+$_default-letter-spacings: (
+    tightest: $kendo-letter-spacing-tightest,
+    tighter: $kendo-letter-spacing-tighter,
+    tight: $kendo-letter-spacing-tight,
+    normal: $kendo-letter-spacing-normal,
+    wide: $kendo-letter-spacing-wide,
+    wider: $kendo-letter-spacing-wider,
+    widest: $kendo-letter-spacing-widest
+) !default;
+
+$_default-font-families: (
+    sans: $kendo-font-family-sans,
+    serif: $kendo-font-family-serif,
+    sans-serif: $kendo-font-family-sans-serif,
+    monospace: $kendo-font-family-monospace
 ) !default;
 
 /// The font sizes map
 /// @group typography
 $kendo-font-sizes: $_default-font-sizes !default;
+$kendo-font-sizes: map.merge( $_default-font-sizes, $kendo-font-sizes );
 
 /// The line heights map
 /// @group typography
 $kendo-line-heights: $_default-line-heights !default;
+$kendo-line-heights: map.merge( $_default-line-heights, $kendo-line-heights );
+
+/// The font weights map
+/// @group typography
+$kendo-font-weights: $_default-font-weights !default;
+$kendo-font-weights: map.merge( $_default-font-weights, $kendo-font-weights );
+
+/// The letter spacings map
+/// @group typography
+$kendo-letter-spacings: $_default-letter-spacings !default;
+$kendo-letter-spacings: map.merge( $_default-letter-spacings, $kendo-letter-spacings );
+
+/// The font families map
+/// @group typography
+$kendo-font-families: $_default-font-families !default;
+$kendo-font-families: map.merge( $_default-font-families, $kendo-font-families );

--- a/packages/fluent/scss/typography/_variables.scss
+++ b/packages/fluent/scss/typography/_variables.scss
@@ -37,7 +37,7 @@ $kendo-h3-font-family: var(--kendo-font-family) !default;
 /// @group typography-component
 $kendo-h4-font-family: var(--kendo-font-family) !default;
 /// The font family of the fifth highest level heading.
-///
+/// @group typography-component
 $kendo-h5-font-family: var(--kendo-font-family) !default;
 /// The font family of the sixth highest level heading.
 /// @group typography-component
@@ -59,14 +59,15 @@ $kendo-h4-line-height: 40px !default;
 /// @group typography-component
 $kendo-h5-line-height: 36px !default;
 /// The line height of the sixth highest level heading.
+/// @group typography-component
 $kendo-h6-line-height: 32px !default;
 
 /// The font weight of the highest level heading.
 /// @group typography-component
-$kendo-h2-font-weight: var(--kendo-font-weight-semibold) !default;
+$kendo-h1-font-weight: var(--kendo-font-weight-semibold) !default;
 /// The font weight of the second highest level heading.
 /// @group typography-component
-$kendo-h1-font-weight: var(--kendo-font-weight-semibold) !default;
+$kendo-h2-font-weight: var(--kendo-font-weight-semibold) !default;
 /// The font weight of the third highest level heading.
 /// @group typography-component
 $kendo-h3-font-weight: var(--kendo-font-weight-semibold) !default;

--- a/packages/material/docs/customization-typography.md
+++ b/packages/material/docs/customization-typography.md
@@ -38,6 +38,16 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-size-xxs</td>
+    <td>Number</td>
+    <td><code>0.5rem</code></td>
+    <td><code>0.5rem</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-size-xs</td>
     <td>Number</td>
     <td><code>0.625rem</code></td>
@@ -148,166 +158,6 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
-    <td>$kendo-letter-spacing</td>
-    <td>Null</td>
-    <td><code>null</code></td>
-    <td><code>null</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-tightest</td>
-    <td>Number</td>
-    <td><code>-.5px</code></td>
-    <td><code>-0.15px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tightest letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-tighter</td>
-    <td>Number</td>
-    <td><code>-.25px</code></td>
-    <td><code>-0.1px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Slightly looser than the tighter letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-tight</td>
-    <td>Number</td>
-    <td><code>-.1px</code></td>
-    <td><code>-0.5px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Moderately tight letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-normal</td>
-    <td>Number</td>
-    <td><code>.25px</code></td>
-    <td><code>0px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The normal letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-wide</td>
-    <td>Number</td>
-    <td><code>.1px</code></td>
-    <td><code>0.5px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Wide letter spacing across all components</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-wider</td>
-    <td>Number</td>
-    <td><code>.25px</code></td>
-    <td><code>0.1px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Slightly wider than the wide letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-widest</td>
-    <td>Number</td>
-    <td><code>.5px</code></td>
-    <td><code>0.15px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The widest letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family-sans-serif</td>
-    <td>List</td>
-    <td><code>Roboto, "Helvetica Neue", sans-serif</code></td>
-    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sans-serif font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family-monospace</td>
-    <td>List</td>
-    <td><code>Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace</code></td>
-    <td><code>(SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The monospace font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family</td>
-    <td>List</td>
-    <td><code>$kendo-font-family-sans-serif</code></td>
-    <td><code>(Roboto, "Helvetica Neue", sans-serif)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-sizes</td>
-    <td>Map</td>
-    <td><code>$_default-font-sizes</code></td>
-    <td><ul><li>xs: 0.625rem</li><li>sm: 0.75rem</li><li>md: 0.875rem</li><li>lg: 1rem</li><li>xl: 1.25rem</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-line-heights</td>
-    <td>Map</td>
-    <td><code>$_default-line-heights</code></td>
-    <td><ul><li>xs: 1</li><li>sm: 1.33</li><li>md: 1.4285714285714286</li><li>lg: 1.5</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacings</td>
-    <td>Map</td>
-    <td><code>$_default-letter-spacings</code></td>
-    <td><ul><li>tightest: -0.5px</li><li>tighter: -0.25px</li><li>tight: -0.1px</li><li>normal: 0.25px</li><li>wide: 0.1px</li><li>wider: 0.25px</li><li>widest: 0.5px</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The letter spacings map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-families</td>
-    <td>Map</td>
-    <td><code>$_default-font-families</code></td>
-    <td><ul><li>sans-serif: (Roboto, "Helvetica Neue", sans-serif)</li><li>monospace: (Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font families map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-size-xxs</td>
-    <td>Number</td>
-    <td><code>0.5rem</code></td>
-    <td><code>0.5rem</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-font-weight</td>
     <td>Number</td>
     <td><code>400</code></td>
@@ -408,6 +258,86 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-letter-spacing</td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-tightest</td>
+    <td>Number</td>
+    <td><code>-.5px</code></td>
+    <td><code>-0.15px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tightest letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-tighter</td>
+    <td>Number</td>
+    <td><code>-.25px</code></td>
+    <td><code>-0.1px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Slightly looser than the tighter letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-tight</td>
+    <td>Number</td>
+    <td><code>-.1px</code></td>
+    <td><code>-0.5px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Moderately tight letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-normal</td>
+    <td>Number</td>
+    <td><code>.25px</code></td>
+    <td><code>0px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The normal letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-wide</td>
+    <td>Number</td>
+    <td><code>.1px</code></td>
+    <td><code>0.5px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Wide letter spacing across all components</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-wider</td>
+    <td>Number</td>
+    <td><code>.25px</code></td>
+    <td><code>0.1px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Slightly wider than the wide letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-widest</td>
+    <td>Number</td>
+    <td><code>.5px</code></td>
+    <td><code>0.15px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The widest letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-family-sans</td>
     <td>List</td>
     <td><code>Arial, Verdana, Tahoma, "Trebuchet MS", Helvetica, Impact, Gill Sans</code></td>
@@ -428,13 +358,83 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-family-sans-serif</td>
+    <td>List</td>
+    <td><code>Roboto, "Helvetica Neue", sans-serif</code></td>
+    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sans-serif font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-family-monospace</td>
+    <td>List</td>
+    <td><code>Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace</code></td>
+    <td><code>(SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The monospace font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-family</td>
+    <td>List</td>
+    <td><code>$kendo-font-family-sans-serif</code></td>
+    <td><code>(Roboto, "Helvetica Neue", sans-serif)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-sizes</td>
+    <td>Map</td>
+    <td><code>$_default-font-sizes</code></td>
+    <td><ul><li>xxs: 0.5rem</li><li>xs: 0.625rem</li><li>sm: 0.75rem</li><li>md: 0.875rem</li><li>lg: 1rem</li><li>xl: 1.25rem</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-line-heights</td>
+    <td>Map</td>
+    <td><code>$_default-line-heights</code></td>
+    <td><ul><li>xs: 1</li><li>sm: 1.33</li><li>md: 1.4285714285714286</li><li>lg: 1.5</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacings</td>
+    <td>Map</td>
+    <td><code>$_default-letter-spacings</code></td>
+    <td><ul><li>tightest: -0.5px</li><li>tighter: -0.25px</li><li>tight: -0.1px</li><li>normal: 0.25px</li><li>wide: 0.1px</li><li>wider: 0.25px</li><li>widest: 0.5px</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The letter spacings map</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-weights</td>
     <td>Map</td>
-    <td><code>$default-font-weights</code></td>
+    <td><code>$_default-font-weights</code></td>
     <td><ul><li>thin: 100</li><li>extra-light: 200</li><li>light: 300</li><li>normal: 400</li><li>medium: 500</li><li>semibold: 600</li><li>bold: 700</li><li>extra-bold: 800</li><li>black: 900</li></ul></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font weights map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-families</td>
+    <td>Map</td>
+    <td><code>$_default-font-families</code></td>
+    <td><ul><li>sans: (Arial, Verdana, Tahoma, "Trebuchet MS", Helvetica, Impact, Gill Sans)</li><li>serif: ("Times New Roman", Georgia, Garamond, Palatino, Baskerville)</li><li>sans-serif: (Roboto, "Helvetica Neue", sans-serif)</li><li>monospace: (Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font families map</div></div>
     </td>
 </tr>
 </tbody>

--- a/packages/material/docs/customization.md
+++ b/packages/material/docs/customization.md
@@ -37610,6 +37610,16 @@ The following table lists the available variables for customizing the Material t
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-size-xxs</td>
+    <td>Number</td>
+    <td><code>0.5rem</code></td>
+    <td><code>0.5rem</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-size-xs</td>
     <td>Number</td>
     <td><code>0.625rem</code></td>
@@ -37720,166 +37730,6 @@ The following table lists the available variables for customizing the Material t
     </td>
 </tr>
 <tr>
-    <td>$kendo-letter-spacing</td>
-    <td>Null</td>
-    <td><code>null</code></td>
-    <td><code>null</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-tightest</td>
-    <td>Number</td>
-    <td><code>-.5px</code></td>
-    <td><code>-0.15px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tightest letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-tighter</td>
-    <td>Number</td>
-    <td><code>-.25px</code></td>
-    <td><code>-0.1px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Slightly looser than the tighter letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-tight</td>
-    <td>Number</td>
-    <td><code>-.1px</code></td>
-    <td><code>-0.5px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Moderately tight letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-normal</td>
-    <td>Number</td>
-    <td><code>.25px</code></td>
-    <td><code>0px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The normal letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-wide</td>
-    <td>Number</td>
-    <td><code>.1px</code></td>
-    <td><code>0.5px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Wide letter spacing across all components</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-wider</td>
-    <td>Number</td>
-    <td><code>.25px</code></td>
-    <td><code>0.1px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Slightly wider than the wide letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacing-widest</td>
-    <td>Number</td>
-    <td><code>.5px</code></td>
-    <td><code>0.15px</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The widest letter spacing across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family-sans-serif</td>
-    <td>List</td>
-    <td><code>Roboto, "Helvetica Neue", sans-serif</code></td>
-    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sans-serif font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family-monospace</td>
-    <td>List</td>
-    <td><code>Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace</code></td>
-    <td><code>(SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The monospace font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-family</td>
-    <td>List</td>
-    <td><code>$kendo-font-family-sans-serif</code></td>
-    <td><code>(Roboto, "Helvetica Neue", sans-serif)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font family across all components.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-sizes</td>
-    <td>Map</td>
-    <td><code>$_default-font-sizes</code></td>
-    <td><ul><li>xs: 0.625rem</li><li>sm: 0.75rem</li><li>md: 0.875rem</li><li>lg: 1rem</li><li>xl: 1.25rem</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-line-heights</td>
-    <td>Map</td>
-    <td><code>$_default-line-heights</code></td>
-    <td><ul><li>xs: 1</li><li>sm: 1.33</li><li>md: 1.4285714285714286</li><li>lg: 1.5</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-letter-spacings</td>
-    <td>Map</td>
-    <td><code>$_default-letter-spacings</code></td>
-    <td><ul><li>tightest: -0.5px</li><li>tighter: -0.25px</li><li>tight: -0.1px</li><li>normal: 0.25px</li><li>wide: 0.1px</li><li>wider: 0.25px</li><li>widest: 0.5px</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The letter spacings map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-families</td>
-    <td>Map</td>
-    <td><code>$_default-font-families</code></td>
-    <td><ul><li>sans-serif: (Roboto, "Helvetica Neue", sans-serif)</li><li>monospace: (Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</li></ul></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font families map</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-font-size-xxs</td>
-    <td>Number</td>
-    <td><code>0.5rem</code></td>
-    <td><code>0.5rem</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The extra extra small font size across all components.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-font-weight</td>
     <td>Number</td>
     <td><code>400</code></td>
@@ -37980,6 +37830,86 @@ The following table lists the available variables for customizing the Material t
     </td>
 </tr>
 <tr>
+    <td>$kendo-letter-spacing</td>
+    <td>Null</td>
+    <td><code>null</code></td>
+    <td><code>null</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-tightest</td>
+    <td>Number</td>
+    <td><code>-.5px</code></td>
+    <td><code>-0.15px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The tightest letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-tighter</td>
+    <td>Number</td>
+    <td><code>-.25px</code></td>
+    <td><code>-0.1px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Slightly looser than the tighter letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-tight</td>
+    <td>Number</td>
+    <td><code>-.1px</code></td>
+    <td><code>-0.5px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Moderately tight letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-normal</td>
+    <td>Number</td>
+    <td><code>.25px</code></td>
+    <td><code>0px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The normal letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-wide</td>
+    <td>Number</td>
+    <td><code>.1px</code></td>
+    <td><code>0.5px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Wide letter spacing across all components</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-wider</td>
+    <td>Number</td>
+    <td><code>.25px</code></td>
+    <td><code>0.1px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Slightly wider than the wide letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacing-widest</td>
+    <td>Number</td>
+    <td><code>.5px</code></td>
+    <td><code>0.15px</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The widest letter spacing across all components.</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-family-sans</td>
     <td>List</td>
     <td><code>Arial, Verdana, Tahoma, "Trebuchet MS", Helvetica, Impact, Gill Sans</code></td>
@@ -38000,13 +37930,83 @@ The following table lists the available variables for customizing the Material t
     </td>
 </tr>
 <tr>
+    <td>$kendo-font-family-sans-serif</td>
+    <td>List</td>
+    <td><code>Roboto, "Helvetica Neue", sans-serif</code></td>
+    <td><code>(system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji")</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The sans-serif font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-family-monospace</td>
+    <td>List</td>
+    <td><code>Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace</code></td>
+    <td><code>(SFMono-Regular, Menlo, Monaco, Consolas, "Roboto Mono", "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The monospace font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-family</td>
+    <td>List</td>
+    <td><code>$kendo-font-family-sans-serif</code></td>
+    <td><code>(Roboto, "Helvetica Neue", sans-serif)</code></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The base font family across all components.</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-sizes</td>
+    <td>Map</td>
+    <td><code>$_default-font-sizes</code></td>
+    <td><ul><li>xxs: 0.5rem</li><li>xs: 0.625rem</li><li>sm: 0.75rem</li><li>md: 0.875rem</li><li>lg: 1rem</li><li>xl: 1.25rem</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font sizes map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-line-heights</td>
+    <td>Map</td>
+    <td><code>$_default-line-heights</code></td>
+    <td><ul><li>xs: 1</li><li>sm: 1.33</li><li>md: 1.4285714285714286</li><li>lg: 1.5</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The line heights map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-letter-spacings</td>
+    <td>Map</td>
+    <td><code>$_default-letter-spacings</code></td>
+    <td><ul><li>tightest: -0.5px</li><li>tighter: -0.25px</li><li>tight: -0.1px</li><li>normal: 0.25px</li><li>wide: 0.1px</li><li>wider: 0.25px</li><li>widest: 0.5px</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The letter spacings map</div></div>
+    </td>
+</tr>
+<tr>
     <td>$kendo-font-weights</td>
     <td>Map</td>
-    <td><code>$default-font-weights</code></td>
+    <td><code>$_default-font-weights</code></td>
     <td><ul><li>thin: 100</li><li>extra-light: 200</li><li>light: 300</li><li>normal: 400</li><li>medium: 500</li><li>semibold: 600</li><li>bold: 700</li><li>extra-bold: 800</li><li>black: 900</li></ul></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font weights map</div></div>
+    </td>
+</tr>
+<tr>
+    <td>$kendo-font-families</td>
+    <td>Map</td>
+    <td><code>$_default-font-families</code></td>
+    <td><ul><li>sans: (Arial, Verdana, Tahoma, "Trebuchet MS", Helvetica, Impact, Gill Sans)</li><li>serif: ("Times New Roman", Georgia, Garamond, Palatino, Baskerville)</li><li>sans-serif: (Roboto, "Helvetica Neue", sans-serif)</li><li>monospace: (Consolas, "Ubuntu Mono", "Lucida Console", "Courier New", monospace)</li></ul></td>
+</tr>
+<tr>
+    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The font families map</div></div>
     </td>
 </tr>
 </tbody>

--- a/packages/material/scss/core/_index.scss
+++ b/packages/material/scss/core/_index.scss
@@ -39,6 +39,10 @@
     $kendo-letter-spacings: $kendo-letter-spacings !default,
     $kendo-letter-spacing: $kendo-letter-spacing !default,
 
+    $default-font-weights: $kendo-font-weights,
+    $kendo-font-weights: $kendo-font-weights !default,
+    $kendo-font-weight: $kendo-font-weight !default,
+
     $default-font-families: $kendo-font-families,
     $kendo-font-families: $kendo-font-families !default,
     $kendo-font-family: $kendo-font-family !default,

--- a/packages/material/scss/core/typography/index.scss
+++ b/packages/material/scss/core/typography/index.scss
@@ -5,6 +5,9 @@
 $kendo-font-size: 0.875rem !default;
 /// The extra extra small font size across all components.
 /// @group typography
+$kendo-font-size-xxs: 0.5rem !default;
+/// The extra extra small font size across all components.
+/// @group typography
 $kendo-font-size-xs: 0.625rem !default;
 /// The small font size across all components.
 /// @group typography
@@ -38,6 +41,37 @@ $kendo-line-height-lg: 1.5 !default;
 /// @group typography
 $kendo-line-height-em: calc( #{$kendo-line-height} * 1em ) !default;
 
+/// The base font weight across all components.
+/// @group typography
+$kendo-font-weight: 400 !default;
+/// The thin font weight across all components.
+/// @group typography
+$kendo-font-weight-thin: 100 !default;
+/// The extra light font weight across all components.
+/// @group typography
+$kendo-font-weight-extra-light: 200 !default;
+/// The light font weight across all components.
+/// @group typography
+$kendo-font-weight-light: 300 !default;
+/// The normal font weight across all components.
+/// @group typography
+$kendo-font-weight-normal: $kendo-font-weight !default;
+/// The medium font weight across all components.
+/// @group typography
+$kendo-font-weight-medium: 500 !default;
+/// The semibold font weight across all components.
+/// @group typography
+$kendo-font-weight-semibold: 600 !default;
+/// The bold font weight across all components.
+/// @group typography
+$kendo-font-weight-bold: 700 !default;
+/// The extra bold font weight across all components.
+/// @group typography
+$kendo-font-weight-extra-bold: 800 !default;
+/// The most pronounced font weight across all components.
+/// @group typography
+$kendo-font-weight-black: 900 !default;
+
 /// The base letter spacing across all components.
 /// @group typography
 $kendo-letter-spacing: null !default;
@@ -63,6 +97,12 @@ $kendo-letter-spacing-wider: .25px !default;
 /// @group typography
 $kendo-letter-spacing-widest: .5px !default;
 
+/// The sans font family across all components.
+/// @group typography
+$kendo-font-family-sans: Arial, Verdana, Tahoma, "Trebuchet MS", Helvetica, Impact, Gill Sans !default;
+/// The serif font family across all components.
+/// @group typography
+$kendo-font-family-serif: "Times New Roman", Georgia, Garamond, Palatino, Baskerville !default;
 /// The sans-serif font family across all components.
 /// @group typography
 $kendo-font-family-sans-serif: Roboto, "Helvetica Neue", sans-serif !default;
@@ -74,6 +114,7 @@ $kendo-font-family-monospace: Consolas, "Ubuntu Mono", "Lucida Console", "Courie
 $kendo-font-family: $kendo-font-family-sans-serif !default;
 
 $_default-font-sizes: (
+    xxs: $kendo-font-size-xxs,
     xs: $kendo-font-size-xs,
     sm: $kendo-font-size-sm,
     md: $kendo-font-size-md,
@@ -88,6 +129,18 @@ $_default-line-heights: (
     lg: $kendo-line-height-lg,
 ) !default;
 
+$_default-font-weights: (
+    thin: $kendo-font-weight-thin,
+    extra-light: $kendo-font-weight-extra-light,
+    light: $kendo-font-weight-light,
+    normal: $kendo-font-weight-normal,
+    medium: $kendo-font-weight-medium,
+    semibold: $kendo-font-weight-semibold,
+    bold: $kendo-font-weight-bold,
+    extra-bold: $kendo-font-weight-extra-bold,
+    "black": $kendo-font-weight-black
+) !default;
+
 $_default-letter-spacings: (
     tightest: $kendo-letter-spacing-tightest,
     tighter: $kendo-letter-spacing-tighter,
@@ -99,6 +152,8 @@ $_default-letter-spacings: (
 ) !default;
 
 $_default-font-families: (
+    sans: $kendo-font-family-sans,
+    serif: $kendo-font-family-serif,
     sans-serif: $kendo-font-family-sans-serif,
     monospace: $kendo-font-family-monospace
 ) !default;
@@ -117,6 +172,11 @@ $kendo-line-heights: map.merge( $_default-line-heights, $kendo-line-heights );
 /// @group typography
 $kendo-letter-spacings: $_default-letter-spacings !default;
 $kendo-letter-spacings: map.merge( $_default-letter-spacings, $kendo-letter-spacings );
+
+/// The font weights map
+/// @group typography
+$kendo-font-weights: $_default-font-weights !default;
+$kendo-font-weights: map.merge( $_default-font-weights, $kendo-font-weights );
 
 /// The font families map
 /// @group typography


### PR DESCRIPTION
Add missing core typography design tokens to Bootstrap, Material, and Fluent themes to achieve full parity with Core and Classic.

Full discrepancy report here:

<details>

### 1. Font Weight Scale

| Token | Core | Classic | Bootstrap | Material | Fluent |
|-------|------|---------|-----------|----------|--------|
| `$kendo-font-weight` (base) | ✅ 400 | ✅ | ❌ missing | ❌ missing | ❌ missing |
| `thin` (100) | ✅ | ✅ | ❌ | ❌ | ❌ |
| `extra-light` (200) | ✅ | ✅ | ❌ | ❌ | ❌ |
| `light` (300) | ✅ | ✅ | ✅ | ❌ | ✅ |
| `normal` (400) | ✅ | ✅ | ✅ | ❌ | ✅ |
| `medium` (500) | ✅ | ✅ | ✅ | ❌ | ✅ |
| `semibold` (600) | ✅ | ✅ | ✅ | ❌ | ✅ |
| `bold` (700) | ✅ | ✅ | ✅ | ❌ | ✅ |
| `extra-bold` (800) | ✅ | ✅ | ❌ | ❌ | ❌ |
| `black` (900) | ✅ | ✅ | ❌ | ❌ | ❌ |

**Material has zero font-weight tokens** — entirely missing. Bootstrap & Fluent are missing the extremes (thin, extra-light, extra-bold, black) and the base `$kendo-font-weight`.

### 2. Letter Spacing Scale

| Token | Core | Classic | Bootstrap | Material | Fluent |
|-------|------|---------|-----------|----------|--------|
| `tightest` | ✅ | ✅ | ❌ | ✅ | ❌ |
| `tighter` | ✅ | ✅ | ❌ | ✅ | ❌ |
| `tight` | ✅ | ✅ | ❌ | ✅ | ❌ |
| `normal` | ✅ | ✅ | ❌ | ✅ | ❌ |
| `wide` | ✅ | ✅ | ❌ | ✅ | ❌ |
| `wider` | ✅ | ✅ | ❌ | ✅ | ❌ |
| `widest` | ✅ | ✅ | ❌ | ✅ | ❌ |

**Bootstrap has zero letter-spacing scale tokens.** Fluent only defines the base `$kendo-letter-spacing: normal` but no scale values (tightest through widest).

### 3. Font Family Tokens

| Token | Core | Classic | Bootstrap | Material | Fluent |
|-------|------|---------|-----------|----------|--------|
| `sans` | ✅ | ✅ | ❌ | ❌ | ❌ |
| `serif` | ✅ | ✅ | ❌ | ❌ | ❌ |
| `sans-serif` | ✅ | ✅ | ✅ | ✅ | ❌ |
| `monospace` | ✅ | ✅ | ✅ | ✅ | ❌ |

Fluent defines no named font-family tokens at all (only the base `$kendo-font-family`).

### 4. Font Size Scale

| Token | Core | Classic | Bootstrap | Material | Fluent |
|-------|------|---------|-----------|----------|--------|
| `xxs` | ✅ | ✅ | ❌ | ❌ | ❌ |
| `xs`–`xl` | ✅ | ✅ | ✅ | ✅ | ✅ |

Bootstrap, Material, and Fluent are all **missing `$kendo-font-size-xxs`**.

</details>