### PR TITLE
chore: update a11y test script to use Meridian theme (FE-1312)

### DIFF
--- a/scripts/test-a11y-unified.mjs
+++ b/scripts/test-a11y-unified.mjs
@@ -457,7 +457,7 @@ function wrapInHtmlPage(componentHtml) {
 <head>
     <meta charset="utf-8">
     <title>A11y Test</title>
-    <link rel="stylesheet" href="http://${HOST}:${PORT}/packages/default/dist/default-ocean-blue-a11y.css">
+    <link rel="stylesheet" href="http://${HOST}:${PORT}/packages/meridian/dist/meridian-main.css">
 </head>
 <body class="k-body">
     <div id="test-area">${componentHtml}</div>


### PR DESCRIPTION
The unified a11y test script (`scripts/test-a11y-unified.mjs`) was the last holdout still referencing the OceanBlue swatch (`default-ocean-blue-a11y.css`). The VPAT generator and contrast tests already use Meridian as the baseline theme.

This updates the CSS path to `packages/meridian/dist/meridian-main.css` so all accessibility tooling is consistent.

Part of: https://progresssoftware.atlassian.net/browse/FE-1312