### PR TITLE
fix(coloreditor): bump min-width to match widest view content

### DIFF
--- a/packages/material/docs/customization-color-editor.md
+++ b/packages/material/docs/customization-color-editor.md
@@ -70,8 +70,8 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-color-editor-md-min-width</td>
     <td>Number</td>
-    <td><code>294px</code></td>
-    <td><code>294px</code></td>
+    <td><code>298px</code></td>
+    <td><code>298px</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The minimum width of the ColorEditor.</div></div>
@@ -513,7 +513,7 @@ The following table lists the available variables for customization.
         preview-height: $kendo-color-editor-lg-color-preview-height,
     )
 )</code></td>
-    <td><ul><li>sm: "min-width":"278px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"14px"</li><li>md: "min-width":"294px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"16px"</li><li>lg: "min-width":"364px","header-padding-x":"var(--kendo-spacing-4\\.5)","header-padding-y":"var(--kendo-spacing-4\\.5)","views-padding-x":"var(--kendo-spacing-4\\.5)","views-padding-y":"var(--kendo-spacing-4\\.5)","preview-gap":"var(--kendo-spacing-1)","preview-width":"42px","preview-height":"18px"</li></ul></td>
+    <td><ul><li>sm: "min-width":"278px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"14px"</li><li>md: "min-width":"298px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"16px"</li><li>lg: "min-width":"364px","header-padding-x":"var(--kendo-spacing-4\\.5)","header-padding-y":"var(--kendo-spacing-4\\.5)","views-padding-x":"var(--kendo-spacing-4\\.5)","views-padding-y":"var(--kendo-spacing-4\\.5)","preview-gap":"var(--kendo-spacing-1)","preview-width":"42px","preview-height":"18px"</li></ul></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The size map of the ColorEditor.</div></div>

--- a/packages/material/docs/customization.md
+++ b/packages/material/docs/customization.md
@@ -9719,8 +9719,8 @@ The following table lists the available variables for customizing the Material t
 <tr>
     <td>$kendo-color-editor-md-min-width</td>
     <td>Number</td>
-    <td><code>294px</code></td>
-    <td><code>294px</code></td>
+    <td><code>298px</code></td>
+    <td><code>298px</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The minimum width of the ColorEditor.</div></div>
@@ -10162,7 +10162,7 @@ The following table lists the available variables for customizing the Material t
         preview-height: $kendo-color-editor-lg-color-preview-height,
     )
 )</code></td>
-    <td><ul><li>sm: "min-width":"278px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"14px"</li><li>md: "min-width":"294px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"16px"</li><li>lg: "min-width":"364px","header-padding-x":"var(--kendo-spacing-4\\.5)","header-padding-y":"var(--kendo-spacing-4\\.5)","views-padding-x":"var(--kendo-spacing-4\\.5)","views-padding-y":"var(--kendo-spacing-4\\.5)","preview-gap":"var(--kendo-spacing-1)","preview-width":"42px","preview-height":"18px"</li></ul></td>
+    <td><ul><li>sm: "min-width":"278px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"14px"</li><li>md: "min-width":"298px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"16px"</li><li>lg: "min-width":"364px","header-padding-x":"var(--kendo-spacing-4\\.5)","header-padding-y":"var(--kendo-spacing-4\\.5)","views-padding-x":"var(--kendo-spacing-4\\.5)","views-padding-y":"var(--kendo-spacing-4\\.5)","preview-gap":"var(--kendo-spacing-1)","preview-width":"42px","preview-height":"18px"</li></ul></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The size map of the ColorEditor.</div></div>

--- a/packages/material/scss/coloreditor/_variables.scss
+++ b/packages/material/scss/coloreditor/_variables.scss
@@ -19,7 +19,7 @@ $kendo-color-editor-min-width: null !default;
 $kendo-color-editor-sm-min-width: 278px !default;
 /// The minimum width of the ColorEditor.
 /// @group color-editor
-$kendo-color-editor-md-min-width: 294px !default;
+$kendo-color-editor-md-min-width: 298px !default;
 /// The minimum width of the ColorEditor.
 /// @group color-editor
 $kendo-color-editor-lg-min-width: 364px !default;

--- a/packages/meridian/docs/customization-color-editor.md
+++ b/packages/meridian/docs/customization-color-editor.md
@@ -60,8 +60,8 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-color-editor-sm-min-width</td>
     <td>Number</td>
-    <td><code>252px</code></td>
-    <td><code>252px</code></td>
+    <td><code>256px</code></td>
+    <td><code>256px</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The minimum width of the ColorEditor.</div></div>
@@ -70,8 +70,8 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-color-editor-md-min-width</td>
     <td>Number</td>
-    <td><code>272px</code></td>
-    <td><code>272px</code></td>
+    <td><code>280px</code></td>
+    <td><code>280px</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The minimum width of the ColorEditor.</div></div>
@@ -80,8 +80,8 @@ The following table lists the available variables for customization.
 <tr>
     <td>$kendo-color-editor-lg-min-width</td>
     <td>Number</td>
-    <td><code>362px</code></td>
-    <td><code>362px</code></td>
+    <td><code>364px</code></td>
+    <td><code>364px</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The minimum width of the ColorEditor.</div></div>
@@ -513,7 +513,7 @@ The following table lists the available variables for customization.
         preview-height: $kendo-color-editor-lg-color-preview-height,
     )
 )</code></td>
-    <td><ul><li>sm: "min-width":"252px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"12px"</li><li>md: "min-width":"272px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"14px"</li><li>lg: "min-width":"362px","header-padding-x":"var(--kendo-spacing-4\\.5)","header-padding-y":"var(--kendo-spacing-4\\.5)","views-padding-x":"var(--kendo-spacing-4\\.5)","views-padding-y":"var(--kendo-spacing-4\\.5)","preview-gap":"var(--kendo-spacing-1)","preview-width":"44px","preview-height":"16px"</li></ul></td>
+    <td><ul><li>sm: "min-width":"256px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"12px"</li><li>md: "min-width":"280px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"14px"</li><li>lg: "min-width":"364px","header-padding-x":"var(--kendo-spacing-4\\.5)","header-padding-y":"var(--kendo-spacing-4\\.5)","views-padding-x":"var(--kendo-spacing-4\\.5)","views-padding-y":"var(--kendo-spacing-4\\.5)","preview-gap":"var(--kendo-spacing-1)","preview-width":"44px","preview-height":"16px"</li></ul></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The size map of the ColorEditor.</div></div>

--- a/packages/meridian/docs/customization.md
+++ b/packages/meridian/docs/customization.md
@@ -10036,8 +10036,8 @@ The following table lists the available variables for customizing the Meridian t
 <tr>
     <td>$kendo-color-editor-sm-min-width</td>
     <td>Number</td>
-    <td><code>252px</code></td>
-    <td><code>252px</code></td>
+    <td><code>256px</code></td>
+    <td><code>256px</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The minimum width of the ColorEditor.</div></div>
@@ -10046,8 +10046,8 @@ The following table lists the available variables for customizing the Meridian t
 <tr>
     <td>$kendo-color-editor-md-min-width</td>
     <td>Number</td>
-    <td><code>272px</code></td>
-    <td><code>272px</code></td>
+    <td><code>280px</code></td>
+    <td><code>280px</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The minimum width of the ColorEditor.</div></div>
@@ -10056,8 +10056,8 @@ The following table lists the available variables for customizing the Meridian t
 <tr>
     <td>$kendo-color-editor-lg-min-width</td>
     <td>Number</td>
-    <td><code>362px</code></td>
-    <td><code>362px</code></td>
+    <td><code>364px</code></td>
+    <td><code>364px</code></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The minimum width of the ColorEditor.</div></div>
@@ -10489,7 +10489,7 @@ The following table lists the available variables for customizing the Meridian t
         preview-height: $kendo-color-editor-lg-color-preview-height,
     )
 )</code></td>
-    <td><ul><li>sm: "min-width":"252px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"12px"</li><li>md: "min-width":"272px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"14px"</li><li>lg: "min-width":"362px","header-padding-x":"var(--kendo-spacing-4\\.5)","header-padding-y":"var(--kendo-spacing-4\\.5)","views-padding-x":"var(--kendo-spacing-4\\.5)","views-padding-y":"var(--kendo-spacing-4\\.5)","preview-gap":"var(--kendo-spacing-1)","preview-width":"44px","preview-height":"16px"</li></ul></td>
+    <td><ul><li>sm: "min-width":"256px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"12px"</li><li>md: "min-width":"280px","header-padding-x":"var(--kendo-spacing-3)","header-padding-y":"var(--kendo-spacing-3)","views-padding-x":"var(--kendo-spacing-3)","views-padding-y":"var(--kendo-spacing-3)","preview-gap":"var(--kendo-spacing-0\\.5)","preview-width":"34px","preview-height":"14px"</li><li>lg: "min-width":"364px","header-padding-x":"var(--kendo-spacing-4\\.5)","header-padding-y":"var(--kendo-spacing-4\\.5)","views-padding-x":"var(--kendo-spacing-4\\.5)","views-padding-y":"var(--kendo-spacing-4\\.5)","preview-gap":"var(--kendo-spacing-1)","preview-width":"44px","preview-height":"16px"</li></ul></td>
 </tr>
 <tr>
     <td colspan="4" class="theme-variables-description-container"><div><b>Description</b><div class="theme-variables-description">The size map of the ColorEditor.</div></div>

--- a/packages/meridian/scss/coloreditor/_variables.scss
+++ b/packages/meridian/scss/coloreditor/_variables.scss
@@ -16,13 +16,13 @@ $kendo-color-editor-spacer: k-spacing(3) !default;
 $kendo-color-editor-min-width: null !default;
 /// The minimum width of the ColorEditor.
 /// @group color-editor
-$kendo-color-editor-sm-min-width: 252px !default;
+$kendo-color-editor-sm-min-width: 256px !default;
 /// The minimum width of the ColorEditor.
 /// @group color-editor
-$kendo-color-editor-md-min-width: 272px !default;
+$kendo-color-editor-md-min-width: 280px !default;
 /// The minimum width of the ColorEditor.
 /// @group color-editor
-$kendo-color-editor-lg-min-width: 362px !default;
+$kendo-color-editor-lg-min-width: 364px !default;
 /// The width of the border around the ColorEditor.
 /// @group color-editor
 $kendo-color-editor-border-width: 1px !default;


### PR DESCRIPTION
closes: https://github.com/telerik/kendo-themes/issues/6173
closes: https://progresssoftware.atlassian.net/browse/FE-1369

## Why

The ColorEditor's `min-width` in the meridian and material themes was smaller than the natural rendered width of the gradient view. Switching from the gradient view to the palette view (or vice versa) made the component visibly jump in width instead of staying stable.

## Approach

Built both themes and measured the actual rendered widths of the gradient view and palette view for every ColorEditor size (sm/md/lg) with a headless browser, then bumped each `*-min-width` SCSS variable to match the widest of the two so the container no longer resizes when switching views:

- meridian: sm 252px -> 256px, md 272px -> 280px, lg 362px -> 364px
- material: md 294px -> 298px (sm/lg were already correct, no change needed)

Regenerated the SassDoc customization docs (`npm run docs`) so the documented default values stay in sync with the SCSS variables.

## Verification

Re-measured gradient vs. palette widths after the change: they now match exactly at every size in both themes, confirming the resize jump is gone. Ran stylelint on the changed files with no issues.