### PR TITLE
fix(menu): update options to include scrollable property and remove unused modifier

### DIFF
--- a/packages/html/src/menu/demos/menu.tsx
+++ b/packages/html/src/menu/demos/menu.tsx
@@ -5,7 +5,10 @@ import { MenuSeparator } from '../menu-separator.spec';
 import { MenuNormal } from '../templates/menu-normal';
 import { Popup } from '../../popup';
 
-const options = Menu.options;
+const options = {
+    ...Menu.options,
+    scrollable: { type: 'boolean' },
+};
 const states = Menu.states;
 const defaults = {
     ...Menu.defaultOptions,
@@ -25,10 +28,6 @@ const variants = [
 
 const modifiers = [
     {
-        name: 'scrollable',
-        title: 'Scrollable',
-    },
-    {
         name: 'opened',
         title: 'Opened',
     },
@@ -42,14 +41,8 @@ export const MenuDemo = (
     const { variant, modifiers: mods, ...other } = { ...defaults, ...props };
 
     let additionalProps: any = {};
-
     Object.keys(mods || {}).forEach((modifier) => {
         switch (modifier) {
-            case 'scrollable':
-                additionalProps.scrollable = mods?.[modifier] ? true : false;
-
-                break;
-
             case 'opened':
                 additionalProps.opened = mods?.[modifier] ? true : false;
                 additionalProps.popup = (


### PR DESCRIPTION
This pull request makes small adjustments to the menu demo configuration in `menu.tsx`, primarily related to the handling of the `scrollable` modifier. The changes simplify the demo by removing the explicit handling and presentation of the `scrollable` modifier while still allowing it to be set through the options.

Key changes:

**Menu options and modifiers refactor:**
* Added `scrollable` as a boolean type to the `options` object, allowing it to be set as an option without being a visible modifier in the UI.
* Removed the `scrollable` modifier from the `modifiers` array, so it is no longer presented as a toggle in the demo UI.
* Removed the explicit case for handling the `scrollable` modifier in the `MenuDemo` component, streamlining the code and relying on the new options structure.This PR updates the Menu demo configuration to expose the scrollable option through the component options instead of handling it as a demo modifier.