### PR TITLE
make ci-a11y-specs blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
   set-commit-status:
     name: Set commit status
     runs-on: ubuntu-latest
-    needs: [ detect-changes, ci-lint-scripts, ci-lint-styles, ci-audit-css, ci-docs, ci-test-units, ci-test-integrations, ci-a11y, ci-test-html-spec ]
+    needs: [ detect-changes, ci-lint-scripts, ci-lint-styles, ci-audit-css, ci-docs, ci-test-units, ci-test-integrations, ci-a11y, ci-test-html-spec, ci-a11y-specs ]
     timeout-minutes: 30
     if: ${{ always() && needs.detect-changes.outputs.snapshot_sha }}
 
@@ -120,6 +120,7 @@ jobs:
               ['${{ needs.ci-lint-styles.result }}', 'Status check > Lint styles'],
               ['${{ needs.ci-audit-css.result }}', 'Status check > CSS Audit'],
               ['${{ needs.ci-a11y.result }}', 'Status check > A11y'],
+              ['${{ needs.ci-a11y-specs.result }}', 'Status check > A11y Specs'],
               ['${{ needs.ci-docs.result }}', 'Status check > Docs'],
               ['${{ needs.ci-test-html-spec.result }}', 'Status check > HTML spec'],
               // Visual status will correspond to this detect-changes job succeeding (since snapshots updated successfully)
@@ -215,15 +216,12 @@ jobs:
     uses: ./.github/workflows/_test-a11y-specs.yml
 
   ci-a11y-specs:
-    name: Status check > A11y Specs (non-blocking)
+    name: Status check > A11y Specs
     runs-on: ubuntu-latest
-    if: ${{ always() }}
     needs: [ a11y-specs ]
     steps:
-      - name: Report status
-        run: |
-          echo "A11y specs check completed (outcome: ${{ needs.a11y-specs.result }})"
-          echo "This check is informational and does not block PR merging."
+      - name: Done
+        run: echo "Done!"
 
 
   docs:

--- a/packages/html/src/grid/templates/grid-grouping-checkbox-groups-column.tsx
+++ b/packages/html/src/grid/templates/grid-grouping-checkbox-groups-column.tsx
@@ -14,7 +14,7 @@ export const GridGroupingCheckboxGroupsColumn = ({ contentClassName, ...other }:
                 <Button icon="filter">Filter</Button>
                 <Button icon="grid-layout" selected>Group</Button>
                 <span className="k-spacer" />
-                <Button icon="more-vertical" fillMode="flat" />
+                <Button icon="more-vertical" fillMode="flat" aria-label="More options" />
             </GridToolbar>
         )}
         groupingHeader={(
@@ -37,7 +37,7 @@ export const GridGroupingCheckboxGroupsColumn = ({ contentClassName, ...other }:
                         <TableThead role="rowgroup">
                             <TableRow role="row">
                                 <GridHeaderCell columnTitle="Groups" role="columnheader"></GridHeaderCell>
-                                <GridHeaderCell role="columnheader">
+                                <GridHeaderCell role="columnheader" accessibleLabel="Select all">
                                     <Checkbox />
                                 </GridHeaderCell>
                                 <GridHeaderCell columnTitle="ID" role="columnheader"></GridHeaderCell>

--- a/packages/html/src/grid/templates/grid-grouping-checkbox-multiple-columns.tsx
+++ b/packages/html/src/grid/templates/grid-grouping-checkbox-multiple-columns.tsx
@@ -13,7 +13,7 @@ export const GridGroupingCheckboxMultipleColumns = ({ contentClassName, ...other
                 <Button icon="filter">Filter</Button>
                 <Button icon="grid-layout" selected>Group</Button>
                 <span className="k-spacer" />
-                <Button icon="more-vertical" fillMode="flat" />
+                <Button icon="more-vertical" fillMode="flat" aria-label="More options" />
             </GridToolbar>
         )}
         groupingHeader={(
@@ -37,7 +37,7 @@ export const GridGroupingCheckboxMultipleColumns = ({ contentClassName, ...other
                             <TableRow role="row">
                                 <GridHeaderCell columnTitle="ID" role="columnheader"></GridHeaderCell>
                                 <GridHeaderCell columnTitle="Name" role="columnheader"></GridHeaderCell>
-                                <GridHeaderCell role="columnheader">
+                                <GridHeaderCell role="columnheader" accessibleLabel="Select all">
                                     <Checkbox />
                                 </GridHeaderCell>
                                 <GridHeaderCell columnTitle="Product ID" role="columnheader"></GridHeaderCell>

--- a/packages/html/src/grid/templates/grid-grouping-checkbox-no-indent.tsx
+++ b/packages/html/src/grid/templates/grid-grouping-checkbox-no-indent.tsx
@@ -13,7 +13,7 @@ export const GridGroupingCheckboxNoIndent = ({ contentClassName, ...other }: any
                 <Button icon="filter">Filter</Button>
                 <Button icon="grid-layout" selected>Group</Button>
                 <span className="k-spacer" />
-                <Button icon="more-vertical" fillMode="flat" />
+                <Button icon="more-vertical" fillMode="flat" aria-label="More options" />
             </GridToolbar>
         )}
         groupingHeader={(
@@ -35,7 +35,7 @@ export const GridGroupingCheckboxNoIndent = ({ contentClassName, ...other }: any
                         </colgroup>
                         <TableThead role="rowgroup">
                             <TableRow role="row">
-                                <GridHeaderCell role="columnheader">
+                                <GridHeaderCell role="columnheader" accessibleLabel="Select all">
                                     <Checkbox />
                                 </GridHeaderCell>
                                 <GridHeaderCell columnTitle="ID" role="columnheader"></GridHeaderCell>

--- a/packages/html/src/grid/templates/grid-grouping-groups-column.tsx
+++ b/packages/html/src/grid/templates/grid-grouping-groups-column.tsx
@@ -13,7 +13,7 @@ export const GridGroupingGroupsColumn = ({ contentClassName, ...other }: any) =>
                 <Button icon="filter">Filter</Button>
                 <Button icon="grid-layout" selected>Group</Button>
                 <span className="k-spacer" />
-                <Button icon="more-vertical" fillMode="flat" />
+                <Button icon="more-vertical" fillMode="flat" aria-label="More options" />
             </GridToolbar>
         )}
         groupingHeader={(

--- a/packages/html/src/grid/templates/grid-grouping-multiple-columns.tsx
+++ b/packages/html/src/grid/templates/grid-grouping-multiple-columns.tsx
@@ -12,7 +12,7 @@ export const GridGroupingMultipleColumns = ({ contentClassName, ...other }: any)
                 <Button icon="filter">Filter</Button>
                 <Button icon="grid-layout" selected>Group</Button>
                 <span className="k-spacer" />
-                <Button icon="more-vertical" fillMode="flat" />
+                <Button icon="more-vertical" fillMode="flat" aria-label="More options" />
             </GridToolbar>
         )}
         groupingHeader={(

--- a/tests/grid/grid-grouping-column.html
+++ b/tests/grid/grid-grouping-column.html
@@ -39,7 +39,7 @@
                     <span class="k-button-text">Group</span>
                 </button>
                 <span class="k-spacer"></span>
-                <button class="k-toolbar-button  k-button k-button-flat k-icon-button">
+                <button class="k-toolbar-button  k-button k-button-flat k-icon-button" aria-label="More options">
                     <span class="k-button-icon k-icon k-svg-icon k-svg-i-more-vertical" aria-hidden="true">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                             <path d="M240 128c26.4 0 48-21.6 48-48s-21.6-48-48-48-48 21.6-48 48 21.6 48 48 48m0 64c-26.4 0-48 21.6-48 48s21.6 48 48 48 48-21.6 48-48-21.6-48-48-48m0 160c-26.4 0-48 21.6-48 48s21.6 48 48 48 48-21.6 48-48-21.6-48-48-48"></path>
@@ -327,7 +327,7 @@
                     <span class="k-button-text">Group</span>
                 </button>
                 <span class="k-spacer"></span>
-                <button class="k-toolbar-button  k-button k-button-flat k-icon-button">
+                <button class="k-toolbar-button  k-button k-button-flat k-icon-button" aria-label="More options">
                     <span class="k-button-icon k-icon k-svg-icon k-svg-i-more-vertical" aria-hidden="true">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                             <path d="M240 128c26.4 0 48-21.6 48-48s-21.6-48-48-48-48 21.6-48 48 21.6 48 48 48m0 64c-26.4 0-48 21.6-48 48s21.6 48 48 48 48-21.6 48-48-21.6-48-48-48m0 160c-26.4 0-48 21.6-48 48s21.6 48 48 48 48-21.6 48-48-21.6-48-48-48"></path>
@@ -400,6 +400,7 @@
                                         </span>
                                     </th>
                                     <th role="columnheader" class="k-header k-table-th">
+                                        <span class="k-sr-only">Select all</span>
                                         <span class="k-checkbox-wrap">
                                             <input class="k-checkbox" type="checkbox">
                                         </span>

--- a/tests/grid/grid-grouping-multiple-columns.html
+++ b/tests/grid/grid-grouping-multiple-columns.html
@@ -39,7 +39,7 @@
                     <span class="k-button-text">Group</span>
                 </button>
                 <span class="k-spacer"></span>
-                <button class="k-toolbar-button  k-button k-button-flat k-icon-button">
+                <button class="k-toolbar-button  k-button k-button-flat k-icon-button" aria-label="More options">
                     <span class="k-button-icon k-icon k-svg-icon k-svg-i-more-vertical" aria-hidden="true">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                             <path d="M240 128c26.4 0 48-21.6 48-48s-21.6-48-48-48-48 21.6-48 48 21.6 48 48 48m0 64c-26.4 0-48 21.6-48 48s21.6 48 48 48 48-21.6 48-48-21.6-48-48-48m0 160c-26.4 0-48 21.6-48 48s21.6 48 48 48 48-21.6 48-48-21.6-48-48-48"></path>
@@ -348,7 +348,7 @@
                     <span class="k-button-text">Group</span>
                 </button>
                 <span class="k-spacer"></span>
-                <button class="k-toolbar-button  k-button k-button-flat k-icon-button">
+                <button class="k-toolbar-button  k-button k-button-flat k-icon-button" aria-label="More options">
                     <span class="k-button-icon k-icon k-svg-icon k-svg-i-more-vertical" aria-hidden="true">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                             <path d="M240 128c26.4 0 48-21.6 48-48s-21.6-48-48-48-48 21.6-48 48 21.6 48 48 48m0 64c-26.4 0-48 21.6-48 48s21.6 48 48 48 48-21.6 48-48-21.6-48-48-48m0 160c-26.4 0-48 21.6-48 48s21.6 48 48 48 48-21.6 48-48-21.6-48-48-48"></path>
@@ -429,6 +429,7 @@
                                         </span>
                                     </th>
                                     <th role="columnheader" class="k-header k-table-th">
+                                        <span class="k-sr-only">Select all</span>
                                         <span class="k-checkbox-wrap">
                                             <input class="k-checkbox" type="checkbox">
                                         </span>

--- a/tests/grid/grid-grouping-no-indent.html
+++ b/tests/grid/grid-grouping-no-indent.html
@@ -219,7 +219,7 @@
                     <span class="k-button-text">Group</span>
                 </button>
                 <span class="k-spacer"></span>
-                <button class="k-toolbar-button  k-button k-button-flat k-icon-button">
+                <button class="k-toolbar-button  k-button k-button-flat k-icon-button" aria-label="More options">
                     <span class="k-button-icon k-icon k-svg-icon k-svg-i-more-vertical" aria-hidden="true">
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                             <path d="M240 128c26.4 0 48-21.6 48-48s-21.6-48-48-48-48 21.6-48 48 21.6 48 48 48m0 64c-26.4 0-48 21.6-48 48s21.6 48 48 48 48-21.6 48-48-21.6-48-48-48m0 160c-26.4 0-48 21.6-48 48s21.6 48 48 48 48-21.6 48-48-21.6-48-48-48"></path>
@@ -284,6 +284,7 @@
                             <thead class="k-table-thead">
                                 <tr role="row" class="k-table-row">
                                     <th role="columnheader" class="k-header k-table-th">
+                                        <span class="k-sr-only">Select all</span>
                                         <span class="k-checkbox-wrap">
                                             <input class="k-checkbox" type="checkbox">
                                         </span>


### PR DESCRIPTION
related to: https://progresssoftware.atlassian.net/browse/FE-1315

## Why

The `ci-a11y-specs` CI job was non-blocking -- it used `if: ${{ always() }}` and only echoed an informational message, so PRs could be merged even when a11y spec tests failed. Additionally, several grid grouping templates had real WCAG violations (`button-name` and `empty-table-header`) that were causing the tests to fail.

## What changed

**CI (`ci.yml`):**
- `ci-a11y-specs` now follows the same pattern as all other status-check jobs (no `if: always()`, just `echo "Done!"`) -- it will fail if `a11y-specs` fails
- Added `ci-a11y-specs` to `set-commit-status`'s `needs` list and results array so it properly blocks PR merging

**Grid grouping templates (5 files):**
- Added `aria-label="More options"` to the icon-only `more-vertical` toolbar button that was triggering `button-name` violations in all five grouping templates
- Added `accessibleLabel="Select all"` to the checkbox select-all column header in the three checkbox grouping templates, fixing `empty-table-header` violations (uses the existing `k-sr-only` span mechanism so the text is visible to screen readers but not visually)

## Result

```
WCAG: 8418 passed, 0 violations (55 acceptable)
```