### PR TITLE
fix(charts): restore chart tooltip to color-white/color-black

### DIFF
--- a/packages/bootstrap/docs/customization-charts.md
+++ b/packages/bootstrap/docs/customization-charts.md
@@ -818,26 +818,6 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
-    <td>$kendo-chart-tooltip-color</td>
-    <td>String</td>
-    <td><code>k-color(app-surface)</code></td>
-    <td><code>var(--kendo-color-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-chart-tooltip-color-inverse</td>
-    <td>String</td>
-    <td><code>k-color(on-app-surface)</code></td>
-    <td><code>var(--kendo-color-on-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The inverse text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-chart-bg</td>
     <td>String</td>
     <td><code>k-color(surface-alt)</code></td>

--- a/packages/bootstrap/docs/customization.md
+++ b/packages/bootstrap/docs/customization.md
@@ -6530,26 +6530,6 @@ The following table lists the available variables for customizing the Bootstrap 
     </td>
 </tr>
 <tr>
-    <td>$kendo-chart-tooltip-color</td>
-    <td>String</td>
-    <td><code>k-color(app-surface)</code></td>
-    <td><code>var(--kendo-color-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-chart-tooltip-color-inverse</td>
-    <td>String</td>
-    <td><code>k-color(on-app-surface)</code></td>
-    <td><code>var(--kendo-color-on-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The inverse text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-chart-bg</td>
     <td>String</td>
     <td><code>k-color(surface-alt)</code></td>

--- a/packages/bootstrap/scss/dataviz/_variables.scss
+++ b/packages/bootstrap/scss/dataviz/_variables.scss
@@ -255,13 +255,6 @@ $kendo-chart-tooltip-padding-y: k-spacing(1) !default;
 /// @group charts
 $kendo-chart-tooltip-transition: left k-transition(fade-in), top k-transition(fade-in) !default;
 
-/// The text color of the chart tooltip.
-/// @group charts
-$kendo-chart-tooltip-color: k-color(app-surface) !default;
-/// The inverse text color of the chart tooltip.
-/// @group charts
-$kendo-chart-tooltip-color-inverse: k-color(on-app-surface) !default;
-
 /// The background color of the Chart.
 /// @group charts
 $kendo-chart-bg: k-color(surface-alt) !default;
@@ -459,8 +452,6 @@ $kendo-gauge-track-bg: k-color(base-emphasis) !default;
     $kendo-chart-tooltip-padding-x: $kendo-chart-tooltip-padding-x,
     $kendo-chart-tooltip-padding-y: $kendo-chart-tooltip-padding-y,
     $kendo-chart-tooltip-transition: $kendo-chart-tooltip-transition,
-    $kendo-chart-tooltip-color: $kendo-chart-tooltip-color,
-    $kendo-chart-tooltip-color-inverse: $kendo-chart-tooltip-color-inverse,
     $kendo-chart-bg: $kendo-chart-bg,
     $kendo-chart-text: $kendo-chart-text,
     $kendo-chart-border: $kendo-chart-border,

--- a/packages/classic/docs/customization-charts.md
+++ b/packages/classic/docs/customization-charts.md
@@ -818,26 +818,6 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
-    <td>$kendo-chart-tooltip-color</td>
-    <td>String</td>
-    <td><code>k-color(app-surface)</code></td>
-    <td><code>var(--kendo-color-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-chart-tooltip-color-inverse</td>
-    <td>String</td>
-    <td><code>k-color(on-app-surface)</code></td>
-    <td><code>var(--kendo-color-on-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The inverse text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-chart-bg</td>
     <td>String</td>
     <td><code>k-color(surface-alt)</code></td>

--- a/packages/classic/docs/customization.md
+++ b/packages/classic/docs/customization.md
@@ -6530,26 +6530,6 @@ The following table lists the available variables for customizing the Classic th
     </td>
 </tr>
 <tr>
-    <td>$kendo-chart-tooltip-color</td>
-    <td>String</td>
-    <td><code>k-color(app-surface)</code></td>
-    <td><code>var(--kendo-color-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-chart-tooltip-color-inverse</td>
-    <td>String</td>
-    <td><code>k-color(on-app-surface)</code></td>
-    <td><code>var(--kendo-color-on-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The inverse text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-chart-bg</td>
     <td>String</td>
     <td><code>k-color(surface-alt)</code></td>

--- a/packages/classic/scss/dataviz/_variables.scss
+++ b/packages/classic/scss/dataviz/_variables.scss
@@ -255,13 +255,6 @@ $kendo-chart-tooltip-padding-y: k-spacing(0.5) !default;
 /// @group charts
 $kendo-chart-tooltip-transition: left k-transition(fade-in), top k-transition(fade-in) !default;
 
-/// The text color of the chart tooltip.
-/// @group charts
-$kendo-chart-tooltip-color: k-color(app-surface) !default;
-/// The inverse text color of the chart tooltip.
-/// @group charts
-$kendo-chart-tooltip-color-inverse: k-color(on-app-surface) !default;
-
 /// The background color of the Chart.
 /// @group charts
 $kendo-chart-bg: k-color(surface-alt) !default;
@@ -458,8 +451,6 @@ $kendo-gauge-track-bg: k-color(base-emphasis) !default;
     $kendo-chart-tooltip-padding-x: $kendo-chart-tooltip-padding-x,
     $kendo-chart-tooltip-padding-y: $kendo-chart-tooltip-padding-y,
     $kendo-chart-tooltip-transition: $kendo-chart-tooltip-transition,
-    $kendo-chart-tooltip-color: $kendo-chart-tooltip-color,
-    $kendo-chart-tooltip-color-inverse: $kendo-chart-tooltip-color-inverse,
     $kendo-chart-bg: $kendo-chart-bg,
     $kendo-chart-text: $kendo-chart-text,
     $kendo-chart-border: $kendo-chart-border,

--- a/packages/core/scss/components/dataviz/_theme.scss
+++ b/packages/core/scss/components/dataviz/_theme.scss
@@ -1,6 +1,7 @@
 
 @use "../../mixins/index.scss" as *;
 @use "../../color-system/_functions.scss" as *;
+@use "../../color-system/_constants.scss" as *;
 @use "./variables.scss" as *;
 @use "../button/_variables.scss" as *;
 
@@ -23,11 +24,13 @@
 
 
     // Tooltip
+    // These colors are intentionally hardcoded and should not be changed.
+    // Chart tooltips always use white/black regardless of the theme.
     .k-chart-tooltip {
-        @include fill( $color: $kendo-chart-tooltip-color );
+        color: $kendo-color-white;
     }
     .k-chart-tooltip-inverse {
-        @include fill( $color: $kendo-chart-tooltip-color-inverse );
+        color: $kendo-color-black;
     }
 
     .k-chart-crosshair-tooltip,

--- a/packages/core/scss/components/dataviz/_variables.scss
+++ b/packages/core/scss/components/dataviz/_variables.scss
@@ -92,9 +92,6 @@ $kendo-chart-tooltip-padding-y: null !default;
 
 $kendo-chart-tooltip-transition: null !default;
 
-$kendo-chart-tooltip-color: null !default;
-$kendo-chart-tooltip-color-inverse: null !default;
-
 $kendo-chart-bg: null !default;
 $kendo-chart-text: null !default;
 $kendo-chart-border: null !default;

--- a/packages/default/docs/customization-charts.md
+++ b/packages/default/docs/customization-charts.md
@@ -818,26 +818,6 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
-    <td>$kendo-chart-tooltip-color</td>
-    <td>String</td>
-    <td><code>k-color(app-surface)</code></td>
-    <td><code>var(--kendo-color-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-chart-tooltip-color-inverse</td>
-    <td>String</td>
-    <td><code>k-color(on-app-surface)</code></td>
-    <td><code>var(--kendo-color-on-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The inverse text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-chart-bg</td>
     <td>String</td>
     <td><code>k-color(surface-alt)</code></td>

--- a/packages/default/docs/customization.md
+++ b/packages/default/docs/customization.md
@@ -6600,26 +6600,6 @@ The following table lists the available variables for customizing the Default th
     </td>
 </tr>
 <tr>
-    <td>$kendo-chart-tooltip-color</td>
-    <td>String</td>
-    <td><code>k-color(app-surface)</code></td>
-    <td><code>var(--kendo-color-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-chart-tooltip-color-inverse</td>
-    <td>String</td>
-    <td><code>k-color(on-app-surface)</code></td>
-    <td><code>var(--kendo-color-on-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The inverse text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-chart-bg</td>
     <td>String</td>
     <td><code>k-color(surface-alt)</code></td>

--- a/packages/default/scss/dataviz/_variables.scss
+++ b/packages/default/scss/dataviz/_variables.scss
@@ -255,13 +255,6 @@ $kendo-chart-tooltip-padding-y: k-spacing(0.5) !default;
 /// @group charts
 $kendo-chart-tooltip-transition: left k-transition(fade-in), top k-transition(fade-in) !default;
 
-/// The text color of the chart tooltip.
-/// @group charts
-$kendo-chart-tooltip-color: k-color(app-surface) !default;
-/// The inverse text color of the chart tooltip.
-/// @group charts
-$kendo-chart-tooltip-color-inverse: k-color(on-app-surface) !default;
-
 /// The background color of the Chart.
 /// @group charts
 $kendo-chart-bg: k-color(surface-alt) !default;
@@ -458,8 +451,6 @@ $kendo-gauge-track-bg: k-color(base-emphasis) !default;
     $kendo-chart-tooltip-padding-x: $kendo-chart-tooltip-padding-x,
     $kendo-chart-tooltip-padding-y: $kendo-chart-tooltip-padding-y,
     $kendo-chart-tooltip-transition: $kendo-chart-tooltip-transition,
-    $kendo-chart-tooltip-color: $kendo-chart-tooltip-color,
-    $kendo-chart-tooltip-color-inverse: $kendo-chart-tooltip-color-inverse,
     $kendo-chart-bg: $kendo-chart-bg,
     $kendo-chart-text: $kendo-chart-text,
     $kendo-chart-border: $kendo-chart-border,

--- a/packages/fluent/scss/dataviz/_variables.scss
+++ b/packages/fluent/scss/dataviz/_variables.scss
@@ -469,8 +469,6 @@ $kendo-gauge-track-bg: k-color(base-emphasis) !default;
     $kendo-chart-area-inactive-opacity: $kendo-chart-area-inactive-opacity,
     $kendo-chart-line-inactive-opacity: $kendo-chart-line-inactive-opacity,
     $kendo-chart-tooltip-transition: $kendo-chart-tooltip-transition,
-    $kendo-chart-tooltip-color: $kendo-chart-tooltip-color,
-    $kendo-chart-tooltip-color-inverse: $kendo-chart-tooltip-color-inverse,
     $kendo-chart-bg: $kendo-chart-bg,
     $kendo-chart-text: $kendo-chart-text,
     $kendo-chart-border: $kendo-chart-border,

--- a/packages/material/docs/customization-charts.md
+++ b/packages/material/docs/customization-charts.md
@@ -818,26 +818,6 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
-    <td>$kendo-chart-tooltip-color</td>
-    <td>String</td>
-    <td><code>k-color(app-surface)</code></td>
-    <td><code>var(--kendo-color-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-chart-tooltip-color-inverse</td>
-    <td>String</td>
-    <td><code>k-color(on-app-surface)</code></td>
-    <td><code>var(--kendo-color-on-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The inverse text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-chart-bg</td>
     <td>String</td>
     <td><code>k-color(surface)</code></td>

--- a/packages/material/docs/customization.md
+++ b/packages/material/docs/customization.md
@@ -6600,26 +6600,6 @@ The following table lists the available variables for customizing the Material t
     </td>
 </tr>
 <tr>
-    <td>$kendo-chart-tooltip-color</td>
-    <td>String</td>
-    <td><code>k-color(app-surface)</code></td>
-    <td><code>var(--kendo-color-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-chart-tooltip-color-inverse</td>
-    <td>String</td>
-    <td><code>k-color(on-app-surface)</code></td>
-    <td><code>var(--kendo-color-on-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The inverse text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-chart-bg</td>
     <td>String</td>
     <td><code>k-color(surface)</code></td>

--- a/packages/material/scss/dataviz/_variables.scss
+++ b/packages/material/scss/dataviz/_variables.scss
@@ -254,13 +254,6 @@ $kendo-chart-tooltip-padding-y: k-spacing(0.5) !default;
 /// @group charts
 $kendo-chart-tooltip-transition: left k-transition(fade-in), top k-transition(fade-in) !default;
 
-/// The text color of the chart tooltip.
-/// @group charts
-$kendo-chart-tooltip-color: k-color(app-surface) !default;
-/// The inverse text color of the chart tooltip.
-/// @group charts
-$kendo-chart-tooltip-color-inverse: k-color(on-app-surface) !default;
-
 /// The background color of the Chart.
 /// @group charts
 $kendo-chart-bg: k-color(surface) !default;
@@ -455,8 +448,6 @@ $kendo-gauge-track-bg: k-color(primary-subtle) !default;
     $kendo-chart-area-inactive-opacity: $kendo-chart-area-inactive-opacity,
     $kendo-chart-line-inactive-opacity: $kendo-chart-line-inactive-opacity,
     $kendo-chart-tooltip-transition: $kendo-chart-tooltip-transition,
-    $kendo-chart-tooltip-color: $kendo-chart-tooltip-color,
-    $kendo-chart-tooltip-color-inverse: $kendo-chart-tooltip-color-inverse,
     $kendo-chart-bg: $kendo-chart-bg,
     $kendo-chart-text: $kendo-chart-text,
     $kendo-chart-border: $kendo-chart-border,

--- a/packages/meridian/docs/customization-charts.md
+++ b/packages/meridian/docs/customization-charts.md
@@ -818,26 +818,6 @@ The following table lists the available variables for customization.
     </td>
 </tr>
 <tr>
-    <td>$kendo-chart-tooltip-color</td>
-    <td>String</td>
-    <td><code>k-color(app-surface)</code></td>
-    <td><code>var(--kendo-color-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-chart-tooltip-color-inverse</td>
-    <td>String</td>
-    <td><code>k-color(on-app-surface)</code></td>
-    <td><code>var(--kendo-color-on-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The inverse text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-chart-bg</td>
     <td>String</td>
     <td><code>k-color(surface-alt)</code></td>

--- a/packages/meridian/docs/customization.md
+++ b/packages/meridian/docs/customization.md
@@ -6820,26 +6820,6 @@ The following table lists the available variables for customizing the Meridian t
     </td>
 </tr>
 <tr>
-    <td>$kendo-chart-tooltip-color</td>
-    <td>String</td>
-    <td><code>k-color(app-surface)</code></td>
-    <td><code>var(--kendo-color-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
-    <td>$kendo-chart-tooltip-color-inverse</td>
-    <td>String</td>
-    <td><code>k-color(on-app-surface)</code></td>
-    <td><code>var(--kendo-color-on-app-surface)</code></td>
-</tr>
-<tr>
-    <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The inverse text color of the chart tooltip.</div></div>
-    </td>
-</tr>
-<tr>
     <td>$kendo-chart-bg</td>
     <td>String</td>
     <td><code>k-color(surface-alt)</code></td>

--- a/packages/meridian/scss/dataviz/_variables.scss
+++ b/packages/meridian/scss/dataviz/_variables.scss
@@ -255,13 +255,6 @@ $kendo-chart-tooltip-padding-y: k-spacing(1.5) !default;
 /// @group charts
 $kendo-chart-tooltip-transition: left k-transition(fade-in), top k-transition(fade-in) !default;
 
-/// The text color of the chart tooltip.
-/// @group charts
-$kendo-chart-tooltip-color: k-color(app-surface) !default;
-/// The inverse text color of the chart tooltip.
-/// @group charts
-$kendo-chart-tooltip-color-inverse: k-color(on-app-surface) !default;
-
 /// The background color of the Chart.
 /// @group charts
 $kendo-chart-bg: k-color(surface-alt) !default;
@@ -458,8 +451,6 @@ $kendo-gauge-track-bg: k-color(base-emphasis) !default;
     $kendo-chart-tooltip-padding-x: $kendo-chart-tooltip-padding-x,
     $kendo-chart-tooltip-padding-y: $kendo-chart-tooltip-padding-y,
     $kendo-chart-tooltip-transition: $kendo-chart-tooltip-transition,
-    $kendo-chart-tooltip-color: $kendo-chart-tooltip-color,
-    $kendo-chart-tooltip-color-inverse: $kendo-chart-tooltip-color-inverse,
     $kendo-chart-bg: $kendo-chart-bg,
     $kendo-chart-text: $kendo-chart-text,
     $kendo-chart-border: $kendo-chart-border,


### PR DESCRIPTION
PR #5664 introduced `$kendo-chart-tooltip-color` and `$kendo-chart-tooltip-color-inverse` variables mapped to `k-color(app-surface)` / `k-color(on-app-surface)`. This caused the chart tooltip colors to vary per theme, breaking the expected appearance. The tooltip colors should remain hardcoded to `$kendo-color-white` and `$kendo-color-black`.

## Changes

- **core `_theme.scss`:** Restored `.k-chart-tooltip { color: $kendo-color-white }` and `.k-chart-tooltip-inverse { color: $kendo-color-black }` with the `// TODO` comment
- **core `_variables.scss`:** Removed the two null variable declarations
- **bootstrap, classic, default, material:** Removed `$kendo-chart-tooltip-color` / `$kendo-chart-tooltip-color-inverse` variable declarations and their map entries
- **fluent `_variables.scss`:** Removed only the map entries (the pre-existing CSS custom property variable declarations are preserved)
- **fluent `_theme.scss`:** Restored the `.k-chart-tooltip` / `.k-chart-tooltip-inverse` overrides that #5664 had removed
- **docs:** Regenerated customization docs for bootstrap, classic, default, and material

https://progresssoftware.atlassian.net/browse/FE-1330