### PR TITLE
fix(ci): reconcile visual reports with pull requests

### DIFF
--- a/.github/workflows/_visual-regression.yml
+++ b/.github/workflows/_visual-regression.yml
@@ -84,12 +84,24 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.sha,
-            });
-            const openPr = prs.find(pr => pr.state === 'open');
+            // Cover the common first-push race cheaply here. The PR lifecycle
+            // reconciler handles PRs opened after this bounded wait expires.
+            let openPr;
+            for (let attempt = 1; attempt <= 6; attempt++) {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+              });
+              openPr = prs.find(pr =>
+                pr.state === 'open' &&
+                pr.head.sha === context.sha &&
+                pr.head.repo?.full_name === `${context.repo.owner}/${context.repo.repo}`
+              );
+              if (openPr || attempt === 6) break;
+              core.info(`No open PR found (attempt ${attempt}/6); retrying in 5 seconds.`);
+              await new Promise(resolve => setTimeout(resolve, 5000));
+            }
             if (openPr) {
               core.exportVariable('REG_REPORT_KEY', `pr-${openPr.number}`);
               core.setOutput('pr-number', String(openPr.number));
@@ -158,6 +170,12 @@ jobs:
             }
           '
 
+      - name: Record report source commit
+        if: ${{ !inputs.baseline && steps.publish-target.outputs.target-dir != '' }}
+        env:
+          SOURCE_DIR: ${{ steps.publish-target.outputs.source-dir }}
+        run: printf '%s\n' '${{ github.sha }}' > "$SOURCE_DIR/.source-sha"
+
       # reg-suit's own publish plugin shells out to `git commit`/`git push`
       # against a worktree of the *entire* gh-pages history, which reliably
       # crashes with ENOBUFS once a run has a real (non-"new") diff to report
@@ -178,6 +196,52 @@ jobs:
           keep_files: false
           user_name: kendo-bot
           user_email: kendouiteam@progress.com
+
+      - name: Validate pull request report
+        id: validate-pr-report
+        if: ${{ !inputs.baseline && steps.resolve-report-key.outputs.pr-number != '' }}
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.resolve-report-key.outputs.pr-number }}
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            core.setOutput('current', String(pr.state === 'open' && pr.head.sha === context.sha));
+
+      # A PR can close or receive another push after report-key resolution.
+      # Remove this run's report only when its source marker still matches, so
+      # a stale run cannot recreate a closed report or delete a newer one.
+      - name: Remove stale pull request report
+        if: ${{ steps.validate-pr-report.outputs.current == 'false' }}
+        env:
+          PR_NUMBER: ${{ steps.resolve-report-key.outputs.pr-number }}
+        run: |
+          git fetch --depth 1 origin gh-pages
+          git worktree add --no-checkout gh-pages-stale origin/gh-pages
+          git -C gh-pages-stale sparse-checkout init --no-cone
+          git -C gh-pages-stale sparse-checkout set "reports/pr-$PR_NUMBER"
+          git -C gh-pages-stale checkout
+
+          cd gh-pages-stale
+          target_dir="reports/pr-$PR_NUMBER"
+          if [ ! -f "$target_dir/.source-sha" ] ||
+             [ "$(cat "$target_dir/.source-sha")" != "${{ github.sha }}" ]; then
+            echo "A newer report replaced this one; leaving it untouched."
+            exit 0
+          fi
+
+          git config user.name "kendo-bot"
+          git config user.email "kendouiteam@progress.com"
+          git rm -r "$target_dir"
+          git commit -m "chore(ci): remove stale visual report for PR #$PR_NUMBER"
+          for attempt in 1 2 3; do
+            git push origin HEAD:gh-pages && break
+            [ "$attempt" -eq 3 ] && exit 1
+            git pull --rebase origin gh-pages
+          done
 
       # Baseline runs publish under reports/<commit-sha>/ (see "Resolve report
       # key" above - REG_REPORT_KEY is only set for PR runs), and fetch() only
@@ -200,7 +264,9 @@ jobs:
 
           for dir in reports/*/; do
             name="$(basename "$dir")"
-            [[ "$name" == pr-* || "$name" == "$KEEP" ]] && continue
+            # Source-marked SHA reports belong to feature runs whose PR may
+            # not exist yet. The lifecycle reconciler moves or removes them.
+            [[ "$name" == pr-* || "$name" == "$KEEP" || -f "$dir/.source-sha" ]] && continue
             git rm -rq --ignore-unmatch "$dir"
           done
 
@@ -237,11 +303,11 @@ jobs:
               return;
             }
 
-            // Pruning above keeps exactly the current baseline commit's
-            // directory alongside the pr-* ones, so whatever's left that
-            // isn't a PR report is the baseline.
+            // Feature runs may temporarily leave commit-keyed reports for the
+            // lifecycle reconciler, so only a baseline run may update the
+            // develop alias.
             const prDirs = dirs.filter(d => d.startsWith('pr-')).sort((a, b) => Number(b.slice(3)) - Number(a.slice(3)));
-            const baselineDir = dirs.find(d => !d.startsWith('pr-'));
+            const baselineDir = ${{ inputs.baseline }} ? context.sha : undefined;
 
             async function putFile(path, content, message) {
               let sha;
@@ -264,7 +330,7 @@ jobs:
             // Static, SHA-independent alias: /develop/ always redirects to
             // whatever the current baseline report is, so nobody has to look
             // up a commit hash to see it.
-            if (baselineDir) {
+            if (${{ inputs.baseline }} && baselineDir) {
               const target = `../reports/${baselineDir}/`;
               const redirect = [
                 '<!DOCTYPE html>',
@@ -323,7 +389,10 @@ jobs:
             // This workflow is push-triggered, so there's no pull_request
             // context (context.issue.number is always unset here) - use the
             // PR resolved in "Resolve report key" instead.
-            const issue_number = Number('${{ steps.resolve-report-key.outputs.pr-number }}') || undefined;
+            const isCurrentPrReport = '${{ steps.validate-pr-report.outputs.current }}' !== 'false';
+            const issue_number = isCurrentPrReport
+              ? Number('${{ steps.resolve-report-key.outputs.pr-number }}') || undefined
+              : undefined;
             if (!issue_number) return;   // no open PR for this commit (or a baseline run)
             const marker = '<!-- reg-suit-visual-report -->';
             const body = [

--- a/.github/workflows/associate-visual-regression.yml
+++ b/.github/workflows/associate-visual-regression.yml
@@ -1,0 +1,356 @@
+name: Associate visual regression report
+
+# Feature CI starts on push, so its first report can finish before a PR exists
+# and publish under reports/<commit-sha>/. Reconcile on both sides of that race:
+# PR-open handles an already-published report, while CI-completed handles a PR
+# that appeared while CI was still running. No pull request code is checked out
+# or executed, and fork PRs are explicitly excluded.
+on:
+  pull_request_target:
+    types: [opened]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  # Match the push-triggered publisher's github.ref key and the close cleanup's
+  # head.ref key, so all report operations for a branch are serialized.
+  group: visual-regression-refs/heads/${{ github.event.pull_request.head.ref || github.event.workflow_run.head_branch }}
+
+jobs:
+  associate:
+    if: >-
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Resolve current pull request
+        id: resolve
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const isPrEvent = context.eventName === 'pull_request_target';
+            const sha = isPrEvent
+              ? context.payload.pull_request.head.sha
+              : context.payload.workflow_run.head_sha;
+            let pr = isPrEvent ? context.payload.pull_request : undefined;
+
+            if (!pr) {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner, repo, commit_sha: sha,
+              });
+              const matching = prs.filter(candidate =>
+                candidate.head.sha === sha &&
+                candidate.head.repo?.full_name === `${owner}/${repo}`
+              );
+              pr = matching.find(candidate => candidate.state === 'open') || matching[0];
+            }
+
+            if (!pr) {
+              core.info('No PR points at this commit; nothing to reconcile.');
+              return;
+            }
+
+            core.setOutput('pr-number', String(pr.number));
+            core.setOutput('sha', sha);
+            core.setOutput(
+              'mode',
+              pr.state === 'open' && pr.head.sha === sha ? 'associate' : 'cleanup'
+            );
+
+      - name: Wait for a published report
+        id: report
+        if: steps.resolve.outputs.pr-number != ''
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr-number }}
+          REPORT_SHA: ${{ steps.resolve.outputs.sha }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = process.env.REPORT_SHA;
+            const prNumber = process.env.PR_NUMBER;
+            const attempts = context.eventName === 'pull_request_target' ? 24 : 6;
+
+            async function read(path) {
+              try {
+                const { data } = await github.rest.repos.getContent({
+                  owner, repo, path, ref: 'gh-pages',
+                });
+                return data;
+              } catch (error) {
+                if (error.status === 404) return undefined;
+                throw error;
+              }
+            }
+
+            for (let attempt = 1; attempt <= attempts; attempt++) {
+              if (await read(`reports/${sha}/out.json`)) {
+                core.setOutput('location', 'commit');
+                return;
+              }
+
+              const marker = await read(`reports/pr-${prNumber}/.source-sha`);
+              if (marker) {
+                const markerSha = Buffer.from(marker.content, 'base64').toString('utf8').trim();
+                if (markerSha === sha) {
+                  core.setOutput('location', 'pr');
+                  return;
+                }
+              }
+
+              if (attempt < attempts) {
+                core.info(`Report is not published yet (attempt ${attempt}/${attempts}); retrying in 10 seconds.`);
+                await new Promise(resolve => setTimeout(resolve, 10000));
+              }
+            }
+
+            core.notice(
+              'No report is available yet. The CI-completed event will retry if CI is still running.'
+            );
+
+      - name: Check out report paths
+        if: steps.report.outputs.location != ''
+        uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+          fetch-depth: 1
+          sparse-checkout: |
+            reports/${{ steps.resolve.outputs.sha }}
+            reports/pr-${{ steps.resolve.outputs.pr-number }}
+          sparse-checkout-cone-mode: false
+
+      - name: Confirm pull request still points at commit
+        id: current
+        if: steps.report.outputs.location != '' && steps.resolve.outputs.mode == 'associate'
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr-number }}
+          REPORT_SHA: ${{ steps.resolve.outputs.sha }}
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            core.setOutput(
+              'matches',
+              String(pr.state === 'open' && pr.head.sha === process.env.REPORT_SHA)
+            );
+
+      - name: Remove report for closed pull request
+        id: closed-cleanup
+        if: steps.report.outputs.location != '' && steps.resolve.outputs.mode == 'cleanup'
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr-number }}
+          REPORT_SHA: ${{ steps.resolve.outputs.sha }}
+        run: |
+          removed=false
+          for target_dir in "reports/$REPORT_SHA" "reports/pr-$PR_NUMBER"; do
+            if [ -f "$target_dir/.source-sha" ] &&
+               [ "$(cat "$target_dir/.source-sha")" = "$REPORT_SHA" ]; then
+              git rm -r "$target_dir"
+              removed=true
+            fi
+          done
+
+          if [ "$removed" != "true" ]; then
+            echo "No report owned by this commit remains."
+            exit 0
+          fi
+
+          git config user.name "kendo-bot"
+          git config user.email "kendouiteam@progress.com"
+          git commit -m "chore(ci): remove visual report for closed PR #$PR_NUMBER"
+          for attempt in 1 2 3; do
+            git push origin HEAD:gh-pages && break
+            [ "$attempt" -eq 3 ] && exit 1
+            git pull --rebase origin gh-pages
+          done
+          echo "removed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Move commit report to pull request
+        id: move
+        if: steps.report.outputs.location == 'commit' && steps.current.outputs.matches == 'true'
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr-number }}
+          REPORT_SHA: ${{ steps.resolve.outputs.sha }}
+        run: |
+          source_dir="reports/$REPORT_SHA"
+          target_dir="reports/pr-$PR_NUMBER"
+
+          if [ ! -f "$source_dir/out.json" ]; then
+            echo "The source report was already moved."
+            exit 0
+          fi
+
+          rm -rf "$target_dir"
+          mv "$source_dir" "$target_dir"
+          printf '%s\n' "$REPORT_SHA" > "$target_dir/.source-sha"
+
+          git config user.name "kendo-bot"
+          git config user.email "kendouiteam@progress.com"
+          git add -A "$source_dir" "$target_dir"
+          git commit -m "chore(ci): associate visual report with PR #$PR_NUMBER"
+
+          for attempt in 1 2 3; do
+            if git push origin HEAD:gh-pages; then
+              echo "moved=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            [ "$attempt" -eq 3 ] && exit 1
+            git pull --rebase origin gh-pages
+          done
+
+      - name: Validate published association
+        id: final
+        if: steps.current.outputs.matches == 'true'
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr-number }}
+          REPORT_SHA: ${{ steps.resolve.outputs.sha }}
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            core.setOutput(
+              'matches',
+              String(pr.state === 'open' && pr.head.sha === process.env.REPORT_SHA)
+            );
+
+      - name: Remove stale moved report
+        if: steps.move.outputs.moved == 'true' && steps.final.outputs.matches != 'true'
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr-number }}
+          REPORT_SHA: ${{ steps.resolve.outputs.sha }}
+        run: |
+          target_dir="reports/pr-$PR_NUMBER"
+          git pull --rebase origin gh-pages
+
+          if [ ! -f "$target_dir/.source-sha" ] ||
+             [ "$(cat "$target_dir/.source-sha")" != "$REPORT_SHA" ]; then
+            echo "A newer report replaced this one; leaving it untouched."
+            exit 0
+          fi
+
+          git rm -r "$target_dir"
+          git commit -m "chore(ci): remove stale visual report for PR #$PR_NUMBER"
+          git push origin HEAD:gh-pages
+
+      - name: Repair reports index
+        if: >-
+          (steps.move.outputs.moved == 'true' && steps.final.outputs.matches == 'true') ||
+          steps.closed-cleanup.outputs.removed == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const { data } = await github.rest.repos.getContent({
+              owner, repo, path: 'reports', ref: 'gh-pages',
+            });
+            const prDirs = data
+              .filter(entry => entry.type === 'dir' && entry.name.startsWith('pr-'))
+              .map(entry => entry.name)
+              .sort((a, b) => Number(b.slice(3)) - Number(a.slice(3)));
+            const rows = prDirs
+              .map(dir => {
+                const number = dir.slice(3);
+                return `<li><a href="reports/${dir}/">PR #${number} report</a> — <a href="https://github.com/${owner}/${repo}/pull/${number}">view PR</a></li>`;
+              })
+              .join('\n');
+            const body = [
+              '<!DOCTYPE html>',
+              '<meta charset="utf-8">',
+              `<title>${repo} visual regression reports</title>`,
+              `<h1>${repo} visual regression reports</h1>`,
+              '<ul>',
+              '<li><a href="develop/">develop (baseline)</a></li>',
+              rows || '<li><em>No open PR reports.</em></li>',
+              '</ul>',
+              '',
+            ].join('\n');
+
+            for (let attempt = 1; attempt <= 3; attempt++) {
+              let current;
+              try {
+                ({ data: current } = await github.rest.repos.getContent({
+                  owner, repo, path: 'index.html', ref: 'gh-pages',
+                }));
+                await github.rest.repos.createOrUpdateFileContents({
+                  owner, repo, path: 'index.html',
+                  message: 'chore(ci): update reports index',
+                  content: Buffer.from(body).toString('base64'),
+                  branch: 'gh-pages',
+                  sha: current.sha,
+                  committer: { name: 'kendo-bot', email: 'kendouiteam@progress.com' },
+                  author: { name: 'kendo-bot', email: 'kendouiteam@progress.com' },
+                });
+                break;
+              } catch (error) {
+                if (attempt === 3 || ![409, 422].includes(error.status)) throw error;
+                core.info(`Reports index changed concurrently; retrying (${attempt}/3).`);
+              }
+            }
+
+      - name: Comment on pull request
+        if: steps.final.outputs.matches == 'true'
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr-number }}
+          REPORT_SHA: ${{ steps.resolve.outputs.sha }}
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = Number(process.env.PR_NUMBER);
+            const reportDir = `reports/pr-${prNumber}`;
+            const markerPath = `${reportDir}/.source-sha`;
+            if (!fs.existsSync(markerPath) ||
+                fs.readFileSync(markerPath, 'utf8').trim() !== process.env.REPORT_SHA) {
+              core.info('The PR report does not match the current head commit; skipping comment.');
+              return;
+            }
+
+            const out = JSON.parse(fs.readFileSync(`${reportDir}/out.json`, 'utf8'));
+            const changed = out.failedItems.length;
+            const added = out.newItems.length;
+            const deleted = out.deletedItems.length;
+            const passed = out.passedItems.length;
+            const reportUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/reports/pr-${prNumber}/`;
+            const marker = '<!-- reg-suit-visual-report -->';
+            const body = [
+              marker,
+              '### 🖼️ Visual regression',
+              '| Changed | New | Deleted | Passed |',
+              '|--:|--:|--:|--:|',
+              `| **${changed}** | ${added} | ${deleted} | ${passed} |`,
+              '',
+              `📊 [Open the diff report](${reportUrl})`,
+              changed === 0 && added === 0
+                ? '_No visual changes detected._'
+                : '_Review the report, then approve by merging — the baseline updates on `develop`._',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: prNumber,
+            });
+            const existing = comments.find(comment => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body,
+              });
+            }

--- a/.github/workflows/cleanup-visual-regression.yml
+++ b/.github/workflows/cleanup-visual-regression.yml
@@ -12,7 +12,7 @@ on:
     types: [closed]
 
 concurrency:
-  group: cleanup-visual-regression-${{ github.event.pull_request.number }}
+  group: visual-regression-refs/heads/${{ github.event.pull_request.head.ref }}
 
 jobs:
   cleanup:
@@ -25,15 +25,72 @@ jobs:
           ref: gh-pages
           fetch-depth: 1
 
-      - name: Remove PR report folder
+      - name: Remove PR report folders
+        id: cleanup
         run: |
-          DIR="reports/pr-${{ github.event.pull_request.number }}"
-          if [ -d "$DIR" ]; then
+          PR_DIR="reports/pr-${{ github.event.pull_request.number }}"
+          SHA_DIR="reports/${{ github.event.pull_request.head.sha }}"
+          removed=false
+          if [ -d "$PR_DIR" ] || [ -d "$SHA_DIR" ]; then
             git config user.name "kendo-bot"
             git config user.email "kendouiteam@progress.com"
-            git rm -r --ignore-unmatch "$DIR"
-            git commit -m "chore(ci): remove visual regression report for closed PR #${{ github.event.pull_request.number }}"
-            git push origin gh-pages
-          else
-            echo "No report folder found at $DIR, nothing to clean up."
+            if [ -d "$PR_DIR" ]; then
+              git rm -r "$PR_DIR"
+              removed=true
+            fi
+            if [ -f "$SHA_DIR/.source-sha" ] &&
+               [ "$(cat "$SHA_DIR/.source-sha")" = "${{ github.event.pull_request.head.sha }}" ]; then
+              git rm -r "$SHA_DIR"
+              removed=true
+            fi
           fi
+
+          if [ "$removed" = "true" ]; then
+            git commit -m "chore(ci): remove visual regression report for closed PR #${{ github.event.pull_request.number }}"
+            for attempt in 1 2 3; do
+              git push origin gh-pages && break
+              [ "$attempt" -eq 3 ] && exit 1
+              git pull --rebase origin gh-pages
+            done
+            echo "removed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No report folders found for this PR, nothing to clean up."
+          fi
+
+      - name: Remove PR from reports index
+        if: steps.cleanup.outputs.removed == 'true'
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const marker = `PR #${process.env.PR_NUMBER} report`;
+
+            for (let attempt = 1; attempt <= 3; attempt++) {
+              try {
+                const { data: current } = await github.rest.repos.getContent({
+                  owner, repo, path: 'index.html', ref: 'gh-pages',
+                });
+                const content = Buffer.from(current.content, 'base64').toString('utf8');
+                const updated = content
+                  .split('\n')
+                  .filter(line => !line.includes(marker))
+                  .join('\n');
+                if (updated === content) return;
+
+                await github.rest.repos.createOrUpdateFileContents({
+                  owner, repo, path: 'index.html',
+                  message: 'chore(ci): update reports index',
+                  content: Buffer.from(updated).toString('base64'),
+                  branch: 'gh-pages',
+                  sha: current.sha,
+                  committer: { name: 'kendo-bot', email: 'kendouiteam@progress.com' },
+                  author: { name: 'kendo-bot', email: 'kendouiteam@progress.com' },
+                });
+                return;
+              } catch (error) {
+                if (attempt === 3 || ![409, 422].includes(error.status)) throw error;
+                core.info(`Reports index changed concurrently; retrying (${attempt}/3).`);
+              }
+            }


### PR DESCRIPTION
There was this strange race condition between branch push, draft PR and PR ready for review, that would prevent me from triggering the image diffs in https://github.com/telerik/kendo-themes/pull/6167 which forced me to manually trigger em. Fixing it. 

smarty pants description bellow
---

## Summary

- retry the initial commit-to-PR lookup briefly to cover the common first-push timing window
- add a lightweight PR-open/CI-completed reconciler that moves an existing commit-keyed report to `reports/pr-<number>/` and posts the visual report comment
- mark reports with their source SHA so stale, superseded, and closed-PR cleanup cannot delete a newer report
- preserve pending commit-keyed feature reports during baseline pruning and keep feature runs from rewriting the `develop` alias
- coordinate report mutation by source branch, retry non-fast-forward cleanup pushes, and remove closed PRs from the reports index

## Security and lifecycle

The reconciler uses `pull_request_target` only for metadata and trusted base-branch workflow code. It never checks out or executes pull-request code, explicitly ignores fork PRs, and grants only `contents: write` and `pull-requests: write` to the reconciliation job. Draft PRs are handled by the normal `opened` event.

The PR-open path waits briefly for an in-flight report; the `workflow_run: completed` path provides the durable follow-up when CI finishes later. Current PR state/head and the persisted source-SHA marker are checked before moving, deleting, or commenting, so canceled and superseded runs cannot overwrite newer reports.

## Validation

- `actionlint .github/workflows/associate-visual-regression.yml .github/workflows/cleanup-visual-regression.yml`
- YAML parsing for all three changed workflows
- `git diff --check`

`_visual-regression.yml` retains its two pre-existing actionlint findings: the organization-allowed `peaceiris/actions-gh-pages@v3` pin and an existing ShellCheck SC2016 notice.
