### PR TITLE
chore(release): migrate releaseTagPattern to nested releaseTag config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -89,7 +89,9 @@
         "stageChanges": true
       }
     },
-    "releaseTagPattern": "v{version}"
+    "releaseTag": {
+      "pattern": "v{version}"
+    }
   },
   "analytics": false
 }


### PR DESCRIPTION
## Problem

The [last "Publish to npm" workflow run](https://github.com/telerik/kendo-themes/actions/runs/34096858743) failed at the **Nx release (dev)** step:

```
NX   Found deprecated releaseTagPattern* properties in your nx.json that are no longer supported in Nx 23.

The following properties were moved to the nested "releaseTag" object in Nx 22 and removed in Nx 23:
  - release.releaseTagPattern

Run "nx repair" to migrate them automatically.
##[error]Process completed with exit code 1.
```

The repo is on `nx@^23.1.1`, which removed the flat `release.releaseTagPattern` property. `nx.json` still used the old flat form, so `npx nx release version --preid dev` exited with code 1, aborting the publish job before the dev-tag npm publish could run.

## Fix

Moved `releaseTagPattern` into the nested `releaseTag.pattern` structure required by Nx 23 (equivalent to running `nx repair`).

```diff
-    "releaseTagPattern": "v{version}"
+    "releaseTag": {
+      "pattern": "v{version}"
+    }
```

## Verification

Reproduced the failure locally: `npx nx release version --preid dev --dry-run` exited 1 with the identical deprecation error before the fix.

After the fix, the same dry-run command exits 0 and correctly resolves versions from existing `v{version}` git tags for all fixed-group packages (e.g. `Resolved the current version as 14.5.1-dev.1 from git tag "v14.5.1-dev.1", based on releaseTag.pattern "v{version}"`).

No release/publish/tag/push commands were executed — only `--dry-run` checks.