### PR TITLE
RFC: Define inline Badge contract

### DIFF
--- a/packages/html/src/badge/badge.spec.tsx
+++ b/packages/html/src/badge/badge.spec.tsx
@@ -39,6 +39,8 @@ export type KendoBadgeProps = KendoBadgeOptions & {
 
 const defaultOptions = {
     cutoutBorder: false,
+    position: null,
+    align: null,
 };
 
 /**
@@ -56,8 +58,8 @@ export const Badge: KendoComponent<KendoBadgeProps & React.HTMLAttributes<HTMLSp
         themeColor,
         cutoutBorder = defaultOptions.cutoutBorder,
         rounded,
-        position,
-        align,
+        position = defaultOptions.position,
+        align = defaultOptions.align,
         ...other
     } = props;
 

--- a/packages/html/src/badge/index.ts
+++ b/packages/html/src/badge/index.ts
@@ -1,4 +1,5 @@
 export * from './badge.spec';
 export * from './templates/badge-normal';
+export * from './templates/badge-positioned';
 export * from './templates/icon-badge';
 export * from './demos/badge';

--- a/packages/html/src/badge/templates/badge-normal.tsx
+++ b/packages/html/src/badge/templates/badge-normal.tsx
@@ -1,3 +1,5 @@
-import { Badge } from "..";
+import { Badge, KendoBadgeProps } from "../badge.spec";
 
-export const BadgeNormal = (props) => <Badge {...props}/>;
+export type BadgeNormalProps = Omit<KendoBadgeProps, 'position' | 'align'> & React.HTMLAttributes<HTMLSpanElement>;
+
+export const BadgeNormal = (props: BadgeNormalProps) => <Badge {...props} />;

--- a/packages/html/src/badge/templates/badge-positioned.tsx
+++ b/packages/html/src/badge/templates/badge-positioned.tsx
@@ -1,0 +1,8 @@
+import { Badge, KendoBadgeProps } from "../badge.spec";
+
+export type BadgePositionedProps = Omit<KendoBadgeProps, 'position' | 'align'> & {
+    position: NonNullable<KendoBadgeProps['position']>;
+    align: NonNullable<KendoBadgeProps['align']>;
+} & React.HTMLAttributes<HTMLSpanElement>;
+
+export const BadgePositioned = (props: BadgePositionedProps) => <Badge {...props} />;

--- a/packages/html/src/badge/tests/badge-cutout-border.tsx
+++ b/packages/html/src/badge/tests/badge-cutout-border.tsx
@@ -1,4 +1,4 @@
-import { Badge, BadgeNormal } from '..';
+import { Badge, BadgeNormal, BadgePositioned } from '..';
 
 
 const styles = `
@@ -53,36 +53,36 @@ export default () =>(
 
                     <span>inside</span>
                     <div className="k-badge-container">
-                        <BadgeNormal fillMode={fillMode} rounded="none" position="inside" align="top-start" cutoutBorder>Rect</BadgeNormal>
+                        <BadgePositioned fillMode={fillMode} rounded="none" position="inside" align="top-start" cutoutBorder>Rect</BadgePositioned>
                     </div>
                     <div className="k-badge-container">
-                        <BadgeNormal fillMode={fillMode} rounded="medium" position="inside" align="top-start" cutoutBorder>Round</BadgeNormal>
+                        <BadgePositioned fillMode={fillMode} rounded="medium" position="inside" align="top-start" cutoutBorder>Round</BadgePositioned>
                     </div>
                     <div className="k-badge-container">
-                        <BadgeNormal fillMode={fillMode} rounded="full" position="inside" align="top-start" cutoutBorder>Pill</BadgeNormal>
+                        <BadgePositioned fillMode={fillMode} rounded="full" position="inside" align="top-start" cutoutBorder>Pill</BadgePositioned>
                     </div>
                     <div className="k-badge-container">
-                        <BadgeNormal fillMode={fillMode} rounded="full" position="inside" align="top-start" cutoutBorder>1</BadgeNormal>
+                        <BadgePositioned fillMode={fillMode} rounded="full" position="inside" align="top-start" cutoutBorder>1</BadgePositioned>
                     </div>
                     <div className="k-badge-container">
-                        <BadgeNormal fillMode={fillMode} rounded="full" position="inside" align="top-start" cutoutBorder></BadgeNormal>
+                        <BadgePositioned fillMode={fillMode} rounded="full" position="inside" align="top-start" cutoutBorder></BadgePositioned>
                     </div>
 
                     <span>edge</span>
                     <div className="k-badge-container">
-                        <BadgeNormal fillMode={fillMode} rounded="none" position="edge" align="top-start" cutoutBorder>Rect</BadgeNormal>
+                        <BadgePositioned fillMode={fillMode} rounded="none" position="edge" align="top-start" cutoutBorder>Rect</BadgePositioned>
                     </div>
                     <div className="k-badge-container">
-                        <BadgeNormal fillMode={fillMode} rounded="medium" position="edge" align="top-start" cutoutBorder>Round</BadgeNormal>
+                        <BadgePositioned fillMode={fillMode} rounded="medium" position="edge" align="top-start" cutoutBorder>Round</BadgePositioned>
                     </div>
                     <div className="k-badge-container">
-                        <BadgeNormal fillMode={fillMode} rounded="full" position="edge" align="top-start" cutoutBorder>Pill</BadgeNormal>
+                        <BadgePositioned fillMode={fillMode} rounded="full" position="edge" align="top-start" cutoutBorder>Pill</BadgePositioned>
                     </div>
                     <div className="k-badge-container">
-                        <BadgeNormal fillMode={fillMode} rounded="full" position="edge" align="top-start" cutoutBorder>1</BadgeNormal>
+                        <BadgePositioned fillMode={fillMode} rounded="full" position="edge" align="top-start" cutoutBorder>1</BadgePositioned>
                     </div>
                     <div className="k-badge-container">
-                        <BadgeNormal fillMode={fillMode} rounded="full" position="edge" align="top-start" cutoutBorder></BadgeNormal>
+                        <BadgePositioned fillMode={fillMode} rounded="full" position="edge" align="top-start" cutoutBorder></BadgePositioned>
                     </div>
                 </>
             ))}

--- a/packages/html/src/badge/tests/badge-position-outline.tsx
+++ b/packages/html/src/badge/tests/badge-position-outline.tsx
@@ -1,4 +1,4 @@
-import { BadgeNormal } from '..';
+import { BadgeNormal, BadgePositioned } from '..';
 
 
 const styles = `
@@ -72,31 +72,31 @@ export default () =>(
 
             <span>Inside</span>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="inside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="inside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="inside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="inside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="inside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="inside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="inside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="inside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
             <span>Edge</span>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="edge" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="edge" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="edge" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="edge" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="edge" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="edge" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="edge" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="edge" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
@@ -104,16 +104,16 @@ export default () =>(
 
             <span>Outside</span>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="outside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="outside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="outside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="outside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="outside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="outside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="outline" rounded="medium" position="outside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="outside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
@@ -121,31 +121,31 @@ export default () =>(
 
             <span>Inside RTL</span>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="inside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="inside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="inside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="inside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="inside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="inside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="inside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="inside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
             <span>Edge RTL</span>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="edge" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="edge" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="edge" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="edge" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="edge" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="edge" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="edge" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="edge" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
@@ -153,16 +153,16 @@ export default () =>(
 
             <span>Outside RTL</span>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="outside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="outside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="outside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="outside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="outside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="outside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="outline" rounded="medium" position="outside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="outline" rounded="medium" position="outside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 

--- a/packages/html/src/badge/tests/badge-position-solid.tsx
+++ b/packages/html/src/badge/tests/badge-position-solid.tsx
@@ -1,4 +1,4 @@
-import { BadgeNormal } from '..';
+import { BadgeNormal, BadgePositioned } from '..';
 
 
 const styles = `
@@ -72,31 +72,31 @@ export default () =>(
 
             <span>Inside</span>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="inside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="inside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="inside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="inside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="inside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="inside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="inside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="inside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
             <span>Edge</span>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="edge" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="edge" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="edge" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="edge" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="edge" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="edge" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="edge" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="edge" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
@@ -104,16 +104,16 @@ export default () =>(
 
             <span>Outside</span>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="outside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="outside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="outside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="outside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="outside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="outside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal fillMode="solid" rounded="medium" position="outside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="outside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
@@ -121,31 +121,31 @@ export default () =>(
 
             <span>Inside RTL</span>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="inside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="inside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="inside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="inside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="inside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="inside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="inside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="inside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
             <span>Edge RTL</span>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="edge" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="edge" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="edge" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="edge" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="edge" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="edge" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="edge" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="edge" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
@@ -153,16 +153,16 @@ export default () =>(
 
             <span>Outside RTL</span>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="outside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="outside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="outside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="outside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="outside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="outside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal fillMode="solid" rounded="medium" position="outside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned fillMode="solid" rounded="medium" position="outside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 

--- a/packages/html/src/badge/tests/badge-position.tsx
+++ b/packages/html/src/badge/tests/badge-position.tsx
@@ -1,4 +1,4 @@
-import { BadgeNormal } from '..';
+import { BadgeNormal, BadgePositioned } from '..';
 
 
 const styles = `
@@ -72,31 +72,31 @@ export default () =>(
 
             <span>Inside</span>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="inside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="inside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="inside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="inside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="inside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="inside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="inside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="inside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
             <span>Edge</span>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="edge" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="edge" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="edge" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="edge" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="edge" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="edge" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="edge" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="edge" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
@@ -104,16 +104,16 @@ export default () =>(
 
             <span>Outside</span>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="outside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="outside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="outside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="outside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="outside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="outside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container">
-                <BadgeNormal rounded="medium" position="outside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="outside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
@@ -121,31 +121,31 @@ export default () =>(
 
             <span>Inside RTL</span>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="inside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="inside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="inside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="inside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="inside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="inside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="inside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="inside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
             <span>Edge RTL</span>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="edge" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="edge" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="edge" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="edge" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="edge" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="edge" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="edge" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="edge" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 
@@ -153,16 +153,16 @@ export default () =>(
 
             <span>Outside RTL</span>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="outside" align="top-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="outside" align="top-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="outside" align="top-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="outside" align="top-end">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="outside" align="bottom-start">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="outside" align="bottom-start">Rect</BadgePositioned>
             </div>
             <div className="k-badge-container k-rtl">
-                <BadgeNormal rounded="medium" position="outside" align="bottom-end">Rect</BadgeNormal>
+                <BadgePositioned rounded="medium" position="outside" align="bottom-end">Rect</BadgePositioned>
             </div>
             <span></span>
 


### PR DESCRIPTION
During the modernization of the Paget Templates and Building Blocks (https://github.com/telerik/kendo-building-blocks/pull/502) I’ve noticed the Badge component has been used as an inline Component on multiple ocasions — in KPI Cards, Grid Cells etc.

It revealed that our React and Angular’s badges has the enforced absolute positioning by default which seems unexpected and sub-optimal. Because of this I’m proposing we do default to non-positioned badge by setting the `position` and `align` to `null`.

Opening up as a discussion!

---

This PR makes the inline Badge contract explicit in the HTML specs and separates normal from positioned Badge templates. Theme styling remains unchanged.

[FE-1347](https://progresssoftware.atlassian.net/browse/FE-1347)

Related PRs:
- [KendoReact #8093](https://github.com/telerik/kendo-react-private/pull/8093)
- [Kendo UI for Angular #7675](https://github.com/telerik/kendo-angular-private/pull/7675)

[FE-1347]: https://progresssoftware.atlassian.net/browse/FE-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ