### PR TITLE
fix(deps): restore root React types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@progress/kendo-e2e": "5.0.6",
         "@stylistic/stylelint-plugin": "^5.3.0",
         "@types/node": "^26.2.0",
+        "@types/react": "19.2.15",
         "@vitejs/plugin-react": "^6.0.5",
         "autoprefixer": "^10.5.4",
         "css-tree": "^3.2.1",
@@ -5288,6 +5289,16 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-devtools-npm/npm/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
     },
     "node_modules/@types/selenium-webdriver": {
       "version": "4.35.6",
@@ -19669,7 +19680,7 @@
         "@progress/kendo-svg-icons": "^4.11.0"
       },
       "devDependencies": {
-        "@types/react": "^19.2.18",
+        "@types/react": "^19.2.15",
         "@vitest/coverage-v8": "4.1.10",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -19678,16 +19689,6 @@
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "packages/html/node_modules/@types/react": {
-      "version": "19.2.15",
-      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-devtools-npm/npm/@types/react/-/react-19.2.15.tgz",
-      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.2.2"
       }
     },
     "packages/material": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@nx/js": "^23.1.1",
     "@stylistic/stylelint-plugin": "^5.3.0",
     "@types/node": "^26.2.0",
+    "@types/react": "19.2.15",
     "@vitejs/plugin-react": "^6.0.5",
     "autoprefixer": "^10.5.4",
     "css-tree": "^3.2.1",
@@ -115,7 +116,6 @@
   },
   "overrides": {
     "ast-v8-to-istanbul": "1.0.3",
-    "@types/react": "19.2.15",
     "@types/glob": "9.0.0",
     "nwsapi": "2.2.23",
     "vite": "8.0.14"

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -58,7 +58,7 @@
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@types/react": "^19.2.18",
+    "@types/react": "^19.2.15",
     "@vitest/coverage-v8": "4.1.10",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",


### PR DESCRIPTION
## Summary

- restore `@types/react@19.2.15` as an explicit root dev dependency
- align the HTML workspace range with the pinned version
- remove the now-redundant root override

## Root cause

The latest dependency update changed the HTML workspace request to `^19.2.18`, while the repository override remained pinned to `19.2.15`. npm consequently placed `@types/react` under `packages/html/node_modules` instead of the root dependency tree. CI caches root `node_modules` and skips `npm ci` on cache hits, so the HTML type-check ran without React type definitions.

Declaring the pinned package at the root makes npm hoist it into the existing cached dependency tree, so no workflow cache changes are needed.

## Validation

- clean `npm ci`
- confirmed `node_modules/@types/react` exists and `packages/html/node_modules/@types/react` does not
- `npm run typecheck -w packages/html`