### PR TITLE
fix(grid): remove ellipsis from checkbox/radio-only cells

### DIFF
--- a/packages/core/scss/components/grid/_layout.scss
+++ b/packages/core/scss/components/grid/_layout.scss
@@ -352,6 +352,13 @@
             text-overflow: clip;
         }
 
+        .k-table-td:has(> .k-checkbox-wrap:only-child),
+        .k-table-th:has(> .k-checkbox-wrap:only-child),
+        .k-table-td:has(> .k-radio-wrap:only-child),
+        .k-table-th:has(> .k-radio-wrap:only-child) {
+            text-overflow: clip;
+        }
+
         .k-hierarchy-cell + .k-grid-content-sticky {
             border-inline-start-width: $kendo-grid-cell-vertical-border-width;
         }


### PR DESCRIPTION
## Description

When a Grid/TreeList td/th contains only a `k-checkbox-wrap` or `k-radio-wrap` as its direct child (i.e. the checkbox selection column), the inherited `text-overflow: ellipsis` rule causes an unexpected ellipsis to appear when the column is set to a narrow width.

## Fix

Added `:has()` selector rules to override `text-overflow` to `clip` for cells whose only direct child is a checkbox or radio wrap — consistent with the existing `.k-pin-cell` pattern already in the same file:

```scss
.k-table-td:has(> .k-checkbox-wrap:only-child),
.k-table-th:has(> .k-checkbox-wrap:only-child),
.k-table-td:has(> .k-radio-wrap:only-child),
.k-table-th:has(> .k-radio-wrap:only-child) {
    text-overflow: clip;
}
```

Fixes #6008
closes: https://progresssoftware.atlassian.net/browse/FE-1293