### PR TITLE
chore(deps): add Harness npm registry to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,16 @@
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+registries:
+  harness-npm:
+    type: npm-registry
+    url: https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-devtools-npm/npm/
+    replaces-base: true
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    registries:
+      - harness-npm
     schedule:
       interval: "monthly"
     target-branch: "develop"


### PR DESCRIPTION
@tsvetomir @ivanchev - since Dependabot would also modify the package-lock, should we maybe override it's registry as well? Or do you maybe consider overriding this at a workflow level intead?