### PR TITLE
fix(grid, table): $kendo-table-font-size and $kendo-grid-font-size overrides not working

### DIFF
--- a/packages/bootstrap/scss/table/_variables.scss
+++ b/packages/bootstrap/scss/table/_variables.scss
@@ -49,21 +49,21 @@ $kendo-table-lg-cell-padding-y: k-spacing(2.5) !default;
 
 /// The font size of the Table for small size.
 /// @group table
-$kendo-table-sm-font-size: var(--kendo-font-size) !default;
+$kendo-table-sm-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for small size.
 /// @group table
 $kendo-table-sm-line-height: var(--kendo-line-height) !default;
 
 /// The font size of the Table for medium size.
 /// @group table
-$kendo-table-md-font-size: var(--kendo-font-size) !default;
+$kendo-table-md-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for medium size.
 /// @group table
 $kendo-table-md-line-height: var(--kendo-line-height) !default;
 
 /// The font size of the Table for large size.
 /// @group table
-$kendo-table-lg-font-size: var(--kendo-font-size) !default;
+$kendo-table-lg-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for large size.
 /// @group table
 $kendo-table-lg-line-height: var(--kendo-line-height) !default;

--- a/packages/classic/scss/table/_variables.scss
+++ b/packages/classic/scss/table/_variables.scss
@@ -50,21 +50,21 @@ $kendo-table-lg-cell-padding-y: k-spacing(2.5) !default;
 
 /// The font size of the Table for small size.
 /// @group table
-$kendo-table-sm-font-size: var(--kendo-font-size) !default;
+$kendo-table-sm-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for small size.
 /// @group table
 $kendo-table-sm-line-height: var(--kendo-line-height) !default;
 
 /// The font size of the Table for medium size.
 /// @group table
-$kendo-table-md-font-size: var(--kendo-font-size) !default;
+$kendo-table-md-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for medium size.
 /// @group table
 $kendo-table-md-line-height: var(--kendo-line-height) !default;
 
 /// The font size of the Table for large size.
 /// @group table
-$kendo-table-lg-font-size: var(--kendo-font-size) !default;
+$kendo-table-lg-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for large size.
 /// @group table
 $kendo-table-lg-line-height: var(--kendo-line-height) !default;

--- a/packages/default/scss/table/_variables.scss
+++ b/packages/default/scss/table/_variables.scss
@@ -50,21 +50,21 @@ $kendo-table-lg-cell-padding-y: k-spacing(2.5) !default;
 
 /// The font size of the Table for small size.
 /// @group table
-$kendo-table-sm-font-size: var(--kendo-font-size) !default;
+$kendo-table-sm-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for small size.
 /// @group table
 $kendo-table-sm-line-height: var(--kendo-line-height) !default;
 
 /// The font size of the Table for medium size.
 /// @group table
-$kendo-table-md-font-size: var(--kendo-font-size) !default;
+$kendo-table-md-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for medium size.
 /// @group table
 $kendo-table-md-line-height: var(--kendo-line-height) !default;
 
 /// The font size of the Table for large size.
 /// @group table
-$kendo-table-lg-font-size: var(--kendo-font-size) !default;
+$kendo-table-lg-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for large size.
 /// @group table
 $kendo-table-lg-line-height: var(--kendo-line-height) !default;

--- a/packages/fluent/scss/table/_variables.scss
+++ b/packages/fluent/scss/table/_variables.scss
@@ -36,23 +36,31 @@ $kendo-table-lg-cell-padding-x: var( --kendo-table-lg-cell-padding-x, #{k-spacin
 /// @group table
 $kendo-table-lg-cell-padding-y: var( --kendo-table-lg-cell-padding-y, #{k-spacing(3)} ) !default;
 
+/// The font size of the table if no size is specified.
+/// @group table
+$kendo-table-font-size: null !default;
+
+/// The line-height of the table if no size is specified.
+/// @group table
+$kendo-table-line-height: null !default;
+
 /// The font size of the Table for small size.
 /// @group table
-$kendo-table-sm-font-size: var( --kendo-table-sm-font-size, var(--kendo-font-size) ) !default;
+$kendo-table-sm-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var( --kendo-table-sm-font-size, var(--kendo-font-size) )) !default;
 /// The line height of the Table for small size.
 /// @group table
 $kendo-table-sm-line-height: var( --kendo-table-sm-line-height, var(--kendo-line-height) ) !default;
 
 /// The font size of the Table for medium size.
 /// @group table
-$kendo-table-md-font-size: var( --kendo-table-md-font-size, var(--kendo-font-size) ) !default;
+$kendo-table-md-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var( --kendo-table-md-font-size, var(--kendo-font-size) )) !default;
 /// The line height of the Table for medium size.
 /// @group table
 $kendo-table-md-line-height: var( --kendo-table-md-line-height, var(--kendo-line-height) ) !default;
 
 /// The font size of the Table for large size.
 /// @group table
-$kendo-table-lg-font-size: var( --kendo-table-lg-font-size, var(--kendo-font-size) ) !default;
+$kendo-table-lg-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var( --kendo-table-lg-font-size, var(--kendo-font-size) )) !default;
 /// The line height of the Table for large size.
 /// @group table
 $kendo-table-lg-line-height: var( --kendo-table-lg-line-height, var(--kendo-line-height) ) !default;
@@ -184,6 +192,8 @@ $kendo-table-cell-row-span-shadow: var( --kendo-table-cell-row-span-shadow, inse
     $kendo-table-border-width: $kendo-table-border-width,
     $kendo-table-cell-vertical-border-width: $kendo-table-cell-vertical-border-width,
     $kendo-table-cell-horizontal-border-width: $kendo-table-cell-horizontal-border-width,
+    $kendo-table-font-size: $kendo-table-font-size,
+    $kendo-table-line-height: $kendo-table-line-height,
     $kendo-table-sm-cell-padding-x: $kendo-table-sm-cell-padding-x,
     $kendo-table-sm-cell-padding-y: $kendo-table-sm-cell-padding-y,
     $kendo-table-md-cell-padding-x: $kendo-table-md-cell-padding-x,

--- a/packages/material/scss/table/_variables.scss
+++ b/packages/material/scss/table/_variables.scss
@@ -51,21 +51,21 @@ $kendo-table-lg-cell-padding-y: k-spacing(4) !default;
 
 /// The font size of the Table for small size.
 /// @group table
-$kendo-table-sm-font-size: var(--kendo-font-size) !default;
+$kendo-table-sm-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for small size.
 /// @group table
 $kendo-table-sm-line-height: var(--kendo-line-height) !default;
 
 /// The font size of the Table for medium size.
 /// @group table
-$kendo-table-md-font-size: var(--kendo-font-size) !default;
+$kendo-table-md-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for medium size.
 /// @group table
 $kendo-table-md-line-height: var(--kendo-line-height) !default;
 
 /// The font size of the Table for large size.
 /// @group table
-$kendo-table-lg-font-size: var(--kendo-font-size) !default;
+$kendo-table-lg-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for large size.
 /// @group table
 $kendo-table-lg-line-height: var(--kendo-line-height) !default;

--- a/packages/meridian/scss/table/_variables.scss
+++ b/packages/meridian/scss/table/_variables.scss
@@ -50,21 +50,21 @@ $kendo-table-lg-cell-padding-y: k-spacing(2.5) !default;
 
 /// The font size of the Table for small size.
 /// @group table
-$kendo-table-sm-font-size: var(--kendo-font-size-sm) !default;
+$kendo-table-sm-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size-sm)) !default;
 /// The line height of the Table for small size.
 /// @group table
 $kendo-table-sm-line-height: var(--kendo-line-height-sm) !default;
 
 /// The font size of the Table for medium size.
 /// @group table
-$kendo-table-md-font-size: var(--kendo-font-size) !default;
+$kendo-table-md-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for medium size.
 /// @group table
 $kendo-table-md-line-height: var(--kendo-line-height) !default;
 
 /// The font size of the Table for large size.
 /// @group table
-$kendo-table-lg-font-size: var(--kendo-font-size) !default;
+$kendo-table-lg-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
 /// The line height of the Table for large size.
 /// @group table
 $kendo-table-lg-line-height: var(--kendo-line-height) !default;


### PR DESCRIPTION
## Description

Fixes #6032

## Root Cause

The table size system generates a `font-size` rule that **always overrides** the base `$kendo-table-font-size` value, regardless of what the user sets.

In `core/scss/components/table/_layout.scss`, the `k-when-default("md", "md")` call returns `"&,"`, producing:

```css
.k-table,          /* ← added by k-when-default (default size match) */
.k-table.k-table-md {
    font-size: var(--kendo-font-size);   /* from $kendo-table-md-font-size */
}
```

This rule appears after the base `.k-table { font-size: $kendo-table-font-size; }` in the output. With equal CSS specificity, the size-system rule always wins — silently ignoring the user's SCSS variable override.

`$kendo-grid-font-size` is also affected because the inner `.k-table` inside `.k-grid` has its own explicit `font-size`, preventing CSS inheritance from the grid.

## Fix

In all 6 theme packages (`default`, `bootstrap`, `material`, `classic`, `fluent`, `meridian`), updated the size-specific font-size variables to fall back to `$kendo-table-font-size` when it is explicitly set:

```scss
// Before
$kendo-table-md-font-size: var(--kendo-font-size) !default;

// After
$kendo-table-md-font-size: if($kendo-table-font-size != null, $kendo-table-font-size, var(--kendo-font-size)) !default;
```

This preserves the default behavior while correctly honoring user overrides via `$kendo-table-font-size` (and transitively, `$kendo-grid-font-size` now works through CSS inheritance as intended).