### PR TITLE
chore(ci): adopt telerik/actions/npm-ci for package installation

### DIFF
--- a/.github/workflows/_audit-css.yml
+++ b/.github/workflows/_audit-css.yml
@@ -33,8 +33,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Download compiled themes artifact
         uses: actions/download-artifact@v5

--- a/.github/workflows/_compile-themes.yml
+++ b/.github/workflows/_compile-themes.yml
@@ -32,8 +32,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Build test assets
         run: |

--- a/.github/workflows/_create-screenshots.yml
+++ b/.github/workflows/_create-screenshots.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/_docs-check.yml
+++ b/.github/workflows/_docs-check.yml
@@ -34,8 +34,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/_lint-scripts.yml
+++ b/.github/workflows/_lint-scripts.yml
@@ -33,8 +33,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Lint scripts
         run: |

--- a/.github/workflows/_lint-styles.yml
+++ b/.github/workflows/_lint-styles.yml
@@ -33,8 +33,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Lint styles
         run: |

--- a/.github/workflows/_package-report.yml
+++ b/.github/workflows/_package-report.yml
@@ -77,8 +77,7 @@ jobs:
           key: root-node_modules-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install PR dependencies
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Measure time and size
         run: |
@@ -151,8 +150,7 @@ jobs:
 
       - name: Install develop dependencies
         if: steps.cache-develop-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Measure time and size
         run: |

--- a/.github/workflows/_prime-cache.yml
+++ b/.github/workflows/_prime-cache.yml
@@ -38,5 +38,4 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master

--- a/.github/workflows/_render-test-pages.yml
+++ b/.github/workflows/_render-test-pages.yml
@@ -103,8 +103,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Build test assets
         run: |

--- a/.github/workflows/_test-a11y-specs.yml
+++ b/.github/workflows/_test-a11y-specs.yml
@@ -37,8 +37,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/_test-contrast.yml
+++ b/.github/workflows/_test-contrast.yml
@@ -62,8 +62,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/_test-html-spec.yml
+++ b/.github/workflows/_test-html-spec.yml
@@ -32,8 +32,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Build scripts
         run: |

--- a/.github/workflows/_test-integrations.yml
+++ b/.github/workflows/_test-integrations.yml
@@ -36,8 +36,7 @@ jobs:
 
       - name: Install root dependencies
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Build test assets
         run: |

--- a/.github/workflows/_test-units.yml
+++ b/.github/workflows/_test-units.yml
@@ -36,8 +36,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Build test assets
         run: |

--- a/.github/workflows/ci_weekly.yml
+++ b/.github/workflows/ci_weekly.yml
@@ -37,8 +37,7 @@ jobs:
 
       - name: Install
         if: steps.cache-root-node_modules.outputs.cache-hit != 'true'
-        run: |
-          npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Lint scripts
         run: |

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -75,7 +75,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install
-        run: npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Build themes for dist
         run: |

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -49,7 +49,7 @@ jobs:
         uses: nuget/setup-nuget@v4
 
       - name: Install
-        run: npm ci --no-audit --no-fund
+        uses: telerik/actions/npm-ci@master
 
       - name: Build themes for dist
         run: |


### PR DESCRIPTION
Replace direct `npm ci --no-audit --no-fund` calls with the shared `telerik/actions/npm-ci@master` composite action across all workflows.

This centralizes registry configuration and install flags, making future registry changes a single-point update in the shared actions repo.

@tsvetomir - it appears `telerik/actions` is not accessible by public repos (as is `kendo-themes`);