### PR TITLE
Fix issues in demos

### DIFF
--- a/packages/html/src/chip/constants.ts
+++ b/packages/html/src/chip/constants.ts
@@ -1,2 +1,3 @@
 export const CHIP_MODULE_NAME = 'chip';
 export const CHIP_FOLDER_NAME = CHIP_MODULE_NAME;
+export const CHIP_DEMO_AVATAR_IMAGE = 'https://demos.telerik.com/kendo-ui/content/web/Customers/RICSU.jpg';

--- a/packages/html/src/chip/demos/chip-list.tsx
+++ b/packages/html/src/chip/demos/chip-list.tsx
@@ -2,6 +2,7 @@ import { ChipList, KendoChipListProps } from '../chip-list.spec';
 import { ChipNormal } from '../templates/chip-normal';
 import { ChipAction } from '../chip-action';
 import Chip, { KendoChipProps } from '../chip.spec';
+import { CHIP_DEMO_AVATAR_IMAGE } from '../constants';
 
 const options = {
   ...Chip.options,
@@ -42,12 +43,13 @@ export const ChipListDemo = (props:
   const hasIcon = modifiers?.icon;
   const hasActions = modifiers?.actions;
   const hasAvatar = modifiers?.avatar;
+  const avatarImage = hasAvatar ? CHIP_DEMO_AVATAR_IMAGE : undefined;
 
   return (
     <ChipList size={other.size}  className={className}>
-      <ChipNormal {...other} role="option" aria-selected="false" aria-pressed={undefined} icon={hasIcon ? "star" : undefined} actions={hasActions ? <ChipAction type="remove" /> : undefined} showAvatar={hasAvatar}>Chip</ChipNormal>
-      <ChipNormal {...other} role="option" aria-selected="false" aria-pressed={undefined} icon={hasIcon ? "star" : undefined} actions={hasActions ? <ChipAction type="remove" /> : undefined} showAvatar={hasAvatar}>Chip</ChipNormal>
-      <ChipNormal {...other} role="option" aria-selected="false" aria-pressed={undefined} icon={hasIcon ? "star" : undefined} actions={hasActions ? <ChipAction type="remove" /> : undefined} showAvatar={hasAvatar}>Chip</ChipNormal>
+      <ChipNormal {...other} role="option" aria-selected="false" aria-pressed={undefined} icon={hasIcon ? "star" : undefined} actions={hasActions ? <ChipAction type="remove" /> : undefined} showAvatar={hasAvatar} avatarImage={avatarImage}>Chip</ChipNormal>
+      <ChipNormal {...other} role="option" aria-selected="false" aria-pressed={undefined} icon={hasIcon ? "star" : undefined} actions={hasActions ? <ChipAction type="remove" /> : undefined} showAvatar={hasAvatar} avatarImage={avatarImage}>Chip</ChipNormal>
+      <ChipNormal {...other} role="option" aria-selected="false" aria-pressed={undefined} icon={hasIcon ? "star" : undefined} actions={hasActions ? <ChipAction type="remove" /> : undefined} showAvatar={hasAvatar} avatarImage={avatarImage}>Chip</ChipNormal>
     </ChipList>
   );
 }

--- a/packages/html/src/chip/demos/chip.tsx
+++ b/packages/html/src/chip/demos/chip.tsx
@@ -1,5 +1,6 @@
 import { ChipAction } from "../chip-action";
 import { Chip, KendoChipProps } from "../chip.spec";
+import { CHIP_DEMO_AVATAR_IMAGE } from '../constants';
 
 const states = Chip.states;
 const defaults = Chip.defaultOptions;
@@ -40,7 +41,7 @@ export const ChipDemo = (
         break;
       case 'avatar':
         additionalProps.showAvatar = mods?.[modifier] ? true : false;
-        additionalProps.avatarImage = mods?.[modifier] ? "https://demos.telerik.com/kendo-ui/content/web/Customers/RICSU.jpg" : undefined;
+        additionalProps.avatarImage = mods?.[modifier] ? CHIP_DEMO_AVATAR_IMAGE : undefined;
         break;
       case 'more-options':
         if (!additionalProps.actions) {

--- a/packages/html/src/slider/demos/slider.tsx
+++ b/packages/html/src/slider/demos/slider.tsx
@@ -42,9 +42,10 @@ export const SliderDemo = (
         modifiers?: { [key: (typeof modifiers)[number]['name']]: boolean };
     }
 ) => {
-    const { variant, modifiers: mods, ...other } = { ...defaults, ...props };
+    const { variant, modifiers: mods, ...other } = props;
 
-    let additionalProps: any = {};
+    let label = defaults.label;
+    let additionalProps: Pick<KendoSliderProps, 'showButtons' | 'showTicks'> = {};
 
     Object.keys(mods || {}).forEach((modifier) => {
         switch (modifier) {
@@ -53,7 +54,7 @@ export const SliderDemo = (
                 break;
             }
             case 'label': {
-                additionalProps.label = mods?.[modifier] ? true : false;
+                label = mods?.[modifier] ? true : false;
                 break;
             }
             case 'tick': {
@@ -62,14 +63,12 @@ export const SliderDemo = (
             }
         }
     });
-
-    const { label = true, showButtons, showTicks } = additionalProps;
     const style = { "--kendo-slider-start": 0, "--kendo-slider-end": 60 } as React.CSSProperties;
 
     switch (variant) {
         case 'vertical':
             return (
-                <SliderVertical showTicks={showTicks} showButtons={showButtons} style={{ height: "300px", ...style }} {...other}>
+                <SliderVertical style={{ height: "300px", ...style }} {...other} {...additionalProps}>
                     <SliderTick label={label} large orientation="vertical" text="0" style={{ position: "absolute", bottom: "0%" }} />
                     <SliderTick label={label} large orientation="vertical" text="2" style={{ position: "absolute", bottom: "25%" }} />
                     <SliderTick label={label} large orientation="vertical" text="4" style={{ position: "absolute", bottom: "50%" }} />
@@ -80,7 +79,7 @@ export const SliderDemo = (
         case 'horizontal':
         default:
             return (
-                <SliderNormal showTicks={showTicks} showButtons={showButtons} style={{ width: "400px", ...style }} {...other}>
+                <SliderNormal style={{ width: "400px", ...style }} {...other} {...additionalProps}>
                     <SliderTick label={label} large orientation="horizontal" text="0" style={{ position: "absolute", left: "0%" }} />
                     <SliderTick label={label} large orientation="horizontal" text="2" style={{ position: "absolute", left: "25%" }} />
                     <SliderTick label={label} large orientation="horizontal" text="4" style={{ position: "absolute", left: "50%" }} />

--- a/packages/html/src/slider/demos/slider.tsx
+++ b/packages/html/src/slider/demos/slider.tsx
@@ -25,15 +25,18 @@ const variants = [
 const modifiers = [
     {
         name: 'label',
-        title: 'Labels'
+        title: 'Labels',
+        default: true,
     },
     {
         name: 'tick',
-        title: 'Ticks'
+        title: 'Ticks',
+        default: true,
     },
     {
         name: 'button',
-        title: 'Side Buttons'
+        title: 'Side Buttons',
+        default: true,
     },
 ];
 


### PR DESCRIPTION
**Summary**
This PR improves HTML demo consistency and option handling across several demo components, and refreshes visual regression outputs accordingly.

**What changed**
Centralized the Chip demo avatar image URL into a shared constant and reused it across Chip demos.
Improved Slider demo modifier behavior:
Added default values for all modifiers (Labels, Ticks, Side Buttons).
Refactored modifier handling to keep label state explicit and type-safe.
Passed computed slider props in a cleaner, unified way.
Updated Grid Layout demo structure and alignment:
Defined explicit grid rows for a consistent 3x3 layout.
Adjusted demo cell composition to match the intended visual structure.
Switched item alignment to stretch for start/middle/end variants while preserving horizontal justification behavior.
Regenerated visual preview artifacts for all affected themes/components.