### PR TITLE
chore(deps): separate major development updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
         exclude-patterns:
           - "sass*"
           - "@progress/kendo-svg-icons"
+        update-types:
+          - "minor"
+          - "patch"
       sass-dependencies:
         patterns:
           - "sass*"


### PR DESCRIPTION
## Rationale

Limit the broad `dev-dependencies` Dependabot group to minor and patch updates. Major development dependency upgrades will now open as separate PRs so incompatible toolchain changes can be migrated and validated independently.

This avoids combinations such as the TypeScript 7 and `typescript-eslint` incompatibility exposed by #6104, while preserving the dedicated Sass and Kendo SVG icon dependency groups.

## Validation

- Parsed `.github/dependabot.yml` successfully as YAML
- Verified `dev-dependencies.update-types` is exactly `minor` and `patch`
- Verified the existing Sass and Kendo SVG icon exclusions remain unchanged