### PR TITLE
fix(scheduler): time and event are misaligned in agenda view

### DIFF
--- a/packages/core/scss/components/scheduler/_layout.scss
+++ b/packages/core/scss/components/scheduler/_layout.scss
@@ -813,6 +813,7 @@
             display: flex;
             align-items: center;
             gap: k-spacing(0.5);
+            align-self: flex-start;
         }
 
         .k-task > .k-event-delete {


### PR DESCRIPTION
closes: https://github.com/telerik/kendo-themes/issues/6132
closes: [FE-1336](https://progresssoftware.atlassian.net/browse/FE-1336)

[FE-1336]: https://progresssoftware.atlassian.net/browse/FE-1336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ