### PR TITLE
fix(timeline): match card callout background to card color

### DIFF
--- a/packages/meridian/scss/timeline/_theme.scss
+++ b/packages/meridian/scss/timeline/_theme.scss
@@ -6,8 +6,11 @@
 @mixin kendo-timeline--theme() {
     @include kendo-timeline--theme-base();
 
-    .k-timeline-card .k-card {
-        background-color: k-color(surface-alt);
+    .k-timeline-card {
+        .k-card,
+        .k-card-callout {
+            background-color: k-color(surface-alt);
+        }
     }
 
     .k-timeline-track-item.k-focus .k-timeline-circle {


### PR DESCRIPTION
fixes: https://progresssoftware.atlassian.net/browse/FE-1291
fixes: https://github.com/telerik/kendo-themes/issues/5998