### PR TITLE
chore(skills): mark .github/skills as internal to hide from skill.sh discovery

### DIFF
--- a/.github/skills/audit-design-tokens/SKILL.md
+++ b/.github/skills/audit-design-tokens/SKILL.md
@@ -3,6 +3,8 @@ name: audit-design-tokens
 description: Audit and report on design token usage (color, spacing, typography, elevation, border-radius) across SCSS packages. Scans for hardcoded values (hex colors, raw px/rem, font stacks, literal box-shadows) that should use design token functions like k-spacing(), k-color(), k-elevation(), k-border-radius(), or $kendo-* variables. Use this skill when the user wants to find hardcoded colors, audit spacing tokens, check typography consistency, or enforce token usage.
 argument-hint: "[component-or-package] [--category color|spacing|typography|elevation|border-radius]"
 compatibility: Requires bash, grep, awk, sed (macOS or Linux)
+metadata:
+  internal: true
 ---
 
 # Design Token Audit

--- a/.github/skills/manage-components/SKILL.md
+++ b/.github/skills/manage-components/SKILL.md
@@ -2,6 +2,8 @@
 name: manage-components
 description: Create or update a Kendo UI component across kendo-themes packages. For new components, scaffolds core skeleton with null variables, theme overrides for targeted themes, HTML spec, templates, visual tests, and unit tests. For existing components, audits the current state, produces a change plan, and applies SCSS variable changes, layout/theme updates, HTML spec modifications, and test additions. Use this skill when the user wants to add a new component, update a component's design, change styling values, add new states or options, or align a component with design assets.
 argument-hint: "[component-name] e.g. chip, button, info-bar"
+metadata:
+  internal: true
 ---
 
 # Component

--- a/.github/skills/manage-html-a11y/SKILL.md
+++ b/.github/skills/manage-html-a11y/SKILL.md
@@ -3,6 +3,8 @@ name: manage-html-a11y
 description: Create or update ARIA accessibility attributes and tests for a Kendo UI component. Reads the ARIA reference doc, builds ariaSpec rules on the HTML spec, applies attributes to TSX templates, and validates with the a11y test runner until all violations and coverage gaps are resolved. Use this skill when the user wants to add accessibility support, fix ARIA violations, update ariaSpec rules, or ensure a component is WCAG 2.2 Level AA compliant.
 argument-hint: "[component] e.g. button, checkbox, grid"
 compatibility: Requires Node.js with npm, and a built HTML package
+metadata:
+  internal: true
 ---
 
 # Add Accessibility

--- a/.github/skills/manage-html-specs/SKILL.md
+++ b/.github/skills/manage-html-specs/SKILL.md
@@ -2,6 +2,8 @@
 name: manage-html-specs
 description: Create or update an HTML component specification (.spec.tsx) in the HTML package. Defines the component's TypeScript types, options, states, render function, constants, and index exports. Use this skill when the user wants to create a new HTML spec, add states/options to a component, or modify a component's HTML structure.
 argument-hint: "[component] e.g. button, chip, grid"
+metadata:
+  internal: true
 ---
 
 # Add HTML Component Spec

--- a/.github/skills/manage-html-templates/SKILL.md
+++ b/.github/skills/manage-html-templates/SKILL.md
@@ -2,6 +2,8 @@
 name: manage-html-templates
 description: Create or update reusable HTML templates for a Kendo UI component in the HTML package. Templates are preset configurations of a component spec, used by visual tests and documentation. Use this skill when the user wants to add a template variant, create a preset configuration, or add a reusable component shorthand.
 argument-hint: "[component] [variant] e.g. chip icon, button icon-text"
+metadata:
+  internal: true
 ---
 
 # Add HTML Template

--- a/.github/skills/manage-html-tests/SKILL.md
+++ b/.github/skills/manage-html-tests/SKILL.md
@@ -2,6 +2,8 @@
 name: manage-html-tests
 description: Create or update visual test scenarios for a Kendo UI component in the HTML package. Creates TSX test files that exercise component states, variants, and edge cases for screenshot-based visual regression testing. Use this skill when the user wants to add test coverage, create visual tests, or ensure a component has proper test scenarios.
 argument-hint: "[component] e.g. button, chip, grid"
+metadata:
+  internal: true
 ---
 
 # Add Visual Test

--- a/.github/skills/manage-scss-modules/SKILL.md
+++ b/.github/skills/manage-scss-modules/SKILL.md
@@ -2,6 +2,8 @@
 name: manage-scss-modules
 description: Create or update design system foundation modules — spacing, color-system, typography, elevation, border-radii, motion, and z-index. These modules live in packages/core/scss/ and are re-exported by each theme via packages/{theme}/scss/core/. Use this skill when the user wants to add a spacing token, color constant, font size, elevation level, border-radius scale value, or animation timing.
 argument-hint: "[module] e.g. spacing, color-system, typography, elevation"
+metadata:
+  internal: true
 ---
 
 # SCSS Module

--- a/.github/skills/manage-scss-styles/SKILL.md
+++ b/.github/skills/manage-scss-styles/SKILL.md
@@ -2,6 +2,8 @@
 name: manage-scss-styles
 description: Create or update SCSS layout mixins, theme mixins, module entry points (_index.scss), and registration in theme entry points for a Kendo UI component. Covers the full component SCSS lifecycle — structural styles, visual styles, wiring, and registration. Use this skill when the user wants to change a component's CSS structure, add visual states, create the style skeleton for a new component, wire up dependencies, or register a component in a theme.
 argument-hint: "[component] e.g. chip, button, tooltip"
+metadata:
+  internal: true
 ---
 
 # SCSS Styles

--- a/.github/skills/manage-scss-variables/SKILL.md
+++ b/.github/skills/manage-scss-variables/SKILL.md
@@ -2,6 +2,8 @@
 name: manage-scss-variables
 description: Create or update SCSS variables for a Kendo UI component — null declarations in core and concrete overrides in targeted theme packages. Handles SassDoc comments, @forward maps, and theme-specific conventions (Fluent CSS custom properties). Use this skill when the user wants to add, change, or remove a component variable.
 argument-hint: "[component] [variable-name] e.g. chip gap, button padding-x"
+metadata:
+  internal: true
 ---
 
 # SCSS Variables

--- a/.github/skills/manage-theme/SKILL.md
+++ b/.github/skills/manage-theme/SKILL.md
@@ -2,6 +2,8 @@
 name: manage-theme
 description: Create a new Kendo UI theme package from scratch or update an existing theme's design tokens, swatches, and component overrides. Handles package scaffolding, core re-exports, swatch configuration, design token changes (spacing, colors, elevation, typography, border-radii), and component-level variable/style overrides. Use this skill when the user wants to create a new theme, change a theme's design tokens, add or edit swatches, or apply broad styling changes across components in a theme.
 argument-hint: "[theme-name] e.g. new-brand, default, fluent"
+metadata:
+  internal: true
 ---
 
 # Theme


### PR DESCRIPTION
NOTE:
always add `internal: true` to local development skills!