### PR TITLE
chore(ci): prune unneeded images from visual-regression reports before publish

### DIFF
--- a/.github/workflows/_visual-regression.yml
+++ b/.github/workflows/_visual-regression.yml
@@ -115,6 +115,49 @@ jobs:
             node -e "const i=require('./reg-publish-info.json'); console.log('source-dir='+i.sourceDir); console.log('target-dir='+i.targetDir);" >> "$GITHUB_OUTPUT"
           fi
 
+      # A full report publishes actual+expected images for every compared
+      # item, passed or not (~9,900 files / ~400MB for this repo, ~99% of it
+      # for items that are pixel-identical). None of that is needed:
+      #  - reg-fetch-gh-pages-plugin's fetch() only ever reads back a
+      #    baseline (develop) report's "actual/" dir as the next run's
+      #    comparison baseline - it never reads "expected/" from anywhere,
+      #    and never reads a PR report (reports/pr-<number>/) back at all.
+      #  - the published report.js viewer (reg-cli) renders plain <img> tags
+      #    with no fetch()/XHR existence check and an onerror handler, so a
+      #    missing image for a passed item just degrades to a broken
+      #    thumbnail if someone expands it, not a broken report.
+      # So it's safe to drop what nothing needs: "expected/" entirely on
+      # baseline reports, and both "actual/"+"expected/" for passed items on
+      # PR reports (keeping full images only for what's actually worth a
+      # human looking at: failed/new/deleted items). This is what keeps
+      # report size bounded well under GitHub Pages' 1GB limit even with
+      # several PRs' reports coexisting on gh-pages at once.
+      - name: Prune unneeded images before publish
+        if: steps.publish-target.outputs.target-dir != ''
+        env:
+          SOURCE_DIR: ${{ steps.publish-target.outputs.source-dir }}
+          IS_BASELINE: ${{ inputs.baseline }}
+        run: |
+          node -e '
+            const fs = require("fs");
+            const path = require("path");
+
+            const sourceDir = process.env.SOURCE_DIR;
+            const isBaseline = process.env.IS_BASELINE === "true";
+            const out = JSON.parse(fs.readFileSync(path.join(sourceDir, "out.json"), "utf8"));
+
+            if (isBaseline) {
+              fs.rmSync(path.join(sourceDir, out.expectedDir), { recursive: true, force: true });
+              console.log("Baseline report: dropped " + out.expectedDir + "/ entirely (never read back).");
+            } else {
+              for (const item of out.passedItems) {
+                fs.rmSync(path.join(sourceDir, out.actualDir, item), { force: true });
+                fs.rmSync(path.join(sourceDir, out.expectedDir, item), { force: true });
+              }
+              console.log(`PR report: dropped actual+expected for ${out.passedItems.length} passed item(s).`);
+            }
+          '
+
       # reg-suit's own publish plugin shells out to `git commit`/`git push`
       # against a worktree of the *entire* gh-pages history, which reliably
       # crashes with ENOBUFS once a run has a real (non-"new") diff to report


### PR DESCRIPTION
Trying to reduce load on the new reg-diff images:

1. Skip uploading images we don't need: for passed items (no visual diff), drop both `actual` + `expected` - only `diff` matters there. For failed/new/deleted items, keep all three.
2. For baseline (develop) reports specifically, also drop `expected` entirely, even for the failed ones - it's never read back (fetch() only ever pulls the previous baseline's `actual/`), so no point publishing it.