### PR TITLE
revert(deps): remove custom registry from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,9 @@
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
-registries:
-  harness-npm:
-    type: npm-registry
-    url: https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-devtools-npm/npm/
-    token: ${{secrets.NPM_REGISTRY_TOKEN}}
-    replaces-base: true
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    registries:
-      - harness-npm
     cooldown:
       default-days: 14
     schedule:


### PR DESCRIPTION
- Dependabot requires a token for custom registries even when public. 
- Tokens must be secrets
- Secrets cannot be empty
- Dependabot cannot authenticate in a public registry with a non-empty token

@Juveniel - Reverting back to `npmjs.org` for Dependabot only is at your discretion. 