### PR TITLE
chore: remove postcss-calc plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "nunjucks": "^3.2.3",
         "nx": "^22.0.1",
         "postcss": "^8.4.47",
-        "postcss-calc": "^10.0.2",
         "postcss-cli": "^11.0.0",
         "postcss-selector-parser": "^7.1.0",
         "sass": "^1.93.3",
@@ -16232,23 +16231,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss-calc": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
-      "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^7.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12 || ^20.9 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.38"
       }
     },
     "node_modules/postcss-cli": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "nunjucks": "^3.2.3",
     "nx": "^22.0.1",
     "postcss": "^8.4.47",
-    "postcss-calc": "^10.0.2",
     "postcss-cli": "^11.0.0",
     "postcss-selector-parser": "^7.1.0",
     "sass": "^1.93.3",

--- a/packages/fluent/docs/customization-image-editor.md
+++ b/packages/fluent/docs/customization-image-editor.md
@@ -170,8 +170,8 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-image-editor-content-border-width</td>
     <td>Number</td>
-    <td><code>0</code></td>
-    <td><code>0</code></td>
+    <td><code>0px</code></td>
+    <td><code>0px</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Imageeditor content border width.</div></div>
@@ -230,8 +230,8 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-image-editor-action-pane-width</td>
     <td>String</td>
-    <td><code>var( --kendo-image-editor-action-pane-width, if( #{$kendo-image-editor-content-border-width} == 0, 270px, calc( 270px + #{$kendo-image-editor-content-border-width}) ) )</code></td>
-    <td><code>var(--kendo-image-editor-action-pane-width, calc(270px + 0))</code></td>
+    <td><code>var( --kendo-image-editor-action-pane-width, calc( 270px + #{$kendo-image-editor-content-border-width}) )</code></td>
+    <td><code>var(--kendo-image-editor-action-pane-width, calc(270px + 0px))</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Imageeditor action pane width.</div></div>

--- a/packages/fluent/docs/customization.md
+++ b/packages/fluent/docs/customization.md
@@ -18635,8 +18635,8 @@ The following table lists the available variables for customizing the Fluent the
 <tr>
     <td>$kendo-image-editor-content-border-width</td>
     <td>Number</td>
-    <td><code>0</code></td>
-    <td><code>0</code></td>
+    <td><code>0px</code></td>
+    <td><code>0px</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Imageeditor content border width.</div></div>
@@ -18695,8 +18695,8 @@ The following table lists the available variables for customizing the Fluent the
 <tr>
     <td>$kendo-image-editor-action-pane-width</td>
     <td>String</td>
-    <td><code>var( --kendo-image-editor-action-pane-width, if( #{$kendo-image-editor-content-border-width} == 0, 270px, calc( 270px + #{$kendo-image-editor-content-border-width}) ) )</code></td>
-    <td><code>var(--kendo-image-editor-action-pane-width, calc(270px + 0))</code></td>
+    <td><code>var( --kendo-image-editor-action-pane-width, calc( 270px + #{$kendo-image-editor-content-border-width}) )</code></td>
+    <td><code>var(--kendo-image-editor-action-pane-width, calc(270px + 0px))</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">Imageeditor action pane width.</div></div>

--- a/packages/fluent/scss/imageeditor/_variables.scss
+++ b/packages/fluent/scss/imageeditor/_variables.scss
@@ -48,7 +48,7 @@ $kendo-image-editor-content-text: var( --kendo-image-editor-content-text, inheri
 $kendo-image-editor-content-border: var( --kendo-image-editor-content-border, inherit ) !default;
 /// Imageeditor content border width.
 /// @group image-editor
-$kendo-image-editor-content-border-width: 0 !default;
+$kendo-image-editor-content-border-width: 0px !default;
 
 /// Imageeditor action pane background color.
 /// @group image-editor
@@ -67,7 +67,7 @@ $kendo-image-editor-action-pane-padding-y: var( --kendo-image-editor-action-pane
 $kendo-image-editor-action-pane-padding-x: var( --kendo-image-editor-action-pane-padding-x, #{k-spacing(3)} ) !default;
 /// Imageeditor action pane width.
 /// @group image-editor
-$kendo-image-editor-action-pane-width: var( --kendo-image-editor-action-pane-width, if( #{$kendo-image-editor-content-border-width} == 0, 270px, calc( 270px + #{$kendo-image-editor-content-border-width}) ) ) !default;
+$kendo-image-editor-action-pane-width: var( --kendo-image-editor-action-pane-width, calc( 270px + #{$kendo-image-editor-content-border-width}) ) !default;
 
 /// Crop background color of the imageeditor.
 /// @group image-editor

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,11 +1,7 @@
 const autoprefixer = require('autoprefixer');
-const calc = require('postcss-calc');
 
 module.exports = {
     plugins: [
-        calc({
-            precision: 10
-        }),
         autoprefixer()
     ]
 };


### PR DESCRIPTION
closes: https://progresssoftware.atlassian.net/browse/FE-363

With the introduction of  OKLCH relative color syntax, the postcss-calc provides negligible value while actively causing problems:

- OKLCH warnings — The plugin produces warnings when encountering relative OKLCH color syntax (oklch(from var(...) calc(l + 0.1) c h)), as it attempts to parse and reduce calc() expressions inside color functions it doesn't understand.

- Minimal impact — An audit of the compiled CSS shows only 89 reducible expressions per theme (e.g., calc(16px * 0.75) → 12px), totaling **873 bytes** out of 810 KB uncompressed — a 0.1% difference that effectively disappears after gzip.

- No runtime cost — These remaining literal calc() expressions are evaluated by the browser once at parse time, so there is no performance impact.

### Changes in the compiled CSS:
**Before**: calc(16px * 0.75) was resolved to 12px in the output
**After**: calc(16px * 0.75) remains as-is — functionally identical, negligible size difference