### PR TITLE
fix(appbar): add missing translucency blur in Meridian

### DIFF
--- a/packages/meridian/scss/appbar/_theme.scss
+++ b/packages/meridian/scss/appbar/_theme.scss
@@ -7,6 +7,8 @@
     @include kendo-appbar--theme-base();
 
     .k-appbar {
+        backdrop-filter: k-translucency-blur(1);
+
         @each $name in $kendo-appbar-theme-colors {
             #{k-when-default($kendo-appbar-default-theme-color, $name)}
             &.k-appbar-#{$name} {


### PR DESCRIPTION
## What
Adds the missing `backdrop-filter: k-translucency-blur(1)` to `.k-appbar` in the Meridian theme.

## Why
`k-translucency-bg()` only sets the semi-transparent background (driven by `--kendo-translucency-base`); the actual blur is applied separately via `backdrop-filter`. Toolbar, Drawer, PanelBar, Pager, and other translucent surfaces already do this, but AppBar was missing it, so setting `--kendo-translucency-base` had no visible blur effect on the AppBar.

## Change
`packages/meridian/scss/appbar/_theme.scss`: added `backdrop-filter: k-translucency-blur(1);` to `.k-appbar`, matching the pattern used by Toolbar/Drawer/PanelBar/Pager.