### PR TITLE
fix(scheduler): resize handles should stay below the sticky scheduler…

### DIFF
--- a/packages/core/scss/components/scheduler/_layout.scss
+++ b/packages/core/scss/components/scheduler/_layout.scss
@@ -471,8 +471,10 @@
 
 
         // Resize handles
+        // Uses "base" instead of the "handle" layer so it stays below the sticky .k-scheduler-header
+        // ref: https://github.com/telerik/kendo-themes/issues/6134
         .k-resize-handle {
-            z-index: k-z-index("handle");
+            z-index: k-z-index("base", 2);
             visibility: hidden;
         }
         .k-resize-n {


### PR DESCRIPTION
… header

closes: https://github.com/telerik/kendo-themes/issues/6134
close: [FE-1335](https://progresssoftware.atlassian.net/browse/FE-1335)

[FE-1335]: https://progresssoftware.atlassian.net/browse/FE-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ