### PR TITLE
Set npm registry for Dependabot

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -107,6 +107,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.import-secrets.outputs.GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
       - name: Mark checks as successful
         if: env.DRY_RUN == ''

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,3 @@ debug.log
 # Generated a11y test reports (not tracked; screenshots in tests/_output/ ARE tracked)
 tests/_output/*.json
 
-# Local npm registry config (not committed)
-.npmrc

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-devtools-npm/npm/
+min-release-age=14
+


### PR DESCRIPTION
Configures the npm registry in `.npmrc` for Dependabot to use.
Updates publishing configuration to revert to default registry.