### PR TITLE
Html devkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@progress/kendo-e2e": "4.14.2",
         "@stylistic/stylelint-plugin": "^5.0.1",
         "@types/node": "^25.0.3",
+        "@vitejs/plugin-react": "^6.0.2",
         "autoprefixer": "^10.4.20",
         "css-tree": "^3.2.1",
         "esbuild": "0.28.0",
@@ -5609,6 +5610,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.2",
+      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-devtools-npm/npm/@vitejs/plugin-react/-/6.0.2/@vitejs/plugin-react-6.0.2.tgz",
+      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@nx/js": "^22.6.3",
     "@stylistic/stylelint-plugin": "^5.0.1",
     "@types/node": "^25.0.3",
+    "@vitejs/plugin-react": "^6.0.2",
     "autoprefixer": "^10.4.20",
     "css-tree": "^3.2.1",
     "esbuild": "0.28.0",
@@ -59,7 +60,8 @@
   },
   "scripts": {
     "prepare": "husky",
-    "start": "node ./scripts/start-dev-server.js",
+    "start": "vite --config packages/html/devkit/vite.config.ts",
+    "start:legacy": "node ./scripts/start-dev-server.js",
     "lint": "npm run lint:scripts && npm run lint:styles",
     "lint:scripts": "eslint \"**/*.{js,jsx,ts,tsx,mjs}\"",
     "lint:styles": "stylelint \"**/*.scss\"",

--- a/packages/html/assets/styles.css
+++ b/packages/html/assets/styles.css
@@ -44,45 +44,47 @@ body {
 }
 
 /* Prevent animations */
+/* stylelint-disable declaration-no-important */
 .k-no-animations,
 .k-no-animations *,
 .k-no-animations ::before,
 .k-no-animations ::after,
-.k-i-loading:before,
-.k-i-loading:after,
-.k-loading-image::before,
-.k-loading-image::after  {
+.k-no-animations .k-i-loading::before,
+.k-no-animations .k-i-loading::after,
+.k-no-animations .k-loading-image::before,
+.k-no-animations .k-loading-image::after {
     animation: none !important;
     transition: none !important;
 }
+/* stylelint-enable declaration-no-important */
 
 /* Manually import Roboto font from https://fonts.googleapis.com/css?family=Roboto:300,400,500,700 */
 @font-face {
-    font-family: 'Roboto';
+    font-family: Roboto;
     font-style: normal;
     font-weight: 300;
-    src: local('Roboto Light'), local('Roboto-Light'), url(https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmSU5fBBc4.woff2) format('woff2');
+    src: local('Roboto Light'), local('Roboto-Light'), url("https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmSU5fBBc4.woff2") format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
-    font-family: 'Roboto';
+    font-family: Roboto;
     font-style: normal;
     font-weight: 400;
-    src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu4mxK.woff2) format('woff2');
+    src: local('Roboto'), local('Roboto-Regular'), url("https://fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu4mxK.woff2") format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
-    font-family: 'Roboto';
+    font-family: Roboto;
     font-style: normal;
     font-weight: 500;
-    src: local('Roboto Medium'), local('Roboto-Medium'), url(https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmEU9fBBc4.woff2) format('woff2');
+    src: local('Roboto Medium'), local('Roboto-Medium'), url("https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmEU9fBBc4.woff2") format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
-    font-family: 'Roboto';
+    font-family: Roboto;
     font-style: normal;
     font-weight: 700;
-    src: local('Roboto Bold'), local('Roboto-Bold'), url(https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmWUlfBBc4.woff2) format('woff2');
+    src: local('Roboto Bold'), local('Roboto-Bold'), url("https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmWUlfBBc4.woff2") format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -99,7 +101,7 @@ body {
 .col-all { grid-column: 1 / -1; }
 
 
-/* Shades of gray*/
+/* Shades of gray */
 .k-bg-gray-50  { background-color: #fafafa; }
 .k-bg-gray-100 { background-color: #f5f5f5; }
 .k-bg-gray-200 { background-color: #e5e5e5; }

--- a/packages/html/devkit/context.tsx
+++ b/packages/html/devkit/context.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { applyParams, readParams, type DevKitParams } from './lib/theme';
+
+export type { DevKitParams } from './lib/theme';
+
+interface DevKitContextValue {
+    params: DevKitParams;
+    setParams: (update: Partial<DevKitParams>) => void;
+}
+
+const DevKitContext = createContext<DevKitContextValue>(null!);
+
+export function useDevKit(): DevKitContextValue {
+    return useContext(DevKitContext);
+}
+
+export function DevKitProvider({ children }: { children: React.ReactNode }) {
+    const [params, setParamsState] = useState<DevKitParams>(readParams);
+
+    // Keep state in sync when the user navigates back/forward.
+    useEffect(() => {
+        const onPopState = () => {
+            const next = readParams();
+            setParamsState(next);
+            applyParams(next);
+        };
+        window.addEventListener('popstate', onPopState);
+        return () => window.removeEventListener('popstate', onPopState);
+    }, []);
+
+    const setParams = useCallback((update: Partial<DevKitParams>) => {
+        setParamsState(prev => {
+            const next: DevKitParams = { ...prev, ...update };
+            // Reset swatch when the theme changes unless the caller set one explicitly.
+            if (update.theme && update.theme !== prev.theme && update.swatch === undefined) {
+                next.swatch = 'all';
+            }
+            applyParams(next);
+            return next;
+        });
+    }, []);
+
+    return (
+        <DevKitContext.Provider value={{ params, setParams }}>
+            {children}
+        </DevKitContext.Provider>
+    );
+}

--- a/packages/html/devkit/devkit.css
+++ b/packages/html/devkit/devkit.css
@@ -1,0 +1,1050 @@
+/* Kendo DevKit — glass UI. */
+.devkit-wrapper,
+.devkit-search-backdrop,
+.devkit-landing,
+.devkit-error {
+    --dk-bg: rgba(10, 12, 20, 0.82);
+    --dk-bg-solid: #0a0c14;
+    --dk-surface: rgba(255, 255, 255, 0.04);
+    --dk-surface-2: rgba(255, 255, 255, 0.07);
+    --dk-surface-3: rgba(255, 255, 255, 0.11);
+    --dk-border: rgba(255, 255, 255, 0.09);
+    --dk-border-strong: rgba(255, 255, 255, 0.16);
+    --dk-hairline: rgba(255, 255, 255, 0.06);
+
+    --dk-text: #f1f5f9;
+    --dk-text-dim: #94a3b8;
+    --dk-text-muted: #5b677d;
+    --dk-text-faint: #3b475c;
+
+    --dk-accent-color: var(--dk-accent, #6366f1);
+    --dk-accent-soft: color-mix(in oklab, var(--dk-accent-color) 16%, transparent);
+    --dk-accent-softer: color-mix(in oklab, var(--dk-accent-color) 9%, transparent);
+    --dk-accent-ring: color-mix(in oklab, var(--dk-accent-color) 38%, transparent);
+    --dk-accent-text: color-mix(in oklab, var(--dk-accent-color) 55%, #e2e8f0);
+    --dk-accent-edge: color-mix(in oklab, var(--dk-accent-color) 30%, transparent);
+
+    --dk-space-1: 4px;
+    --dk-space-2: 8px;
+    --dk-space-3: 12px;
+    --dk-space-4: 16px;
+    --dk-space-5: 22px;
+    --dk-space-6: 28px;
+
+    --dk-radius-sm: 7px;
+    --dk-radius-md: 10px;
+    --dk-radius-lg: 14px;
+    --dk-radius-xl: 18px;
+
+    --dk-blur: 22px;
+
+    --dk-shadow-bar: 0 -6px 32px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    --dk-shadow-pop: 0 12px 34px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+    --dk-shadow-modal: 0 28px 72px rgba(0, 0, 0, 0.62), 0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+
+    --dk-dur-fast: 0.12s;
+    --dk-dur-base: 0.2s;
+    --dk-dur-slow: 0.28s;
+    --dk-ease: cubic-bezier(0.34, 1.12, 0.64, 1);
+    --dk-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+
+    --dk-font: -apple-system, blinkmacsystemfont, "Segoe UI", system-ui, sans-serif;
+    --dk-mono: ui-monospace, sfmono-regular, menlo, monospace;
+
+    box-sizing: border-box;
+}
+
+.devkit-wrapper *,
+.devkit-search-backdrop *,
+.devkit-landing *,
+.devkit-error * {
+    box-sizing: border-box;
+}
+
+/* Subtle, shared edge-highlight gradient used on glass surfaces. */
+.devkit-bar,
+.devkit-search-dialog,
+.devkit-select-list,
+.devkit-toast {
+    background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0) 38%);
+}
+
+/* Shared focus ring. */
+.devkit-wrapper :focus-visible,
+.devkit-search-backdrop :focus-visible,
+.devkit-landing :focus-visible,
+.devkit-error :focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--dk-accent-ring);
+}
+
+/* Bar wrapper & handle. */
+.devkit-wrapper {
+    position: fixed;
+    bottom: 0;
+    left: 50%;
+    z-index: 999999;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: var(--dk-font);
+    pointer-events: none;
+    transform: translateX(-50%);
+}
+
+.devkit-handle {
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    width: 72px;
+    height: 22px;
+    padding: 0 0 6px;
+    border: none;
+    border-radius: var(--dk-radius-md) var(--dk-radius-md) 0 0;
+    background: transparent;
+    pointer-events: all;
+    cursor: pointer;
+}
+
+.devkit-handle::before {
+    content: "";
+    display: block;
+    width: 40px;
+    height: 4px;
+    border-radius: 99px;
+    background: rgba(148, 163, 184, 0.35);
+    transition: background var(--dk-dur-base), width var(--dk-dur-base), transform var(--dk-dur-base);
+}
+
+.devkit-handle:hover::before {
+    width: 48px;
+    background: var(--dk-accent-color);
+}
+
+.devkit-wrapper:focus-within .devkit-handle::before {
+    background: var(--dk-accent-color);
+}
+
+.devkit-handle:focus-visible {
+    box-shadow: 0 0 0 3px var(--dk-accent-ring);
+}
+
+.devkit-wrapper:hover .devkit-handle::before {
+    transform: translateY(2px);
+}
+
+/* The bar. */
+.devkit-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--dk-space-1);
+    height: 52px;
+    padding: 0 var(--dk-space-3);
+    border: 1px solid var(--dk-border);
+    border-bottom: none;
+    border-radius: var(--dk-radius-lg) var(--dk-radius-lg) 0 0;
+    background-color: var(--dk-bg);
+    box-shadow: var(--dk-shadow-bar);
+    color: var(--dk-text-dim);
+    font-size: 12.5px;
+    line-height: 1;
+    white-space: nowrap;
+    pointer-events: all;
+    opacity: 0;
+    transform: translateY(100%);
+    backdrop-filter: blur(var(--dk-blur)) saturate(160%);
+    transition: transform var(--dk-dur-slow) var(--dk-ease), opacity var(--dk-dur-base) ease;
+}
+
+.devkit-bar[data-visible="true"] {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* Brand. */
+.devkit-brand {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: var(--dk-space-2);
+    padding: 0 var(--dk-space-1);
+    color: var(--dk-text);
+    font-weight: 600;
+    font-size: 13px;
+    letter-spacing: -0.01em;
+    user-select: none;
+}
+
+.devkit-logo {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
+}
+
+/* Separator. */
+.devkit-sep {
+    flex-shrink: 0;
+    width: 1px;
+    height: 22px;
+    margin: 0 var(--dk-space-2);
+    background: var(--dk-hairline);
+}
+
+/* Action buttons / links. */
+.devkit-action {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: var(--dk-space-2);
+    height: 34px;
+    padding: 0 var(--dk-space-3);
+    border: 1px solid transparent;
+    border-radius: var(--dk-radius-sm);
+    background: transparent;
+    color: var(--dk-text-dim);
+    font-family: inherit;
+    font-size: 12.5px;
+    white-space: nowrap;
+    text-decoration: none;
+    cursor: pointer;
+    transition: background var(--dk-dur-fast), color var(--dk-dur-fast), border-color var(--dk-dur-fast);
+}
+
+.devkit-action:hover {
+    border-color: var(--dk-border);
+    background: var(--dk-surface-2);
+    color: var(--dk-text);
+}
+
+.devkit-action:active {
+    background: var(--dk-surface-3);
+}
+
+/* Motion toggle + switch. */
+.devkit-motion-toggle {
+    color: var(--dk-text-dim);
+}
+
+.devkit-toggle-on {
+    border-color: rgba(255, 255, 255, 0.35);
+    background: rgba(255, 255, 255, 0.14);
+    color: #f1f5f9;
+}
+
+.devkit-toggle-on:hover {
+    border-color: rgba(255, 255, 255, 0.45);
+    background: rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+}
+
+.devkit-switch {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    width: 28px;
+    height: 16px;
+    margin-left: 2px;
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.12);
+    transition: background var(--dk-dur-base), border-color var(--dk-dur-base);
+}
+
+.devkit-switch-thumb {
+    display: block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.55);
+    margin-left: 2px;
+    transition: transform var(--dk-dur-base) var(--dk-ease), background var(--dk-dur-base);
+}
+
+.devkit-toggle-on .devkit-switch {
+    border-color: rgba(255, 255, 255, 0.5);
+    background: rgba(255, 255, 255, 0.28);
+}
+
+.devkit-toggle-on .devkit-switch-thumb {
+    background: #ffffff;
+    transform: translateX(12px);
+}
+
+/* Icon / kbd. */
+.devkit-icon {
+    flex-shrink: 0;
+    width: 13px;
+    height: 13px;
+    opacity: 0.9;
+}
+
+.devkit-kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border: 1px solid var(--dk-border);
+    border-radius: 5px;
+    background: var(--dk-surface-2);
+    color: var(--dk-text-muted);
+    font-family: inherit;
+    font-size: 10.5px;
+    font-weight: 500;
+    line-height: 1;
+}
+
+/* Custom select (listbox). */
+.devkit-select-group {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: var(--dk-space-2);
+}
+
+.devkit-select-label {
+    color: var(--dk-text-muted);
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    user-select: none;
+}
+
+.devkit-select-wrap {
+    position: relative;
+}
+
+.devkit-select {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--dk-space-2);
+    min-width: 116px;
+    height: 34px;
+    padding: 0 var(--dk-space-2) 0 var(--dk-space-3);
+    border: 1px solid var(--dk-border);
+    border-radius: var(--dk-radius-sm);
+    background: var(--dk-surface);
+    color: var(--dk-text);
+    font-family: inherit;
+    font-size: 12.5px;
+    cursor: pointer;
+    transition: border-color var(--dk-dur-fast), background var(--dk-dur-fast);
+}
+
+.devkit-select:hover {
+    border-color: var(--dk-border-strong);
+    background: var(--dk-surface-2);
+}
+
+.devkit-select[aria-expanded="true"] {
+    border-color: var(--dk-accent-edge);
+    background: var(--dk-surface-2);
+}
+
+.devkit-select-value {
+    flex: 1;
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+}
+
+.devkit-select-arrow {
+    flex-shrink: 0;
+    width: 11px;
+    height: 11px;
+    color: var(--dk-text-muted);
+    transform: rotate(90deg);
+    transition: transform var(--dk-dur-base) var(--dk-ease-out), color var(--dk-dur-fast);
+}
+
+.devkit-select[aria-expanded="true"] .devkit-select-arrow {
+    color: var(--dk-accent-text);
+    transform: rotate(-90deg);
+}
+
+.devkit-select-list {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 0;
+    min-width: 100%;
+    max-height: 264px;
+    margin: 0;
+    padding: var(--dk-space-1);
+    overflow-y: auto;
+    border: 1px solid var(--dk-border);
+    border-radius: var(--dk-radius-md);
+    background-color: var(--dk-bg);
+    box-shadow: var(--dk-shadow-pop);
+    list-style: none;
+    backdrop-filter: blur(var(--dk-blur)) saturate(160%);
+    animation: devkit-pop var(--dk-dur-base) var(--dk-ease-out);
+}
+
+@keyframes devkit-pop {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.devkit-select-option {
+    display: flex;
+    align-items: center;
+    height: 30px;
+    padding: 0 var(--dk-space-3);
+    border-radius: var(--dk-radius-sm);
+    color: var(--dk-text-dim);
+    font-size: 12.5px;
+    white-space: nowrap;
+    cursor: pointer;
+}
+
+.devkit-select-option[data-active="true"] {
+    background: var(--dk-accent-soft);
+    color: var(--dk-accent-text);
+}
+
+.devkit-select-option[aria-selected="true"] {
+    color: var(--dk-text);
+    font-weight: 600;
+}
+
+/* Quick-cycle toast. */
+.devkit-toast {
+    position: fixed;
+    bottom: 84px;
+    left: 50%;
+    z-index: 999998;
+    display: flex;
+    align-items: center;
+    gap: var(--dk-space-2);
+    padding: 9px var(--dk-space-4);
+    border: 1px solid var(--dk-border);
+    border-radius: 99px;
+    background-color: var(--dk-bg);
+    box-shadow: var(--dk-shadow-pop);
+    color: var(--dk-text);
+    font-family: var(--dk-font);
+    font-size: 12.5px;
+    pointer-events: none;
+    transform: translateX(-50%);
+    backdrop-filter: blur(var(--dk-blur)) saturate(160%);
+    animation: devkit-pop var(--dk-dur-base) var(--dk-ease-out);
+}
+
+.devkit-toast-label {
+    color: var(--dk-text-muted);
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.devkit-toast-value {
+    color: var(--dk-accent-text);
+    font-weight: 600;
+}
+
+.devkit-toast-error {
+    border-color: color-mix(in oklab, #f87171 40%, transparent);
+}
+
+.devkit-toast-error .devkit-toast-value {
+    color: #fca5a5;
+}
+
+.devkit-spinner {
+    width: 13px;
+    height: 13px;
+    border: 2px solid var(--dk-accent-soft);
+    border-top-color: var(--dk-accent-color);
+    border-radius: 50%;
+    animation: devkit-spin 0.6s linear infinite;
+}
+
+@keyframes devkit-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+/* Search command palette. */
+.devkit-search-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1000000;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 12vh;
+    background: rgba(4, 6, 12, 0.5);
+    font-family: var(--dk-font);
+    backdrop-filter: blur(5px);
+    animation: devkit-fade-in var(--dk-dur-fast) ease;
+}
+
+@keyframes devkit-fade-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes devkit-slide-up {
+    from {
+        opacity: 0;
+        transform: translateY(12px) scale(0.99);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.devkit-search-dialog {
+    display: flex;
+    flex-direction: column;
+    width: 620px;
+    max-width: calc(100vw - 32px);
+    max-height: min(560px, calc(100vh - 24vh));
+    overflow: hidden;
+    border: 1px solid var(--dk-border);
+    border-radius: var(--dk-radius-xl);
+    background-color: rgba(13, 16, 26, 0.92);
+    box-shadow: var(--dk-shadow-modal);
+    color: var(--dk-text);
+    font-size: 13.5px;
+    backdrop-filter: blur(28px) saturate(170%);
+    animation: devkit-slide-up var(--dk-dur-base) var(--dk-ease-out);
+}
+
+.devkit-search-input-row {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: var(--dk-space-3);
+    padding: var(--dk-space-4) var(--dk-space-5);
+    border-bottom: 1px solid var(--dk-hairline);
+}
+
+.devkit-search-input-icon {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    color: var(--dk-text-muted);
+}
+
+.devkit-search-input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    background: transparent;
+    color: var(--dk-text);
+    font-family: inherit;
+    font-size: 15.5px;
+    line-height: 1.5;
+    outline: none;
+}
+
+.devkit-search-input::placeholder {
+    color: var(--dk-text-faint);
+}
+
+.devkit-search-esc {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    height: 22px;
+    padding: 0 8px;
+    border: 1px solid var(--dk-border);
+    border-radius: 6px;
+    background: var(--dk-surface-2);
+    color: var(--dk-text-muted);
+    font-family: inherit;
+    font-size: 11px;
+    cursor: pointer;
+    transition: background var(--dk-dur-fast), color var(--dk-dur-fast);
+}
+
+.devkit-search-esc:hover {
+    background: var(--dk-surface-3);
+    color: var(--dk-text-dim);
+}
+
+.devkit-search-results {
+    flex: 1;
+    padding: var(--dk-space-2) 0;
+    overflow-y: auto;
+    scroll-behavior: smooth;
+}
+
+.devkit-search-group-label {
+    display: flex;
+    align-items: center;
+    gap: var(--dk-space-2);
+    padding: var(--dk-space-3) var(--dk-space-5) var(--dk-space-1);
+    color: var(--dk-text-muted);
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    user-select: none;
+}
+
+.devkit-search-group-label .devkit-icon {
+    width: 11px;
+    height: 11px;
+}
+
+.devkit-search-item {
+    display: flex;
+    align-items: center;
+    gap: var(--dk-space-3);
+    padding: 8px var(--dk-space-5);
+    color: var(--dk-text-dim);
+    text-decoration: none;
+    scroll-margin: 8px 0;
+    cursor: pointer;
+    transition: background var(--dk-dur-fast), color var(--dk-dur-fast);
+}
+
+.devkit-search-item:hover {
+    color: var(--dk-text);
+}
+
+.devkit-search-item-active {
+    background: var(--dk-accent-soft);
+    color: var(--dk-accent-text);
+}
+
+.devkit-search-item-icon {
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+    color: var(--dk-text-faint);
+}
+
+.devkit-search-item-active .devkit-search-item-icon {
+    color: var(--dk-accent-text);
+}
+
+.devkit-search-item-test {
+    flex: 1;
+    min-width: 0;
+}
+
+.devkit-hl {
+    color: var(--dk-accent-text);
+    font-weight: 600;
+}
+
+.devkit-search-empty {
+    padding: 44px var(--dk-space-5);
+    color: var(--dk-text-faint);
+    font-size: 14px;
+    text-align: center;
+}
+
+.devkit-search-footer {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: var(--dk-space-4);
+    padding: var(--dk-space-3) var(--dk-space-5);
+    border-top: 1px solid var(--dk-hairline);
+    color: var(--dk-text-faint);
+    font-size: 11px;
+}
+
+.devkit-search-hint {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--dk-space-1);
+}
+
+.devkit-search-hint kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border: 1px solid var(--dk-border);
+    border-radius: 5px;
+    background: var(--dk-surface);
+    color: var(--dk-text-muted);
+    font-size: 10px;
+    font-family: inherit;
+}
+
+.devkit-search-count {
+    margin-left: auto;
+    color: var(--dk-text-muted);
+}
+
+/* Landing page. */
+.devkit-landing {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    background: var(--dk-bg-solid);
+    background-image: radial-gradient(120% 60% at 50% -10%, var(--dk-accent-softer), transparent 60%);
+    color: var(--dk-text);
+    font-family: var(--dk-font);
+}
+
+.devkit-landing-header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: var(--dk-space-3);
+    padding: var(--dk-space-4) var(--dk-space-6);
+    border-bottom: 1px solid var(--dk-hairline);
+    background: rgba(8, 10, 17, 0.7);
+    backdrop-filter: blur(14px) saturate(150%);
+}
+
+.devkit-landing-logo {
+    flex-shrink: 0;
+    width: 26px;
+    height: 26px;
+    border-radius: 6px;
+}
+
+.devkit-landing-title {
+    color: var(--dk-text);
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: -0.015em;
+}
+
+.devkit-landing-stats {
+    margin-left: auto;
+    color: var(--dk-text-muted);
+    font-size: 12px;
+}
+
+.devkit-landing-stats strong {
+    color: var(--dk-text-dim);
+    font-weight: 600;
+}
+
+.devkit-landing-body {
+    flex: 1;
+    width: 100%;
+    max-width: 880px;
+    margin: 0 auto;
+    padding: var(--dk-space-6) var(--dk-space-6) 96px;
+}
+
+/* Landing search. */
+.devkit-landing-search {
+    position: relative;
+    margin-bottom: var(--dk-space-5);
+}
+
+.devkit-landing-search-icon {
+    position: absolute;
+    top: 50%;
+    left: var(--dk-space-4);
+    width: 16px;
+    height: 16px;
+    color: var(--dk-text-muted);
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.devkit-landing-search-input {
+    width: 100%;
+    height: 46px;
+    padding: 0 110px 0 44px;
+    border: 1px solid var(--dk-border);
+    border-radius: var(--dk-radius-lg);
+    background: var(--dk-surface);
+    color: var(--dk-text);
+    font-family: inherit;
+    font-size: 14px;
+    transition: border-color var(--dk-dur-fast), background var(--dk-dur-fast);
+}
+
+.devkit-landing-search-input:focus {
+    border-color: var(--dk-accent-edge);
+    background: var(--dk-surface-2);
+    outline: none;
+    box-shadow: 0 0 0 3px var(--dk-accent-ring);
+}
+
+.devkit-landing-search-input::placeholder {
+    color: var(--dk-text-faint);
+}
+
+.devkit-landing-search-kbd {
+    position: absolute;
+    top: 50%;
+    right: var(--dk-space-3);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--dk-space-1);
+    color: var(--dk-text-faint);
+    font-size: 11px;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.devkit-landing-search-kbd kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border: 1px solid var(--dk-border);
+    border-radius: 5px;
+    background: var(--dk-surface);
+    color: var(--dk-text-muted);
+    font-size: 10px;
+}
+
+/* Accordion list. */
+.devkit-acc-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--dk-space-1);
+}
+
+.devkit-acc-item {
+    overflow: hidden;
+    border: 1px solid var(--dk-hairline);
+    border-radius: var(--dk-radius-md);
+    background: rgba(255, 255, 255, 0.015);
+    transition: border-color var(--dk-dur-fast);
+}
+
+.devkit-acc-item:hover {
+    border-color: var(--dk-border);
+}
+
+.devkit-acc-item[data-open="true"] {
+    border-color: var(--dk-accent-edge);
+    background: var(--dk-accent-softer);
+}
+
+.devkit-acc-summary {
+    display: flex;
+    align-items: center;
+    gap: var(--dk-space-3);
+    width: 100%;
+    padding: var(--dk-space-3) var(--dk-space-4);
+    border: none;
+    background: transparent;
+    color: inherit;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background var(--dk-dur-fast);
+}
+
+.devkit-acc-summary:hover {
+    background: var(--dk-surface);
+}
+
+.devkit-acc-chevron {
+    flex-shrink: 0;
+    width: 12px;
+    height: 12px;
+    color: var(--dk-text-faint);
+    transition: transform var(--dk-dur-base) var(--dk-ease-out), color var(--dk-dur-fast);
+}
+
+.devkit-acc-item[data-open="true"] .devkit-acc-chevron {
+    color: var(--dk-accent-text);
+    transform: rotate(90deg);
+}
+
+.devkit-acc-name {
+    flex: 1;
+    color: var(--dk-text-dim);
+    font-size: 13.5px;
+    font-weight: 500;
+}
+
+.devkit-acc-item[data-open="true"] .devkit-acc-name {
+    color: var(--dk-text);
+}
+
+.devkit-acc-badge {
+    padding: 1px 9px;
+    border: 1px solid var(--dk-hairline);
+    border-radius: 99px;
+    background: var(--dk-surface-2);
+    color: var(--dk-text-muted);
+    font-size: 11px;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+    transition: color var(--dk-dur-fast), background var(--dk-dur-fast), border-color var(--dk-dur-fast);
+}
+
+.devkit-acc-item[data-open="true"] .devkit-acc-badge {
+    border-color: var(--dk-accent-edge);
+    background: var(--dk-accent-soft);
+    color: var(--dk-accent-text);
+}
+
+/* Animated expand region (grid-rows technique — no JS measuring). */
+.devkit-acc-region {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows var(--dk-dur-base) var(--dk-ease-out);
+}
+
+.devkit-acc-item[data-open="true"] .devkit-acc-region {
+    grid-template-rows: 1fr;
+}
+
+.devkit-acc-inner {
+    min-height: 0;
+    overflow: hidden;
+}
+
+.devkit-test-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: var(--dk-space-1) var(--dk-space-4) var(--dk-space-3) 40px;
+    border-top: 1px solid var(--dk-hairline);
+}
+
+.devkit-test-link {
+    display: flex;
+    align-items: center;
+    gap: var(--dk-space-2);
+    padding: 6px var(--dk-space-2);
+    border-radius: var(--dk-radius-sm);
+    color: var(--dk-text-muted);
+    font-size: 12.5px;
+    text-decoration: none;
+    transition: background var(--dk-dur-fast), color var(--dk-dur-fast);
+}
+
+.devkit-test-link:hover {
+    background: var(--dk-surface);
+    color: var(--dk-accent-text);
+}
+
+.devkit-no-results {
+    padding: 56px 0;
+    color: var(--dk-text-faint);
+    font-size: 14px;
+    text-align: center;
+}
+
+/* Error card. */
+.devkit-error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: var(--dk-space-6);
+    background: var(--dk-bg-solid);
+    background-image: radial-gradient(100% 60% at 50% 0%, rgba(248, 113, 113, 0.08), transparent 60%);
+    font-family: var(--dk-font);
+}
+
+.devkit-error-card {
+    width: 100%;
+    max-width: 560px;
+    padding: var(--dk-space-6);
+    border: 1px solid var(--dk-border);
+    border-radius: var(--dk-radius-lg);
+    background: var(--dk-surface);
+    box-shadow: var(--dk-shadow-pop);
+}
+
+.devkit-error-title {
+    margin-bottom: var(--dk-space-3);
+    color: #fca5a5;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.devkit-error-route {
+    display: inline-block;
+    margin-bottom: var(--dk-space-4);
+    padding: 3px 8px;
+    border-radius: 6px;
+    background: var(--dk-surface-2);
+    color: var(--dk-text-dim);
+    font-family: var(--dk-mono);
+    font-size: 12.5px;
+}
+
+.devkit-error-message {
+    max-height: 280px;
+    margin: 0 0 var(--dk-space-5);
+    padding: var(--dk-space-4);
+    overflow: auto;
+    border: 1px solid var(--dk-hairline);
+    border-radius: var(--dk-radius-md);
+    background: rgba(0, 0, 0, 0.3);
+    color: var(--dk-text-dim);
+    font-family: var(--dk-mono);
+    font-size: 12px;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.devkit-error-back {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--dk-space-2);
+    height: 36px;
+    padding: 0 var(--dk-space-4);
+    border: 1px solid var(--dk-accent-edge);
+    border-radius: var(--dk-radius-sm);
+    background: var(--dk-accent-soft);
+    color: var(--dk-accent-text);
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none;
+    transition: background var(--dk-dur-fast);
+}
+
+.devkit-error-back:hover {
+    background: var(--dk-accent-ring);
+}
+
+/* Reduced motion: neutralize all devkit animation/transition.
+ * !important is the accepted idiom here — it must beat every rule above. */
+/* stylelint-disable declaration-no-important */
+@media (prefers-reduced-motion: reduce) {
+    .devkit-wrapper *,
+    .devkit-search-backdrop *,
+    .devkit-landing *,
+    .devkit-error *,
+    .devkit-bar,
+    .devkit-search-dialog,
+    .devkit-select-list,
+    .devkit-toast {
+        scroll-behavior: auto !important;
+        transition-duration: 0.001ms !important;
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+    }
+}
+/* stylelint-enable declaration-no-important */

--- a/packages/html/devkit/index.html
+++ b/packages/html/devkit/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en" class="k-no-animations">
+    <head>
+        <title>Kendo Themes Dev Server</title>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="stylesheet" data-role="kendo-theme" href="/packages/meridian/dist/all.css" />
+        <link rel="stylesheet" data-role="kendo-theme-utils" href="/packages/utils/dist/all.css" />
+        <link rel="stylesheet" href="/packages/html/assets/styles.css"/>
+    </head>
+    <body class="k-body">
+        <div id="app"></div>
+        <div id="devkit-portal"></div>
+        <script type="module" src="/packages/html/devkit/main.tsx"></script>
+    </body>
+</html>

--- a/packages/html/devkit/lib/bootstrap.ts
+++ b/packages/html/devkit/lib/bootstrap.ts
@@ -1,0 +1,59 @@
+/// <reference types="vite/client" />
+import { applyParams, getThemeLink, readParams, refreshThemeLink, syncAccent, THEME_EVENTS } from './theme';
+
+/** Legacy gradient-off escape hatch, mirrored from assets/scripts.js. */
+function applyGradientOff(): void {
+    if (new URLSearchParams(location.search).get('gradientoff') !== 'true') return;
+    const style = document.createElement('style');
+    style.textContent =
+        '.k-picker, .k-button, .k-spreadsheet-insert-image-dialog label, ' +
+        '.k-scheduler-agendaview .k-scheduler-content tr.k-hover { background-image: none; }';
+    document.head.appendChild(style);
+}
+
+function measureScrollbarWidth(): string {
+    const div = document.createElement('div');
+    div.style.cssText = 'overflow:scroll;overflow-x:hidden;zoom:1;clear:both;display:block';
+    div.innerHTML = '&nbsp;';
+    document.body.appendChild(div);
+    const width = `${div.offsetWidth - div.scrollWidth}px`;
+    document.body.removeChild(div);
+    return width;
+}
+
+/** Mirror Kendo chart color CSS vars onto SVG `fill` so charts render correctly. */
+function applyKendoChartColors(): void {
+    const link = getThemeLink();
+    if (!link?.sheet) return;
+    [...link.sheet.cssRules]
+        .filter(r => (r as CSSStyleRule).selectorText?.startsWith('.k-var'))
+        .filter(r => Boolean((r as CSSStyleRule).style.backgroundColor))
+        .forEach(r => {
+            (r as CSSStyleRule).style.fill = (r as CSSStyleRule).style.backgroundColor;
+        });
+}
+
+/** Pre-React setup: apply theme params (no flash) and finish on window load. */
+export function runBootstrap(): void {
+    applyParams(readParams());
+    applyGradientOff();
+
+    window.addEventListener('load', () => {
+        document.documentElement.style.setProperty('--kendo-scrollbar-width', measureScrollbarWidth());
+        applyKendoChartColors();
+        syncAccent();
+    });
+}
+
+/** Wires dev-server HMR events: live-SCSS hot-swap and on-demand build errors. */
+export function setupHmr(): void {
+    if (!import.meta.hot) return;
+
+    // Live SCSS: refetch the active theme stylesheet without a full reload.
+    import.meta.hot.on('kendo:css-update', ({ theme }: { theme: string }) => refreshThemeLink(theme));
+
+    // Surface on-demand compile failures as an in-app toast (terminal logs details).
+    import.meta.hot.on('kendo:css-error', (detail: { pkg: string; name: string; message: string }) => {
+        window.dispatchEvent(new CustomEvent(THEME_EVENTS.error, { detail }));
+    });
+}

--- a/packages/html/devkit/lib/dom.ts
+++ b/packages/html/devkit/lib/dom.ts
@@ -1,0 +1,8 @@
+/** Shared DOM helpers for the devkit. */
+
+/** True when the event target is a field that should swallow global shortcuts. */
+export function isEditable(target: EventTarget | null): boolean {
+    const el = target as HTMLElement | null;
+    if (!el) return false;
+    return ['INPUT', 'TEXTAREA', 'SELECT'].includes(el.tagName) || el.isContentEditable;
+}

--- a/packages/html/devkit/lib/fuzzy.ts
+++ b/packages/html/devkit/lib/fuzzy.ts
@@ -1,0 +1,77 @@
+/**
+ * Tiny zero-dependency fuzzy matcher. Matches `query` as a subsequence of
+ * `text`, rewarding consecutive runs and word-boundary hits so that e.g.
+ * "btnsolid" ranks "button-solid" highly. Returns `null` when there is no match.
+ */
+
+export interface FuzzyResult {
+    /** Higher is better. */
+    score: number;
+    /** Indices in `text` that were matched, ascending. */
+    matched: number[];
+}
+
+const BOUNDARY = /[-_/\s.]/;
+
+export function fuzzyMatch(query: string, text: string): FuzzyResult | null {
+    if (!query) return { score: 0, matched: [] };
+
+    const q = query.toLowerCase();
+    const t = text.toLowerCase();
+    const matched: number[] = [];
+
+    let score = 0;
+    let qi = 0;
+    let prevIndex = -1;
+
+    for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+        if (t[ti] !== q[qi]) continue;
+
+        let bonus = 1;
+        if (prevIndex === ti - 1) bonus += 4; // consecutive run
+        if (ti === 0 || BOUNDARY.test(t[ti - 1])) bonus += 3; // word boundary
+        score += bonus;
+
+        matched.push(ti);
+        prevIndex = ti;
+        qi++;
+    }
+
+    if (qi < q.length) return null; // not all query chars consumed
+
+    // Reward shorter targets and a match that starts early.
+    score += Math.max(0, 12 - (matched[0] ?? 0));
+    score -= t.length * 0.05;
+
+    return { score, matched };
+}
+
+/**
+ * Splits `text` into alternating plain / matched segments based on `matched`
+ * indices, ready to render with the matched parts highlighted.
+ */
+export interface Segment {
+    text: string;
+    match: boolean;
+}
+
+export function segmentize(text: string, matched: number[]): Segment[] {
+    if (!matched.length) return [{ text, match: false }];
+
+    const hit = new Set(matched);
+    const segments: Segment[] = [];
+    let buf = '';
+    let bufMatch = hit.has(0);
+
+    for (let i = 0; i < text.length; i++) {
+        const isMatch = hit.has(i);
+        if (isMatch !== bufMatch) {
+            if (buf) segments.push({ text: buf, match: bufMatch });
+            buf = '';
+            bufMatch = isMatch;
+        }
+        buf += text[i];
+    }
+    if (buf) segments.push({ text: buf, match: bufMatch });
+    return segments;
+}

--- a/packages/html/devkit/lib/recents.ts
+++ b/packages/html/devkit/lib/recents.ts
@@ -1,0 +1,35 @@
+/**
+ * Recently-visited demos, persisted in localStorage. Used to populate the
+ * command palette when the query is empty.
+ */
+
+export interface RecentDemo {
+    component: string;
+    test: string;
+}
+
+const KEY = 'devkit:recents';
+const LIMIT = 8;
+
+export function getRecents(): RecentDemo[] {
+    try {
+        const raw = localStorage.getItem(KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed.slice(0, LIMIT) : [];
+    } catch {
+        return [];
+    }
+}
+
+export function pushRecent(component: string, test: string): void {
+    try {
+        const next = [
+            { component, test },
+            ...getRecents().filter(r => !(r.component === component && r.test === test)),
+        ].slice(0, LIMIT);
+        localStorage.setItem(KEY, JSON.stringify(next));
+    } catch {
+        /* storage unavailable — recents are best-effort */
+    }
+}

--- a/packages/html/devkit/lib/theme.ts
+++ b/packages/html/devkit/lib/theme.ts
@@ -1,0 +1,128 @@
+/**
+ * Single source of truth for devkit theme state.
+ *
+ * Both the pre-React bootstrap (`main.tsx`) and the React context (`context.tsx`)
+ * read and apply theme params through here so the swatch-alias rule, the dist CSS
+ * path, the animations class and the adaptive accent all live in exactly one place.
+ */
+
+export interface DevKitParams {
+    theme: string;
+    swatch: string;
+    animations: boolean;
+}
+
+const DEFAULTS: DevKitParams = {
+    theme: 'meridian',
+    swatch: 'all',
+    animations: false,
+};
+
+const THEME_LINK = 'link[data-role="kendo-theme"]';
+
+/** Custom window events the UI uses to track on-demand compilation. */
+export const THEME_EVENTS = {
+    loading: 'devkit:theme-loading',
+    loaded: 'devkit:theme-loaded',
+    error: 'devkit:css-error',
+} as const;
+
+/** The active Kendo theme `<link>` (single home for the selector). */
+export function getThemeLink(): HTMLLinkElement | null {
+    return document.querySelector<HTMLLinkElement>(THEME_LINK);
+}
+
+/** Reads the current params from the URL query string. */
+export function readParams(): DevKitParams {
+    const p = new URLSearchParams(location.search);
+    return {
+        theme: p.get('theme') || DEFAULTS.theme,
+        swatch: p.get('swatch') || DEFAULTS.swatch,
+        animations: p.get('animations') === 'true',
+    };
+}
+
+/** Resolves the on-disk swatch name, applying the `${theme}-${swatch}` alias rule. */
+function resolveSwatch(theme: string, swatch: string): string {
+    if (swatch !== 'all' && !swatch.startsWith(theme)) return `${theme}-${swatch}`;
+    return swatch;
+}
+
+/** The one place that builds a theme's compiled CSS path. */
+function themeHref(theme: string, swatch: string): string {
+    return `/packages/${theme}/dist/${resolveSwatch(theme, swatch)}.css`;
+}
+
+/** Builds the `?theme=&swatch=` query string used by demo/listing links. */
+export function themeQuery(theme: string, swatch: string): string {
+    return `?theme=${encodeURIComponent(theme)}&swatch=${encodeURIComponent(swatch)}`;
+}
+
+/**
+ * Mirrors the devkit accent (`--dk-accent`) to the active Kendo theme's primary
+ * color so the whole UI subtly tints to whatever is being previewed. Removing the
+ * property (when a theme doesn't expose one) lets the CSS fallback take over.
+ */
+export function syncAccent(): void {
+    const primary = getComputedStyle(document.documentElement)
+        .getPropertyValue('--kendo-color-primary')
+        .trim();
+    if (primary) {
+        document.documentElement.style.setProperty('--dk-accent', primary);
+    } else {
+        document.documentElement.style.removeProperty('--dk-accent');
+    }
+}
+
+/**
+ * Swaps the theme stylesheet, re-syncing the accent once the new CSS is parsed.
+ * Emits `devkit:theme-loading` / `devkit:theme-loaded` on `window` so the UI can
+ * show progress while the server compiles the theme on demand (first request can
+ * take a second or two; a swatch's first build longer).
+ */
+function swapThemeLink(theme: string, swatch: string): void {
+    const link = getThemeLink();
+    if (!link) return;
+
+    const href = themeHref(theme, swatch);
+    const current = new URL(link.href, location.origin).pathname;
+    if (current === href) {
+        syncAccent();
+        return;
+    }
+
+    window.dispatchEvent(new CustomEvent(THEME_EVENTS.loading, { detail: { theme, swatch } }));
+    const done = () => {
+        syncAccent();
+        window.dispatchEvent(new CustomEvent(THEME_EVENTS.loaded, { detail: { theme, swatch } }));
+    };
+    link.addEventListener('load', done, { once: true });
+    link.addEventListener('error', done, { once: true });
+    link.href = href;
+}
+
+/**
+ * Cache-busts the active theme stylesheet when the server recompiles it (live
+ * SCSS), re-syncing the accent once reloaded. No-op if the link isn't `theme`.
+ */
+export function refreshThemeLink(theme: string): void {
+    const link = getThemeLink();
+    if (!link?.href.includes(`/packages/${theme}/`)) return;
+    const url = new URL(link.href);
+    url.searchParams.set('t', String(Date.now()));
+    link.addEventListener('load', syncAccent, { once: true });
+    link.href = url.toString();
+}
+
+/** Applies params to the DOM: URL, theme stylesheet, animations class, accent. */
+export function applyParams(params: DevKitParams): void {
+    const url = new URL(location.href);
+    url.searchParams.set('theme', params.theme);
+    url.searchParams.set('swatch', params.swatch);
+    url.searchParams.set('animations', String(params.animations));
+    history.replaceState({}, '', url.toString());
+
+    swapThemeLink(params.theme, params.swatch);
+
+    document.documentElement.classList.toggle('k-no-animations', !params.animations);
+}

--- a/packages/html/devkit/lib/useShortcuts.ts
+++ b/packages/html/devkit/lib/useShortcuts.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from 'react';
+import type { DevKitParams } from './theme';
+import { isEditable } from './dom';
+
+interface QuickCycleOptions {
+    params: DevKitParams;
+    setParams: (update: Partial<DevKitParams>) => void;
+    themes: string[];
+    swatches: string[];
+}
+
+export interface Toast {
+    id: number;
+    label: string;
+    value: string;
+}
+
+function step<T>(list: T[], current: T, dir: 1 | -1): T {
+    if (!list.length) return current;
+    const i = list.indexOf(current);
+    const next = (i + dir + list.length) % list.length;
+    return list[next];
+}
+
+/**
+ * Global power-user shortcuts (Ctrl/Cmd+Shift+…):
+ *   ← / →  cycle theme   ↑ / ↓  cycle swatch   M  toggle motion
+ * Returns the most recent change as a transient toast for on-screen feedback.
+ */
+export function useQuickCycle(opts: QuickCycleOptions): Toast | null {
+    const [toast, setToast] = useState<Toast | null>(null);
+    const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    // Keep the latest options without re-binding the listener each render.
+    const ref = useRef(opts);
+    ref.current = opts;
+
+    const fire = (label: string, value: string) => {
+        setToast({ id: Date.now(), label, value });
+        clearTimeout(timer.current);
+        timer.current = setTimeout(() => setToast(null), 1400);
+    };
+
+    useEffect(() => {
+        function onKey(e: KeyboardEvent) {
+            if (!(e.ctrlKey || e.metaKey) || !e.shiftKey) return;
+            if (isEditable(e.target)) return;
+
+            const { params, setParams, themes, swatches } = ref.current;
+            const key = e.key.toLowerCase();
+
+            if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+                e.preventDefault();
+                const theme = step(themes, params.theme, e.key === 'ArrowRight' ? 1 : -1);
+                setParams({ theme });
+                fire('Theme', theme);
+            } else if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+                e.preventDefault();
+                const swatch = step(swatches, params.swatch, e.key === 'ArrowDown' ? 1 : -1);
+                setParams({ swatch });
+                fire('Swatch', swatch);
+            } else if (key === 'm') {
+                e.preventDefault();
+                const animations = !params.animations;
+                setParams({ animations });
+                fire('Animations', animations ? 'on' : 'off');
+            }
+        }
+
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, []);
+
+    useEffect(() => () => clearTimeout(timer.current), []);
+
+    return toast;
+}

--- a/packages/html/devkit/lib/useThemeStatus.ts
+++ b/packages/html/devkit/lib/useThemeStatus.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from 'react';
+import { THEME_EVENTS } from './theme';
+
+export interface ThemeStatus {
+    kind: 'loading' | 'error';
+    text: string;
+}
+
+/**
+ * Tracks on-demand theme compilation for the dev bar: shows a "loading" status
+ * while CSS compiles and a transient "error" status if a build fails.
+ */
+export function useThemeStatus(): ThemeStatus | null {
+    const [status, setStatus] = useState<ThemeStatus | null>(null);
+    const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    useEffect(() => {
+        const onLoading = (e: Event) => {
+            const { theme, swatch } = (e as CustomEvent).detail ?? {};
+            clearTimeout(timer.current);
+            setStatus({ kind: 'loading', text: swatch && swatch !== 'all' ? swatch : theme });
+        };
+        const onLoaded = () => setStatus(s => (s?.kind === 'loading' ? null : s));
+        const onError = (e: Event) => {
+            const { pkg } = (e as CustomEvent).detail ?? {};
+            clearTimeout(timer.current);
+            setStatus({ kind: 'error', text: `${pkg} build failed` });
+            timer.current = setTimeout(() => setStatus(null), 4000);
+        };
+
+        window.addEventListener(THEME_EVENTS.loading, onLoading);
+        window.addEventListener(THEME_EVENTS.loaded, onLoaded);
+        window.addEventListener(THEME_EVENTS.error, onError);
+        return () => {
+            window.removeEventListener(THEME_EVENTS.loading, onLoading);
+            window.removeEventListener(THEME_EVENTS.loaded, onLoaded);
+            window.removeEventListener(THEME_EVENTS.error, onError);
+            clearTimeout(timer.current);
+        };
+    }, []);
+
+    return status;
+}

--- a/packages/html/devkit/main.tsx
+++ b/packages/html/devkit/main.tsx
@@ -1,0 +1,56 @@
+/// <reference types="vite/client" />
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { readParams, themeQuery } from './lib/theme';
+import { runBootstrap, setupHmr } from './lib/bootstrap';
+
+// Apply theme params before React mounts so there's no flash of the wrong theme.
+runBootstrap();
+
+function render(node: React.ReactElement): void {
+    ReactDOM.createRoot(document.getElementById('app')!).render(node);
+}
+
+async function init(): Promise<void> {
+    // Match /{component}/{test} — the devkit URL scheme.
+    const match = location.pathname.match(/^\/([^/]+)\/([^/]+)\/?$/);
+
+    if (!match) {
+        const { LandingPage } = await import('./ui/LandingPage');
+        render(<LandingPage />);
+        return;
+    }
+
+    const [, component, test] = match;
+    const { DevBar } = await import('./ui/DevBar');
+    const { DevKitProvider } = await import('./context');
+    const { ErrorBoundary, ErrorCard } = await import('./ui/ErrorBoundary');
+
+    const { theme, swatch } = readParams();
+    const backHref = `/${themeQuery(theme, swatch)}`;
+
+    try {
+        // @vite-ignore: intentional dynamic import resolved at request time.
+        const mod = await import(/* @vite-ignore */ `/packages/html/src/${component}/tests/${test}.tsx`);
+        const App = mod.default as React.ComponentType;
+
+        render(
+            <DevKitProvider>
+                <ErrorBoundary title={`${component}/${test}`} backHref={backHref}>
+                    <App />
+                </ErrorBoundary>
+                <DevBar />
+            </DevKitProvider>
+        );
+    } catch (err) {
+        render(
+            <DevKitProvider>
+                <ErrorCard title={`${component}/${test}`} backHref={backHref} message={String(err)} />
+                <DevBar />
+            </DevKitProvider>
+        );
+    }
+}
+
+void init();
+setupHmr();

--- a/packages/html/devkit/tsconfig.app.json
+++ b/packages/html/devkit/tsconfig.app.json
@@ -1,0 +1,30 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "target": "es2020",
+        "lib": ["es2020", "dom", "dom.iterable"],
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "isolatedModules": true,
+        "esModuleInterop": true,
+        "noEmit": true,
+        "strictFunctionTypes": true,
+        "noImplicitAny": false,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "strictNullChecks": true
+    },
+    "include": [
+        "context.tsx",
+        "main.tsx",
+        "lib/**/*.ts",
+        "ui/**/*.tsx",
+        "types/**/*.d.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "vite.config.ts"
+    ]
+}

--- a/packages/html/devkit/tsconfig.json
+++ b/packages/html/devkit/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "files": [],
+    "references": [
+        {
+            "path": "./tsconfig.app.json"
+        },
+        {
+            "path": "./tsconfig.node.json"
+        }
+    ]
+}

--- a/packages/html/devkit/tsconfig.node.json
+++ b/packages/html/devkit/tsconfig.node.json
@@ -1,0 +1,22 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "target": "es2020",
+        "lib": ["es2020"],
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "types": ["node"],
+        "isolatedModules": true,
+        "esModuleInterop": true,
+        "noEmit": true,
+        "strictFunctionTypes": true,
+        "noImplicitAny": false,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "strictNullChecks": true
+    },
+    "include": [
+        "vite.config.ts"
+    ]
+}

--- a/packages/html/devkit/types/virtual.d.ts
+++ b/packages/html/devkit/types/virtual.d.ts
@@ -1,0 +1,7 @@
+declare module 'virtual:test-routes' {
+    export const testRoutes: Record<string, string[]>;
+}
+
+declare module 'virtual:swatch-map' {
+    export const swatchMap: Record<string, string[]>;
+}

--- a/packages/html/devkit/ui/DevBar.tsx
+++ b/packages/html/devkit/ui/DevBar.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { swatchMap } from 'virtual:swatch-map';
+import { useDevKit } from '../context';
+import { themeQuery } from '../lib/theme';
+import { isEditable } from '../lib/dom';
+import { useQuickCycle } from '../lib/useShortcuts';
+import { useThemeStatus } from '../lib/useThemeStatus';
+import { DevBarSearch } from './DevBarSearch';
+import { Select } from './Select';
+import { BackIcon, KendoLogo, PlayIcon, SearchIcon } from './icons';
+import '../devkit.css';
+
+export function DevBar() {
+    const { params, setParams } = useDevKit();
+    const [expanded, setExpanded] = useState(true);
+    const [searchOpen, setSearchOpen] = useState(false);
+    const wrapperRef = useRef<HTMLDivElement>(null);
+
+    const themes = useMemo(() => Object.keys(swatchMap).sort(), []);
+    const swatches = useMemo(() => {
+        const list = (swatchMap[params.theme] || []).filter(s => s !== 'all').sort();
+        return ['all', ...list];
+    }, [params.theme]);
+
+    const isDemo = /^\/[^/]+\/[^/]+\/?$/.test(location.pathname);
+    const listingHref = `/${themeQuery(params.theme, params.swatch)}`;
+
+    const toast = useQuickCycle({ params, setParams, themes, swatches });
+    const status = useThemeStatus();
+
+    // Global shortcuts to open the command palette.
+    useEffect(() => {
+        function onKey(e: KeyboardEvent) {
+            if (searchOpen) return;
+            if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+                e.preventDefault();
+                setSearchOpen(true);
+            } else if (e.key === '/' && !isEditable(e.target) && !e.ctrlKey && !e.metaKey) {
+                e.preventDefault();
+                setSearchOpen(true);
+            }
+        }
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [searchOpen]);
+
+    const portalTarget = document.getElementById('devkit-portal') ?? document.body;
+
+    return (
+        <>
+            <div
+                ref={wrapperRef}
+                className="devkit-wrapper"
+                onFocus={() => setExpanded(true)}
+            >
+                <button
+                    className="devkit-handle"
+                    onClick={() => setExpanded(v => !v)}
+                    aria-label={expanded ? 'Collapse dev bar' : 'Expand dev bar'}
+                    aria-expanded={expanded}
+                    aria-controls="devkit-bar"
+                />
+
+                <div
+                    id="devkit-bar"
+                    role="toolbar"
+                    aria-label="Kendo Dev Bar"
+                    className="devkit-bar"
+                    data-visible={expanded}
+                >
+                    <div className="devkit-brand">
+                        <KendoLogo className="devkit-logo" />
+                        <span>Dev</span>
+                    </div>
+
+                    <div className="devkit-sep" aria-hidden="true" />
+
+                    <button
+                        className="devkit-action"
+                        onClick={() => setSearchOpen(true)}
+                        aria-label="Search demos (Ctrl+K)"
+                    >
+                        <SearchIcon className="devkit-icon" />
+                        <span>Search</span>
+                        <kbd className="devkit-kbd">⌘K</kbd>
+                    </button>
+
+                    {isDemo && (
+                        <>
+                            <div className="devkit-sep" aria-hidden="true" />
+                            <a className="devkit-action" href={listingHref} aria-label="Back to component listing">
+                                <BackIcon className="devkit-icon" />
+                                <span>All demos</span>
+                            </a>
+                        </>
+                    )}
+
+                    <div className="devkit-sep" aria-hidden="true" />
+
+                    <Select
+                        label="Theme"
+                        value={params.theme}
+                        options={themes}
+                        onChange={theme => setParams({ theme })}
+                    />
+                    <Select
+                        label="Swatch"
+                        value={params.swatch}
+                        options={swatches}
+                        onChange={swatch => setParams({ swatch })}
+                    />
+
+                    <div className="devkit-sep" aria-hidden="true" />
+
+                    <button
+                        className={`devkit-action devkit-motion-toggle${params.animations ? ' devkit-toggle-on' : ''}`}
+                        onClick={() => setParams({ animations: !params.animations })}
+                        aria-pressed={params.animations}
+                        title={params.animations ? 'Disable animations' : 'Enable animations'}
+                    >
+                        <PlayIcon className="devkit-icon" />
+                        <span>Animations</span>
+                        <span className="devkit-switch" aria-hidden="true">
+                            <span className="devkit-switch-thumb" />
+                        </span>
+                    </button>
+                </div>
+            </div>
+
+            {status ? (
+                <div className={`devkit-toast${status.kind === 'error' ? ' devkit-toast-error' : ''}`} role="status">
+                    {status.kind === 'loading' && <span className="devkit-spinner" aria-hidden="true" />}
+                    <span className="devkit-toast-label">{status.kind === 'loading' ? 'Compiling' : 'Error'}</span>
+                    <span className="devkit-toast-value">{status.text}</span>
+                </div>
+            ) : toast ? (
+                <div key={toast.id} className="devkit-toast" role="status">
+                    <span className="devkit-toast-label">{toast.label}</span>
+                    <span className="devkit-toast-value">{toast.value}</span>
+                </div>
+            ) : null}
+
+            {searchOpen && createPortal(
+                <DevBarSearch
+                    theme={params.theme}
+                    swatch={params.swatch}
+                    onClose={() => setSearchOpen(false)}
+                />,
+                portalTarget
+            )}
+        </>
+    );
+}

--- a/packages/html/devkit/ui/DevBarSearch.tsx
+++ b/packages/html/devkit/ui/DevBarSearch.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { testRoutes } from 'virtual:test-routes';
+import { fuzzyMatch } from '../lib/fuzzy';
+import { getRecents, pushRecent } from '../lib/recents';
+import { themeQuery } from '../lib/theme';
+import { Highlight } from './Highlight';
+import { ClockIcon, FileIcon, SearchIcon } from './icons';
+
+interface Props {
+    theme: string;
+    swatch: string;
+    onClose: () => void;
+}
+
+interface Item {
+    component: string;
+    test: string;
+    matched: number[]; // indices into `${component}/${test}`
+    index: number; // position in the flat list (for active tracking)
+}
+
+const EMPTY_LIMIT = 50;
+
+function label(component: string, test: string): string {
+    return `${component}/${test}`;
+}
+
+export function DevBarSearch({ theme, swatch, onClose }: Props) {
+    const [query, setQuery] = useState('');
+    const [activeIndex, setActiveIndex] = useState(0);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const activeRef = useRef<HTMLAnchorElement>(null);
+
+    const themeQs = themeQuery(theme, swatch);
+
+    // Flat, sorted catalogue of every demo (theme-independent).
+    const catalogue = useMemo(
+        () =>
+            Object.entries(testRoutes)
+                .sort((a, b) => a[0].localeCompare(b[0]))
+                .flatMap(([component, tests]) =>
+                    [...tests].sort().map(test => ({ component, test }))
+                ),
+        []
+    );
+
+    // Recents that still exist in the catalogue.
+    const recents = useMemo(() => {
+        const exists = new Set(catalogue.map(c => label(c.component, c.test)));
+        return getRecents().filter(r => exists.has(label(r.component, r.test)));
+    }, [catalogue]);
+
+    const q = query.trim();
+
+    // Build the displayed list + its mode.
+    const { mode, items } = useMemo<{ mode: 'search' | 'recent' | 'all'; items: Item[] }>(() => {
+        if (!q) {
+            const source = recents.length ? recents : catalogue.slice(0, EMPTY_LIMIT);
+            return {
+                mode: recents.length ? 'recent' : 'all',
+                items: source.map((c, index) => ({ ...c, matched: [], index })),
+            };
+        }
+        const scored = catalogue
+            .map(c => ({ c, res: fuzzyMatch(q, label(c.component, c.test)) }))
+            .filter((x): x is { c: typeof x.c; res: NonNullable<typeof x.res> } => x.res !== null)
+            .sort((a, b) => b.res.score - a.res.score);
+        return {
+            mode: 'search',
+            items: scored.map(({ c, res }, index) => ({ ...c, matched: res.matched, index })),
+        };
+    }, [q, catalogue, recents]);
+
+    const navigate = (item: Item) => {
+        pushRecent(item.component, item.test);
+        window.location.href = `/${item.component}/${item.test}${themeQs}`;
+    };
+
+    useEffect(() => setActiveIndex(0), [q]);
+    useEffect(() => { inputRef.current?.focus(); }, []);
+    useEffect(() => { activeRef.current?.scrollIntoView({ block: 'nearest' }); }, [activeIndex]);
+
+    // Keyboard: navigation + close + focus trap.
+    useEffect(() => {
+        function onKey(e: KeyboardEvent) {
+            if (e.key === 'Escape') {
+                e.stopPropagation();
+                onClose();
+            } else if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setActiveIndex(i => Math.min(i + 1, items.length - 1));
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setActiveIndex(i => Math.max(i - 1, 0));
+            } else if (e.key === 'Enter') {
+                e.preventDefault();
+                const item = items[activeIndex];
+                if (item) navigate(item);
+            } else if (e.key === 'Tab') {
+                // Trap focus inside the dialog.
+                const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+                    'a[href], button, input, [tabindex]:not([tabindex="-1"])'
+                );
+                if (!focusable?.length) return;
+                const first = focusable[0];
+                const last = focusable[focusable.length - 1];
+                if (e.shiftKey && document.activeElement === first) {
+                    e.preventDefault();
+                    last.focus();
+                } else if (!e.shiftKey && document.activeElement === last) {
+                    e.preventDefault();
+                    first.focus();
+                }
+            }
+        }
+        window.addEventListener('keydown', onKey, { capture: true });
+        return () => window.removeEventListener('keydown', onKey, { capture: true });
+    }, [items, activeIndex, onClose, themeQs]);
+
+    const groupLabel =
+        mode === 'recent' ? 'Recent' : mode === 'search' ? `${items.length} result${items.length === 1 ? '' : 's'}` : 'All demos';
+
+    return (
+        <div className="devkit-search-backdrop" role="presentation" onClick={onClose}>
+            <div
+                ref={dialogRef}
+                className="devkit-search-dialog"
+                role="dialog"
+                aria-label="Search demos"
+                aria-modal="true"
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="devkit-search-input-row">
+                    <SearchIcon className="devkit-search-input-icon" />
+                    <input
+                        ref={inputRef}
+                        className="devkit-search-input"
+                        type="search"
+                        placeholder="Search demos…"
+                        value={query}
+                        onChange={e => setQuery(e.target.value)}
+                        role="combobox"
+                        aria-expanded="true"
+                        aria-controls="devkit-search-results"
+                        aria-activedescendant={items[activeIndex] ? `devkit-opt-${activeIndex}` : undefined}
+                        autoComplete="off"
+                        autoCorrect="off"
+                        spellCheck={false}
+                    />
+                    <button className="devkit-search-esc" onClick={onClose} aria-label="Close search">
+                        Esc
+                    </button>
+                </div>
+
+                <div id="devkit-search-results" className="devkit-search-results" role="listbox" aria-label="Search results">
+                    {items.length === 0 ? (
+                        <p className="devkit-search-empty" role="status">
+                            No demos match &ldquo;{q}&rdquo;
+                        </p>
+                    ) : (
+                        <>
+                            <div className="devkit-search-group-label">
+                                {mode === 'recent' && <ClockIcon className="devkit-icon" />}
+                                {groupLabel}
+                            </div>
+                            {items.map(item => {
+                                const isActive = item.index === activeIndex;
+                                const text = label(item.component, item.test);
+                                return (
+                                    <a
+                                        key={text}
+                                        id={`devkit-opt-${item.index}`}
+                                        ref={isActive ? activeRef : undefined}
+                                        className={`devkit-search-item${isActive ? ' devkit-search-item-active' : ''}`}
+                                        href={`/${item.component}/${item.test}${themeQs}`}
+                                        role="option"
+                                        aria-selected={isActive}
+                                        onMouseEnter={() => setActiveIndex(item.index)}
+                                        onClick={e => { e.preventDefault(); navigate(item); }}
+                                    >
+                                        <FileIcon className="devkit-search-item-icon" />
+                                        <span className="devkit-search-item-test">
+                                            <Highlight text={text} matched={item.matched} />
+                                        </span>
+                                    </a>
+                                );
+                            })}
+                        </>
+                    )}
+                </div>
+
+                <div className="devkit-search-footer" aria-hidden="true">
+                    <span className="devkit-search-hint"><kbd>↵</kbd> open</span>
+                    <span className="devkit-search-hint"><kbd>↑↓</kbd> navigate</span>
+                    <span className="devkit-search-hint"><kbd>esc</kbd> close</span>
+                    <span className="devkit-search-count">{catalogue.length} demos</span>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/packages/html/devkit/ui/ErrorBoundary.tsx
+++ b/packages/html/devkit/ui/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { BackIcon } from './icons';
+
+interface Props {
+    /** Label for what failed, e.g. "button/button-solid". */
+    title: string;
+    /** Link back to the listing (carrying current theme params). */
+    backHref: string;
+    children?: React.ReactNode;
+}
+
+interface State {
+    error: Error | null;
+}
+
+/**
+ * Catches both render-time errors and explicit failures (pass `error` via the
+ * `Failure` helper below) and shows a styled glass card instead of a blank page.
+ */
+export class ErrorBoundary extends React.Component<Props, State> {
+    state: State = { error: null };
+
+    static getDerivedStateFromError(error: Error): State {
+        return { error };
+    }
+
+    render() {
+        const { error } = this.state;
+        if (!error) return this.props.children;
+        return <ErrorCard title={this.props.title} backHref={this.props.backHref} message={String(error)} />;
+    }
+}
+
+export function ErrorCard({ title, backHref, message }: { title: string; backHref: string; message: string }) {
+    return (
+        <div className="devkit-error">
+            <div className="devkit-error-card">
+                <div className="devkit-error-title">Failed to load demo</div>
+                <code className="devkit-error-route">{title}</code>
+                <pre className="devkit-error-message">{message}</pre>
+                <a className="devkit-error-back" href={backHref}>
+                    <BackIcon className="devkit-icon" />
+                    Back to all demos
+                </a>
+            </div>
+        </div>
+    );
+}

--- a/packages/html/devkit/ui/Highlight.tsx
+++ b/packages/html/devkit/ui/Highlight.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { segmentize } from '../lib/fuzzy';
+
+/** Renders `text` with the fuzzy-matched character ranges emphasized. */
+export function Highlight({ text, matched }: { text: string; matched: number[] }) {
+    return (
+        <>
+            {segmentize(text, matched).map((seg, i) =>
+                seg.match
+                    ? <span key={i} className="devkit-hl">{seg.text}</span>
+                    : <span key={i}>{seg.text}</span>
+            )}
+        </>
+    );
+}

--- a/packages/html/devkit/ui/LandingPage.tsx
+++ b/packages/html/devkit/ui/LandingPage.tsx
@@ -1,0 +1,152 @@
+import React, { useMemo, useState } from 'react';
+import { testRoutes } from 'virtual:test-routes';
+import { DevKitProvider, useDevKit } from '../context';
+import { fuzzyMatch } from '../lib/fuzzy';
+import { themeQuery } from '../lib/theme';
+import { pushRecent } from '../lib/recents';
+import { DevBar } from './DevBar';
+import { Highlight } from './Highlight';
+import { ChevronIcon, KendoLogo, SearchIcon } from './icons';
+import '../devkit.css';
+
+interface MatchedTest {
+    test: string;
+    matched: number[];
+}
+
+interface MatchedComponent {
+    component: string;
+    componentMatched: number[];
+    tests: MatchedTest[];
+}
+
+function LandingPageContent() {
+    const { params } = useDevKit();
+    const [search, setSearch] = useState('');
+    const [open, setOpen] = useState<Set<string>>(new Set());
+
+    const themeQs = themeQuery(params.theme, params.swatch);
+    const q = search.trim();
+
+    const components = useMemo<MatchedComponent[]>(() => {
+        return Object.entries(testRoutes)
+            .map(([component, tests]) => {
+                const compRes = q ? fuzzyMatch(q, component) : { score: 0, matched: [] };
+                const sorted = [...tests].sort();
+
+                // A component-name match surfaces all its tests; otherwise filter per test.
+                const matchedTests: MatchedTest[] = compRes
+                    ? sorted.map(test => ({ test, matched: [] }))
+                    : sorted
+                          .map(test => ({ test, res: fuzzyMatch(q, test) }))
+                          .filter((x): x is { test: string; res: NonNullable<typeof x.res> } => x.res !== null)
+                          .map(x => ({ test: x.test, matched: x.res.matched }));
+
+                return {
+                    component,
+                    componentMatched: compRes?.matched ?? [],
+                    tests: matchedTests,
+                };
+            })
+            .filter(c => c.tests.length > 0)
+            .sort((a, b) => a.component.localeCompare(b.component));
+    }, [q]);
+
+    const totalTests = useMemo(
+        () => Object.values(testRoutes).reduce((sum, tests) => sum + tests.length, 0),
+        []
+    );
+
+    const toggle = (component: string) =>
+        setOpen(prev => {
+            const next = new Set(prev);
+            if (next.has(component)) next.delete(component);
+            else next.add(component);
+            return next;
+        });
+
+    return (
+        <div className="devkit-landing">
+            <header className="devkit-landing-header">
+                <KendoLogo className="devkit-landing-logo" />
+                <span className="devkit-landing-title">Kendo Themes Dev</span>
+                <span className="devkit-landing-stats">
+                    <strong>{Object.keys(testRoutes).length}</strong> components ·{' '}
+                    <strong>{totalTests}</strong> tests
+                </span>
+            </header>
+
+            <main className="devkit-landing-body">
+                <div className="devkit-landing-search" role="search">
+                    <SearchIcon className="devkit-landing-search-icon" />
+                    <input
+                        className="devkit-landing-search-input"
+                        type="search"
+                        placeholder="Filter components or tests…"
+                        value={search}
+                        onChange={e => setSearch(e.target.value)}
+                        aria-label="Filter components"
+                    />
+                    <span className="devkit-landing-search-kbd" aria-hidden="true">
+                        <kbd>⌘K</kbd> palette
+                    </span>
+                </div>
+
+                {components.length === 0 ? (
+                    <div className="devkit-no-results" role="status">
+                        No components match &ldquo;{q}&rdquo;
+                    </div>
+                ) : (
+                    <div className="devkit-acc-list">
+                        {components.map(({ component, componentMatched, tests }) => {
+                            const isOpen = q ? true : open.has(component);
+                            const regionId = `devkit-region-${component}`;
+                            return (
+                                <div key={component} className="devkit-acc-item" data-open={isOpen}>
+                                    <button
+                                        className="devkit-acc-summary"
+                                        onClick={() => toggle(component)}
+                                        aria-expanded={isOpen}
+                                        aria-controls={regionId}
+                                    >
+                                        <ChevronIcon className="devkit-acc-chevron" />
+                                        <span className="devkit-acc-name">
+                                            <Highlight text={component} matched={componentMatched} />
+                                        </span>
+                                        <span className="devkit-acc-badge">{tests.length}</span>
+                                    </button>
+                                    <div id={regionId} className="devkit-acc-region" role="region">
+                                        <div className="devkit-acc-inner">
+                                            <div className="devkit-test-list">
+                                                {tests.map(({ test, matched }) => (
+                                                    <a
+                                                        key={test}
+                                                        className="devkit-test-link"
+                                                        href={`/${component}/${test}${themeQs}`}
+                                                        onClick={() => pushRecent(component, test)}
+                                                    >
+                                                        <Highlight text={test} matched={matched} />
+                                                    </a>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </main>
+
+            <DevBar />
+        </div>
+    );
+}
+
+export function LandingPage() {
+    return (
+        <DevKitProvider>
+            <LandingPageContent />
+        </DevKitProvider>
+    );
+}

--- a/packages/html/devkit/ui/Select.tsx
+++ b/packages/html/devkit/ui/Select.tsx
@@ -1,0 +1,163 @@
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { ChevronIcon } from './icons';
+
+interface SelectProps {
+    label: string;
+    value: string;
+    options: string[];
+    onChange: (value: string) => void;
+}
+
+/**
+ * Compact, fully-keyboard-accessible listbox dropdown. Replaces the native
+ * `<select>` so the option list can be styled to match the glass UI and animate.
+ * Opens upward (the bar lives at the bottom of the viewport).
+ */
+export function Select({ label, value, options, onChange }: SelectProps) {
+    const [open, setOpen] = useState(false);
+    const [active, setActive] = useState(0);
+    const rootRef = useRef<HTMLDivElement>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const listRef = useRef<HTMLUListElement>(null);
+    const typeahead = useRef({ buffer: '', at: 0 });
+    const baseId = useId();
+
+    const selectedIndex = Math.max(0, options.indexOf(value));
+
+    const close = useCallback((focusButton = true) => {
+        setOpen(false);
+        if (focusButton) buttonRef.current?.focus();
+    }, []);
+
+    const choose = useCallback((option: string) => {
+        onChange(option);
+        close();
+    }, [onChange, close]);
+
+    // Open with the current value highlighted; move DOM focus into the list.
+    useEffect(() => {
+        if (!open) return;
+        setActive(selectedIndex);
+        listRef.current?.focus();
+    }, [open, selectedIndex]);
+
+    // Keep the active option scrolled into view.
+    useEffect(() => {
+        if (!open) return;
+        listRef.current?.querySelector('[data-active="true"]')
+            ?.scrollIntoView({ block: 'nearest' });
+    }, [open, active]);
+
+    // Close on outside interaction.
+    useEffect(() => {
+        if (!open) return;
+        function onDown(e: PointerEvent) {
+            if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+        }
+        window.addEventListener('pointerdown', onDown, true);
+        return () => window.removeEventListener('pointerdown', onDown, true);
+    }, [open]);
+
+    const onListKeyDown = (e: React.KeyboardEvent) => {
+        switch (e.key) {
+            case 'Escape':
+                e.preventDefault();
+                close();
+                break;
+            case 'ArrowDown':
+                e.preventDefault();
+                setActive(i => Math.min(i + 1, options.length - 1));
+                break;
+            case 'ArrowUp':
+                e.preventDefault();
+                setActive(i => Math.max(i - 1, 0));
+                break;
+            case 'Home':
+                e.preventDefault();
+                setActive(0);
+                break;
+            case 'End':
+                e.preventDefault();
+                setActive(options.length - 1);
+                break;
+            case 'Enter':
+            case ' ':
+                e.preventDefault();
+                choose(options[active]);
+                break;
+            case 'Tab':
+                setOpen(false);
+                break;
+            default: {
+                // Type-ahead: jump to the first option starting with typed chars.
+                if (e.key.length !== 1) return;
+                const now = Date.now();
+                const ta = typeahead.current;
+                ta.buffer = now - ta.at > 600 ? e.key : ta.buffer + e.key;
+                ta.at = now;
+                const match = options.findIndex(o =>
+                    o.toLowerCase().startsWith(ta.buffer.toLowerCase())
+                );
+                if (match >= 0) setActive(match);
+            }
+        }
+    };
+
+    return (
+        <div className="devkit-select-group" ref={rootRef}>
+            <span className="devkit-select-label" id={`${baseId}-label`}>{label}</span>
+            <div className="devkit-select-wrap">
+                <button
+                    ref={buttonRef}
+                    type="button"
+                    className="devkit-select"
+                    aria-haspopup="listbox"
+                    aria-expanded={open}
+                    aria-labelledby={`${baseId}-label`}
+                    onClick={() => setOpen(o => !o)}
+                    onKeyDown={e => {
+                        if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            setOpen(true);
+                        }
+                    }}
+                >
+                    <span className="devkit-select-value">{value}</span>
+                    <ChevronIcon className="devkit-select-arrow" />
+                </button>
+
+                {open && (
+                    <ul
+                        ref={listRef}
+                        role="listbox"
+                        tabIndex={-1}
+                        className="devkit-select-list"
+                        aria-labelledby={`${baseId}-label`}
+                        aria-activedescendant={`${baseId}-opt-${active}`}
+                        onKeyDown={onListKeyDown}
+                        onBlur={e => {
+                            if (!rootRef.current?.contains(e.relatedTarget as Node)) {
+                                setOpen(false);
+                            }
+                        }}
+                    >
+                        {options.map((option, i) => (
+                            <li
+                                key={option}
+                                id={`${baseId}-opt-${i}`}
+                                role="option"
+                                aria-selected={option === value}
+                                data-active={i === active}
+                                className="devkit-select-option"
+                                onMouseEnter={() => setActive(i)}
+                                onClick={() => choose(option)}
+                            >
+                                {option}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/packages/html/devkit/ui/icons.tsx
+++ b/packages/html/devkit/ui/icons.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+/**
+ * Shared SVG icon set for the devkit. Each icon inherits `currentColor` and
+ * accepts a className so callers control sizing/color via CSS tokens.
+ */
+
+interface IconProps {
+    className?: string;
+}
+
+function Icon({ className, children, viewBox = '0 0 16 16' }: IconProps & {
+    children: React.ReactNode;
+    viewBox?: string;
+}) {
+    return (
+        <svg
+            className={className}
+            viewBox={viewBox}
+            fill="currentColor"
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            {children}
+        </svg>
+    );
+}
+
+export const SearchIcon = ({ className }: IconProps) => (
+    <Icon className={className}>
+        <path d="M6.5 1a5.5 5.5 0 1 1 0 11 5.5 5.5 0 0 1 0-11zm0 1a4.5 4.5 0 1 0 0 9 4.5 4.5 0 0 0 0-9zm5.443 8.736.707.707-3.5 3.5-.707-.707 3.5-3.5z" />
+    </Icon>
+);
+
+export const ChevronIcon = ({ className }: IconProps) => (
+    <Icon className={className}>
+        <path
+            fillRule="evenodd"
+            d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"
+        />
+    </Icon>
+);
+
+export const BackIcon = ({ className }: IconProps) => (
+    <Icon className={className}>
+        <path
+            fillRule="evenodd"
+            d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"
+        />
+    </Icon>
+);
+
+export const FileIcon = ({ className }: IconProps) => (
+    <Icon className={className}>
+        <path d="M9.293 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4.707L9.293 0zM9.5 3.5v-2l3 3h-2a1 1 0 0 1-1-1z" />
+    </Icon>
+);
+
+export const PlayIcon = ({ className }: IconProps) => (
+    <Icon className={className}>
+        <path d="M3 2.5a.5.5 0 0 1 .765-.424l10 5.5a.5.5 0 0 1 0 .848l-10 5.5A.5.5 0 0 1 3 13.5v-11z" />
+    </Icon>
+);
+
+export const ClockIcon = ({ className }: IconProps) => (
+    <Icon className={className}>
+        <path d="M8 3.5a.5.5 0 0 0-.5.5v4a.5.5 0 0 0 .252.434l2.5 1.5a.5.5 0 0 0 .496-.868L8.5 7.71V4a.5.5 0 0 0-.5-.5z" />
+        <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0z" />
+    </Icon>
+);
+
+export const KendoLogo = ({ className }: IconProps) => (
+    <svg
+        className={className}
+        viewBox="0 0 20 20"
+        fill="none"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <rect width="20" height="20" rx="4" fill="#FF6358" />
+        <path d="M4 4h5v12H4zM11 4h5v5h-5zM11 11h5v5h-5z" fill="white" />
+    </svg>
+);

--- a/packages/html/devkit/vite.config.ts
+++ b/packages/html/devkit/vite.config.ts
@@ -1,0 +1,326 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { globSync } from 'glob';
+import type { Plugin, ViteDevServer } from 'vite';
+
+// __dirname is provided by Vite's esbuild config bundler
+const devkitDir = __dirname;
+const repoRoot = resolve(devkitDir, '../../..');
+
+// Packages under packages/* that are not selectable themes.
+const NON_THEME_PACKAGES = new Set(['utils', 'html']);
+
+const execAsync = promisify(exec);
+const sassBin = resolve(repoRoot, 'node_modules/.bin/sass');
+
+/** Compile a package's `scss/all.scss` → `dist/all.css` (expanded, dev mode). */
+function compileAllCss(pkg: string): Promise<unknown> {
+    const cmd = `"${sassBin}" --no-source-map --load-path=../../node_modules ./scss/all.scss ./dist/all.css`;
+    return execAsync(cmd, { cwd: resolve(repoRoot, `packages/${pkg}`) });
+}
+
+/** Build every swatch CSS for a theme (gulp → sass → postcss) via its npm script. */
+function buildSwatches(pkg: string): Promise<unknown> {
+    return execAsync('npm run sass:dist', { cwd: resolve(repoRoot, `packages/${pkg}`) });
+}
+
+/** Extracts the most useful error text from a failed exec. */
+function execError(err: unknown): string {
+    return (err as { stderr?: string }).stderr?.trim() || String(err);
+}
+
+/**
+ * Serves devkit/index.html for all SPA navigation requests (routes without a
+ * file extension that aren't Vite-internal paths). Registered as a pre-middleware
+ * so it intercepts navigation requests before Vite's built-in 404 handling.
+ * Requests with file extensions are skipped and handled normally by Vite.
+ */
+function htmlFallbackPlugin(): Plugin {
+    const indexHtmlPath = resolve(devkitDir, 'index.html');
+
+    return {
+        name: 'devkit-html-fallback',
+        configureServer(server) {
+            server.middlewares.use(async (req, res, next) => {
+                const url = req.url ?? '/';
+
+                // Skip Vite internals, HMR, and requests that look like file assets
+                if (
+                    url.startsWith('/@') ||
+                    url.startsWith('/__') ||
+                    /\.\w{1,10}(\?.*)?$/.test(url)
+                ) {
+                    return next();
+                }
+
+                try {
+                    const rawHtml = readFileSync(indexHtmlPath, 'utf-8');
+                    const transformed = await server.transformIndexHtml(url, rawHtml);
+                    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+                    res.end(transformed);
+                } catch (e) {
+                    next(e as Error);
+                }
+            });
+        },
+    };
+}
+
+/**
+ * Redirects legacy esbuild dev-server URLs to clean devkit routes so that
+ * existing bookmarks and render-test-pages URLs continue to work.
+ *
+ * Legacy:  /packages/html/dist/{component}/tests/{test}/
+ * Devkit:  /{component}/{test}?...
+ */
+function legacyRedirectPlugin(): Plugin {
+    return {
+        name: 'devkit-legacy-redirect',
+        configureServer(server) {
+            server.middlewares.use((req, res, next) => {
+                const url = req.url ?? '/';
+                const m = url.match(/^\/packages\/html\/dist\/([^/?]+)\/tests\/([^/?]+)\/?(\?.*)?$/);
+                if (m) {
+                    const [, comp, test, qs = ''] = m;
+                    res.writeHead(301, { Location: `/${comp}/${test}${qs}` });
+                    res.end();
+                    return;
+                }
+                next();
+            });
+        },
+    };
+}
+
+/**
+ * Generates the `virtual:test-routes` module — a static map of
+ * `{ [component]: testName[] }` derived from `packages/html/src` at startup.
+ * Also watches for new/deleted test files and invalidates the virtual module
+ * so the dev server picks them up without a restart.
+ */
+function testRoutesPlugin(): Plugin {
+    const virtualId = 'virtual:test-routes';
+    const resolvedId = `\0${virtualId}`;
+
+    function buildRoutes(): string {
+        const files = globSync('packages/html/src/**/tests/*.tsx', {
+            cwd: repoRoot,
+            posix: true,
+        });
+
+        const routes: Record<string, string[]> = {};
+        for (const file of files) {
+            const m = file.match(/packages\/html\/src\/([^/]+)\/tests\/([^/]+)\.tsx$/);
+            if (m) {
+                const [, component, test] = m;
+                if (!routes[component]) routes[component] = [];
+                routes[component].push(test);
+            }
+        }
+
+        return `export const testRoutes = ${JSON.stringify(routes)};`;
+    }
+
+    return {
+        name: 'devkit-test-routes',
+        resolveId(id) {
+            if (id === virtualId) return resolvedId;
+        },
+        load(id) {
+            if (id !== resolvedId) return;
+            return buildRoutes();
+        },
+        configureServer(server) {
+            const testGlob = resolve(repoRoot, 'packages/html/src/**/tests/*.tsx');
+            server.watcher.add(testGlob);
+
+            const invalidate = () => {
+                const mod = server.moduleGraph.getModuleById(resolvedId);
+                if (mod) server.moduleGraph.invalidateModule(mod);
+                server.ws.send({ type: 'full-reload' });
+            };
+
+            const isTestFile = (f: string) =>
+                f.replace(/\\/g, '/').match(/packages\/html\/src\/[^/]+\/tests\/[^/]+\.tsx$/) !== null;
+
+            server.watcher.on('add', (f) => { if (isTestFile(f)) invalidate(); });
+            server.watcher.on('unlink', (f) => { if (isTestFile(f)) invalidate(); });
+        },
+    };
+}
+
+/**
+ * Generates the `virtual:swatch-map` module — a static map of
+ * `{ [theme]: swatchName[] }` derived from each theme's swatch *source*
+ * (`lib/swatches/*.json`). Sourcing from definitions rather than compiled dist
+ * means the dropdown is fully populated even before anything is built; the CSS
+ * is compiled lazily on first request (see `lazyCssPlugin`).
+ */
+function swatchMapPlugin(): Plugin {
+    const virtualId = 'virtual:swatch-map';
+    const resolvedId = `\0${virtualId}`;
+
+    return {
+        name: 'devkit-swatch-map',
+        resolveId(id) {
+            if (id === virtualId) return resolvedId;
+        },
+        load(id) {
+            if (id !== resolvedId) return;
+
+            const files = globSync('packages/*/lib/swatches/*.json', {
+                cwd: repoRoot,
+                posix: true,
+            });
+
+            const map: Record<string, string[]> = {};
+            for (const file of files) {
+                const m = file.match(/packages\/([^/]+)\/lib\/swatches\/([^/]+)\.json$/);
+                if (m) {
+                    const [, theme, swatch] = m;
+                    if (NON_THEME_PACKAGES.has(theme)) continue;
+                    (map[theme] ??= []).push(swatch);
+                }
+            }
+            for (const swatches of Object.values(map)) swatches.sort();
+
+            return `export const swatchMap = ${JSON.stringify(map)};`;
+        },
+    };
+}
+
+/**
+ * Watches theme SCSS sources for changes, recompiles the affected theme's
+ * `all.css` using the sass binary, then sends a custom `kendo:css-update` HMR
+ * event so the browser hot-swaps the CSS link without a full page reload.
+ *
+ * Only active in dev server mode (`apply: 'serve'`).
+ */
+function scssWatchPlugin(): Plugin {
+    const pending = new Map<string, ReturnType<typeof setTimeout>>();
+
+    return {
+        name: 'devkit-scss-watch',
+        apply: 'serve',
+        configureServer(server) {
+            // Tell chokidar to watch all theme SCSS source trees
+            server.watcher.add(`${repoRoot}/packages/*/scss/**/*.scss`);
+
+            server.watcher.on('change', (filePath: string) => {
+                const normalised = filePath.replace(/\\/g, '/');
+                const m = normalised.match(/packages\/([^/]+)\/scss\//);
+                if (!m) return;
+
+                const theme = m[1];
+                if (NON_THEME_PACKAGES.has(theme)) return;
+
+                // Debounce rapid saves — only compile once per 300 ms quiet window
+                const existing = pending.get(theme);
+                if (existing) clearTimeout(existing);
+
+                pending.set(theme, setTimeout(async () => {
+                    pending.delete(theme);
+                    server.config.logger.info(`  → [kendo] recompiling ${theme}/all.css…`, { timestamp: true });
+
+                    try {
+                        await compileAllCss(theme);
+                        server.config.logger.info(`  ✓ [kendo] ${theme}/all.css ready`, { timestamp: true });
+                        // Notify any connected browser to hot-swap the CSS link
+                        server.ws.send({ type: 'custom', event: 'kendo:css-update', data: { theme } });
+                    } catch (err) {
+                        server.config.logger.error(`  ✗ [kendo] ${theme} sass error:\n${execError(err)}`);
+                    }
+                }, 300));
+            });
+        },
+    };
+}
+
+/**
+ * Compiles theme CSS on demand: when the browser requests a
+ * `/packages/{pkg}/dist/{name}.css` that doesn't exist yet, build it, then let
+ * Vite serve the freshly written file. `all.css` uses the fast single-file sass
+ * command; any other name triggers the theme's full swatch build (once). This
+ * removes the pre-build requirement — `npm start` just works and only the CSS
+ * you actually view is compiled (and cached to disk for next time).
+ */
+function lazyCssPlugin(): Plugin {
+    const building = new Map<string, Promise<unknown>>();
+
+    function ensureBuilt(server: ViteDevServer, pkg: string, name: string): Promise<unknown> {
+        const isAll = name === 'all';
+        const key = isAll ? `${pkg}/all` : `${pkg}/__swatches__`;
+
+        let job = building.get(key);
+        if (!job) {
+            const label = isAll ? `${pkg}/all.css` : `${pkg} swatches`;
+            server.config.logger.info(`  → [kendo] compiling ${label}…`, { timestamp: true });
+            job = (isAll ? compileAllCss(pkg) : buildSwatches(pkg))
+                .then(() => server.config.logger.info(`  ✓ [kendo] ${label} ready`, { timestamp: true }))
+                .finally(() => building.delete(key));
+            building.set(key, job);
+        }
+        return job;
+    }
+
+    return {
+        name: 'devkit-lazy-css',
+        apply: 'serve',
+        configureServer(server) {
+            server.middlewares.use(async (req, res, next) => {
+                const url = (req.url ?? '').split('?')[0];
+                const m = url.match(/^\/packages\/([^/]+)\/dist\/([^/]+)\.css$/);
+                if (!m) return next();
+
+                const [, pkg, name] = m;
+                const distPath = resolve(repoRoot, `packages/${pkg}/dist/${name}.css`);
+                if (existsSync(distPath)) return next(); // already built — Vite serves it
+
+                // Only packages with an scss entry are buildable; others 404 as before.
+                if (!existsSync(resolve(repoRoot, `packages/${pkg}/scss/all.scss`))) return next();
+
+                try {
+                    await ensureBuilt(server, pkg, name);
+                } catch (err) {
+                    const message = execError(err);
+                    server.config.logger.error(`  ✗ [kendo] ${pkg}/${name}.css build failed:\n${message}`);
+                    server.ws.send({ type: 'custom', event: 'kendo:css-error', data: { pkg, name, message } });
+                    // Respond with a valid (empty) stylesheet so the <link> still fires `load`.
+                    res.writeHead(200, { 'Content-Type': 'text/css' });
+                    res.end(`/* devkit: failed to build ${pkg}/${name}.css — see terminal */`);
+                    return;
+                }
+                return next(); // file now exists — hand off to Vite's static serving
+            });
+        },
+    };
+}
+
+export default defineConfig({
+    root: repoRoot,
+    appType: 'custom',
+    server: {
+        port: 3000,
+        fs: {
+            // Allow serving files from outside the root (e.g. node_modules hoisted to repo root)
+            strict: false,
+        },
+    },
+    optimizeDeps: {
+        entries: ['packages/html/devkit/main.tsx'],
+        include: ['react', 'react-dom/client'],
+    },
+    plugins: [
+        legacyRedirectPlugin(),
+        lazyCssPlugin(),
+        htmlFallbackPlugin(),
+        react(),
+        testRoutesPlugin(),
+        swatchMapPlugin(),
+        scssWatchPlugin(),
+    ],
+});


### PR DESCRIPTION
closes: https://progresssoftware.atlassian.net/browse/FE-1283

 ## Summary
 
 Added a new Vite-based HTML devkit for `packages/html` and wired the repo to use it as the default `npm start` path. The devkit includes route handling, lazy CSS compilation, swatch/test route discovery, and HMR support for theme CSS changes.
 
 ## Why
 
 This modernizes the HTML development flow while keeping existing workflows intact. Splitting the TypeScript config into browser and Node targets separates Vite/runtime concerns from app code, and the legacy screenshot/render-test pipeline remains supported through redirects so existing URLs and scripts keep working.
 