### PR TITLE
feat(diagram): add rich text editor styles

### DIFF
--- a/packages/core/scss/components/diagram/_layout.scss
+++ b/packages/core/scss/components/diagram/_layout.scss
@@ -10,4 +10,35 @@
         gap: k-spacing(3);
     }
 
+    // Diagram rich text editor
+    .k-diagram-rich-text-editor {
+
+        .k-editor-content {
+
+            .k-placeholder:first-child::before {
+                content: attr(data-placeholder);
+                cursor: text;
+                height: 0;
+                font-style: italic;
+                opacity: 0.6;
+            }
+
+            .k-placeholder::before {
+                float: inline-start;
+                width: 100%;
+            }
+
+            outline: none;
+
+            p {
+                margin-block: var(--editor-p-margin-top, 0) var(--editor-p-margin-bottom, 0);
+            }
+
+            .ProseMirror-selectednode { // stylelint-disable-line selector-class-pattern
+                outline-width: 2px;
+                outline-style: solid;
+            }
+        }
+    }
+
 }

--- a/packages/core/scss/components/diagram/_theme.scss
+++ b/packages/core/scss/components/diagram/_theme.scss
@@ -1,2 +1,23 @@
+@use "../../color-system/_functions.scss" as *;
+
 @mixin kendo-diagram--theme-base() {
+
+    // Diagram rich text editor
+    .k-diagram-rich-text-editor {
+
+        .k-editor-content {
+
+            .k-placeholder:first-child::before {
+                color: k-color(subtle);
+            }
+
+            &::selection {
+                background: var(--editor-selection-bg);
+            }
+
+            .ProseMirror-selectednode { // stylelint-disable-line selector-class-pattern
+                outline-color: var(--editor-selection-bg);
+            }
+        }
+    }
 }


### PR DESCRIPTION
moving the styles from the react repo to the kendo-themes: https://github.com/telerik/kendo-react-private/blob/diagram-editing/apps/examples/src/pages/examples/diagram/styles.scss